### PR TITLE
🔧 chore: prepare v0.3.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 # MCP config with secrets
 .mcp.json
 data/
+.serena/
 
 # Dependencies
 node_modules/
 
 # Build output
 dist/
+gemini2obsidian-*.zip
 
 # IDE
 .vscode/
@@ -24,6 +26,7 @@ npm-debug.log*
 
 # Test files
 elements-sample.html
+coverage/
 
 # Environment
 .env

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "build:zip": "npm run build && cd dist && zip -r ../gemini2obsidian-$(node -p \"require('../package.json').version\").zip . -x '*.DS_Store' -x '.vite/*' && cd ..",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

- Bump version to 0.3.1
- Add `build:zip` script for Chrome Web Store deployment
- Update .gitignore with build artifacts and tool directories

## Changes

### package.json

- Version: 0.3.0 → 0.3.1
- New script: `npm run build:zip` - builds and creates versioned zip for Web Store

### .gitignore

- Added `.serena/` (MCP tool directory)
- Added `coverage/` (test coverage reports)
- Added `gemini2obsidian-*.zip` (build artifacts)

## Test plan

- [x] `npm run build:zip` creates `gemini2obsidian-0.3.1.zip`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)