### PR TITLE
✨ feat: Deep Research extraction from Gemini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Run CI on all pull requests regardless of target branch
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 # MCP config with secrets
 .mcp.json
 data/
+.serena/
 
 # Dependencies
 node_modules/
 
 # Build output
 dist/
+gemini2obsidian-*.zip
 
 # IDE
 .vscode/
@@ -24,6 +26,7 @@ npm-debug.log*
 
 # Test files
 elements-sample.html
+coverage/
 
 # Environment
 .env

--- a/docs/design/deep-research-extraction.md
+++ b/docs/design/deep-research-extraction.md
@@ -1,0 +1,609 @@
+# Deep Research 抽出機能 設計書
+
+## 1. 概要
+
+### 1.1 目的
+Gemini の Deep Research 機能が生成するレポートを、既存の会話抽出機能に追加して Obsidian に保存できるようにする。
+
+### 1.2 スコープ
+- Deep Research レポートの検出と抽出
+- 既存の会話抽出との排他制御
+- 出力フォーマットの拡張（`type` フィールド追加）
+- 同一レポートの上書き保存
+
+### 1.3 スコープ外
+- 図表・画像の特殊処理（将来対応）
+- thinking-panel（思考過程）の抽出
+- toc-menu（目次）の抽出
+
+---
+
+## 2. 要件定義
+
+### 2.1 機能要件
+
+| ID | 要件 | 優先度 |
+|----|------|--------|
+| FR-01 | Deep Research パネルが展開中の場合、レポートのみを抽出する | 必須 |
+| FR-02 | Deep Research パネルが閉じている場合、通常会話を抽出する | 必須 |
+| FR-03 | レポートのタイトルを `h2.title-text.gds-title-s` から取得する | 必須 |
+| FR-04 | レポート本文を `#extended-response-markdown-content` から取得する | 必須 |
+| FR-05 | frontmatter に `type: deep-research` を追加して識別する | 必須 |
+| FR-06 | 同一レポートの再保存時は上書きする | 必須 |
+
+### 2.2 非機能要件
+
+| ID | 要件 |
+|----|------|
+| NFR-01 | 既存の会話抽出機能に影響を与えない |
+| NFR-02 | セレクタのフォールバック機構を維持する |
+| NFR-03 | DOMPurify によるサニタイズを適用する |
+
+---
+
+## 3. HTML 構造分析
+
+### 3.1 Deep Research パネル構造
+
+```
+deep-research-immersive-panel
+├── toolbar
+│   └── div.toolbar.has-title
+│       └── div.left-panel
+│           └── h2.title-text.gds-title-s  ← タイトル取得元
+│
+└── div.container
+    ├── thinking-panel  ← 抽出対象外
+    │
+    └── response-container
+        └── structured-content-container[data-test-id="message-content"]
+            └── message-content#extended-response-message-content
+                └── div#extended-response-markdown-content.markdown.markdown-main-panel
+                    └── <h1>, <h2>, <p>, <ul>... ← 本文取得元
+```
+
+### 3.2 通常会話構造（比較用）
+
+```
+conversation-container
+└── model-response
+    └── structured-content-container
+        └── message-content#message-content-id-r_xxxxx
+            └── div.markdown.markdown-main-panel
+```
+
+### 3.3 識別ポイント
+
+| 要素 | Deep Research | 通常会話 |
+|------|--------------|---------|
+| 親コンポーネント | `deep-research-immersive-panel` | `conversation-container` |
+| message-content ID | `extended-response-message-content` | `message-content-id-r_xxxxx` |
+| markdown ID | `extended-response-markdown-content` | なし（クラスのみ） |
+| data-test-id | `message-content` | なし |
+
+### 3.4 Angular 動的属性について
+
+以下の属性は Angular が動的生成するため、セレクタには使用しない：
+- `_ngcontent-ng-c*` - コンポーネントスコープ属性
+- `_nghost-ng-c*` - ホスト要素属性
+- `ng-tns-c*-*` - 動的スコープクラス
+
+追加クラス（`stronger`, `enable-updated-hr-color`, `ng-star-inserted`）は部分一致セレクタで無視される。
+
+---
+
+## 4. 設計
+
+### 4.1 セレクタ定義
+
+```typescript
+// src/content/extractors/gemini.ts に追加
+
+const DEEP_RESEARCH_SELECTORS = {
+  // Deep Research パネル（存在確認用）
+  panel: [
+    'deep-research-immersive-panel',
+  ],
+  
+  // レポートタイトル
+  title: [
+    'deep-research-immersive-panel h2.title-text.gds-title-s',
+    'deep-research-immersive-panel .title-text',
+    'toolbar h2.title-text',
+  ],
+  
+  // レポート本文
+  content: [
+    '#extended-response-markdown-content',
+    'message-content#extended-response-message-content .markdown-main-panel',
+    'structured-content-container[data-test-id="message-content"] .markdown-main-panel',
+  ],
+};
+```
+
+### 4.2 型定義の拡張
+
+#### 4.2.1 `source` と `type` の関係
+
+```typescript
+// src/lib/types.ts
+
+/**
+ * source: プラットフォーム識別子（既存）
+ *   - 'gemini' | 'claude' | 'perplexity'
+ *   - IConversationExtractor.platform と一致
+ *   - ファイル名やID生成に使用
+ *
+ * type: コンテンツ種別識別子（新規）
+ *   - 'conversation' | 'deep-research'
+ *   - 同一プラットフォーム内でのコンテンツ種別を区別
+ *   - タグ生成やフォーマット分岐に使用
+ */
+
+// ConversationData に type フィールドを追加
+export interface ConversationData {
+  id: string;
+  title: string;
+  url: string;
+  source: 'gemini' | 'claude' | 'perplexity';  // プラットフォーム（変更なし）
+  type?: 'conversation' | 'deep-research';      // コンテンツ種別（新規追加）
+  messages: ConversationMessage[];
+  extractedAt: Date;
+  metadata: ConversationMetadata;
+}
+
+// NoteFrontmatter に type フィールドを追加
+export interface NoteFrontmatter {
+  id: string;
+  title: string;
+  source: string;
+  type?: string;  // 新規追加（optional で後方互換性維持）
+  url: string;
+  created: string;
+  modified: string;
+  tags: string[];
+  message_count: number;
+}
+```
+
+#### 4.2.2 型の使い分け
+
+| フィールド | 用途 | 例 |
+|-----------|------|-----|
+| `source` | プラットフォーム識別、ID prefix | `gemini_xxx`, `claude_xxx` |
+| `type` | コンテンツ種別、フォーマット分岐 | `deep-research` → レポート形式出力 |
+
+### 4.3 GeminiExtractor の拡張
+
+```typescript
+// src/content/extractors/gemini.ts
+
+export class GeminiExtractor extends BaseExtractor {
+  // 既存のプロパティ・メソッド...
+
+  /**
+   * Deep Research パネルが表示中かどうかを判定
+   */
+  isDeepResearchVisible(): boolean {
+    const panel = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.panel);
+    return panel !== null;
+  }
+
+  /**
+   * Deep Research レポートのタイトルを取得
+   */
+  getDeepResearchTitle(): string {
+    const titleEl = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.title);
+    if (titleEl?.textContent) {
+      return this.sanitizeText(titleEl.textContent).substring(0, 200);
+    }
+    return 'Untitled Deep Research Report';
+  }
+
+  /**
+   * Deep Research レポートの本文を抽出
+   */
+  extractDeepResearchContent(): string {
+    const contentEl = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.content);
+    if (contentEl) {
+      return sanitizeHtml(contentEl.innerHTML);
+    }
+    return '';
+  }
+
+  /**
+   * Deep Research レポートを抽出
+   */
+  extractDeepResearch(): ExtractionResult {
+    const title = this.getDeepResearchTitle();
+    const content = this.extractDeepResearchContent();
+
+    if (!content) {
+      return {
+        success: false,
+        error: 'Deep Research content not found',
+        warnings: ['Panel is visible but content element is empty or missing'],
+      };
+    }
+
+    // タイトルからIDを生成（上書き用）
+    // BaseExtractor から継承した this.generateHashValue() を使用
+    const titleHash = this.generateHashValue(title);
+    const conversationId = `deep-research-${titleHash}`;
+
+    return {
+      success: true,
+      data: {
+        id: conversationId,
+        title,
+        url: window.location.href,
+        source: 'gemini',        // プラットフォーム
+        type: 'deep-research',   // コンテンツ種別
+        messages: [
+          {
+            id: 'report-0',
+            role: 'assistant',
+            content,
+            htmlContent: content,
+            index: 0,
+          },
+        ],
+        extractedAt: new Date(),
+        metadata: {
+          messageCount: 1,
+          userMessageCount: 0,
+          assistantMessageCount: 1,
+          hasCodeBlocks: content.includes('<code') || content.includes('```'),
+        },
+      },
+    };
+  }
+
+  /**
+   * メイン抽出メソッド（修正）
+   * ルーティングロジック: Deep Research パネル表示 → レポート抽出、それ以外 → 会話抽出
+   */
+  async extract(): Promise<ExtractionResult> {
+    try {
+      if (!this.canExtract()) {
+        return {
+          success: false,
+          error: 'Not on a Gemini page',
+        };
+      }
+
+      // ルーティング: Deep Research パネルが表示中の場合はレポートを抽出
+      if (this.isDeepResearchVisible()) {
+        console.info('[G2O] Deep Research panel detected, extracting report');
+        return this.extractDeepResearch();
+      }
+
+      // 通常の会話抽出（既存ロジック - 変更なし）
+      console.info('[G2O] Extracting normal conversation');
+      const messages = this.extractMessages();
+      // ... 既存のコード（省略）...
+    } catch (error) {
+      console.error('[G2O] Extraction error:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown extraction error',
+      };
+    }
+  }
+}
+```
+
+### 4.4 Content Script のルーティングフロー
+
+```
+src/content/index.ts: handleSync()
+        │
+        ▼
+  extractor.canExtract()
+        │
+        ├── false → エラー表示
+        │
+        ▼ true
+  extractor.extract()  ← ここで内部ルーティング
+        │
+        ├── isDeepResearchVisible() === true
+        │   └── extractDeepResearch() → type: 'deep-research'
+        │
+        └── isDeepResearchVisible() === false
+            └── extractMessages() → type: undefined (通常会話)
+        │
+        ▼
+  conversationToNote(result.data)
+        │
+        ├── data.type === 'deep-research'
+        │   └── レポート形式で出力（見出し構造維持）
+        │
+        └── data.type !== 'deep-research'
+            └── Callout 形式で出力（Q&A）
+        │
+        ▼
+  saveToObsidian(note)
+```
+
+**重要**: ルーティングは `GeminiExtractor.extract()` 内で完結する。
+`src/content/index.ts` は変更不要（`extract()` の結果を `conversationToNote()` に渡すだけ）。
+
+### 4.5 マークダウン変換の拡張
+
+```typescript
+// src/content/markdown.ts
+
+export function conversationToNote(
+  data: ConversationData,
+  options: TemplateOptions
+): ObsidianNote {
+  const now = new Date().toISOString();
+
+  // frontmatter 生成
+  const frontmatter: NoteFrontmatter = {
+    id: `${data.source}_${data.id}`,
+    title: data.title,
+    source: data.source,
+    ...(data.type && { type: data.type }),  // type がある場合のみ追加
+    url: data.url,
+    created: data.extractedAt.toISOString(),
+    modified: now,
+    tags: data.type === 'deep-research' 
+      ? ['ai-research', 'deep-research', data.source]
+      : ['ai-conversation', data.source],
+    message_count: data.messages.length,
+  };
+
+  // Deep Research の場合は本文をそのまま変換（見出し構造維持）
+  let body: string;
+  if (data.type === 'deep-research') {
+    body = htmlToMarkdown(data.messages[0].content);
+  } else {
+    // 通常会話のフォーマット（既存ロジック）
+    const bodyParts: string[] = [];
+    for (const message of data.messages) {
+      const formatted = formatMessage(message.content, message.role, options);
+      bodyParts.push(formatted);
+    }
+    body = bodyParts.join('\n\n');
+  }
+
+  // ファイル名生成
+  const fileName = generateFileName(data.title, data.id);
+  const contentHash = generateContentHash(body);
+
+  return {
+    fileName,
+    frontmatter,
+    body,
+    contentHash,
+  };
+}
+```
+
+---
+
+## 5. 出力フォーマット
+
+### 5.1 Deep Research レポート出力例
+
+```markdown
+---
+id: gemini_deep-research-a1b2c3d4
+title: ハワイ旅行準備と現地注意点レポート
+source: gemini
+type: deep-research
+url: https://gemini.google.com/app/xxx
+created: 2025-01-11T10:00:00.000Z
+modified: 2025-01-11T10:00:00.000Z
+tags:
+  - ai-research
+  - deep-research
+  - gemini
+message_count: 1
+---
+
+# 2026年3月ハワイ（オアフ島）渡航における観光インフラ・法制度・リスク管理に関する包括的調査報告書
+
+## 1. はじめに
+
+本レポートは、2026年3月にハワイ・オアフ島への渡航を計画されている方向けに...
+
+## 2. 渡航準備
+
+### 2.1 必要書類
+
+- 有効なパスポート（残存有効期間6ヶ月以上推奨）
+- ESTA（電子渡航認証システム）の事前申請
+...
+```
+
+### 5.2 通常会話との比較
+
+| 項目 | Deep Research | 通常会話 |
+|------|--------------|---------|
+| id | `gemini_deep-research-{hash}` | `gemini_{conversationId}` |
+| type | `deep-research` | `conversation` または未設定 |
+| tags | `ai-research, deep-research, gemini` | `ai-conversation, gemini` |
+| 本文形式 | レポート全体（見出し構造維持） | Callout 形式の Q&A |
+
+---
+
+## 6. ID 生成とファイル上書き
+
+### 6.1 ID 生成ロジック
+
+```typescript
+// Deep Research の場合
+// BaseExtractor から継承した this.generateHashValue() を使用
+const titleHash = this.generateHashValue(title);
+const id = `deep-research-${titleHash}`;
+
+// 参照: src/content/extractors/base.ts
+protected generateHashValue(content: string): string {
+  return generateHash(content);  // src/lib/hash.ts
+}
+
+// 参照: src/lib/hash.ts
+export function generateHash(content: string): string {
+  let hash = 0;
+  for (let i = 0; i < content.length; i++) {
+    const char = content.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(16).padStart(8, '0');
+}
+```
+
+### 6.2 上書き判定
+
+同一の `id` を持つファイルが存在する場合、Obsidian API 経由で上書きされる。
+これにより、同じタイトルの Deep Research レポートは常に最新版で上書きされる。
+
+---
+
+## 7. テスト計画
+
+### 7.1 ユニットテスト
+
+| テスト項目 | 説明 |
+|-----------|------|
+| `isDeepResearchVisible()` | パネル表示判定 |
+| `getDeepResearchTitle()` | タイトル抽出 |
+| `extractDeepResearchContent()` | 本文抽出 |
+| `extractDeepResearch()` | 統合抽出 |
+| `extract()` | 排他制御（パネル表示時はレポート、非表示時は会話） |
+
+### 7.2 エッジケーステスト
+
+| テスト項目 | シナリオ | 期待結果 |
+|-----------|---------|---------|
+| パネル表示・コンテンツなし | `deep-research-immersive-panel` 存在、`#extended-response-markdown-content` なし | `success: false`, 警告付きエラー |
+| パネル表示・タイトルなし | パネル存在、タイトル要素なし | デフォルトタイトル使用 |
+| パネル表示・空コンテンツ | コンテンツ要素存在、innerHTML 空 | `success: false` |
+| 通常会話とパネル共存 | 両方存在 | Deep Research のみ抽出 |
+
+### 7.3 テストフィクスチャ
+
+- `test/fixtures/deep-research-sample.html`（作成済み）
+- `test/fixtures/dom-helpers.ts` に Deep Research ヘルパーを追加
+
+```typescript
+// test/fixtures/dom-helpers.ts に追加
+
+/**
+ * Deep Research パネル DOM 構造を作成
+ */
+export function createDeepResearchDOM(
+  title: string,
+  content: string
+): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">${title}</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+          <structured-content-container data-test-id="message-content">
+            <message-content id="extended-response-message-content">
+              <div id="extended-response-markdown-content" 
+                   class="markdown markdown-main-panel">
+                ${content}
+              </div>
+            </message-content>
+          </structured-content-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}
+
+/**
+ * パネルのみ（コンテンツなし）の DOM を作成
+ */
+export function createEmptyDeepResearchPanel(): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">Test Report</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}
+```
+
+---
+
+## 8. 影響範囲
+
+### 8.1 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/lib/types.ts` | `type` フィールド追加 |
+| `src/content/extractors/gemini.ts` | Deep Research 抽出メソッド追加、DEEP_RESEARCH_SELECTORS 追加 |
+| `src/content/markdown.ts` | Deep Research 用フォーマット処理分岐 |
+| `test/fixtures/dom-helpers.ts` | Deep Research ヘルパー追加 |
+| `test/extractors/gemini.test.ts` | Deep Research テスト追加 |
+
+### 8.2 変更なしファイル
+
+| ファイル | 理由 |
+|---------|------|
+| `src/content/index.ts` | ルーティングは extractor 内で完結 |
+| `src/background/index.ts` | 変更不要 |
+| `src/lib/obsidian-api.ts` | 変更不要 |
+
+### 8.3 後方互換性
+
+- 既存の `ConversationData` に optional な `type` フィールドを追加
+- `type` が未設定の場合は従来通り会話として扱う
+- 既存のテストは影響を受けない
+
+---
+
+## 9. 今後の拡張可能性
+
+### 9.1 将来対応候補
+
+- thinking-panel（思考過程）の抽出オプション
+- 図表・画像の埋め込み対応
+- 複数 Deep Research レポートの一括抽出
+- レポート内リンクの Obsidian 形式変換
+
+---
+
+## 10. 承認
+
+| 項目 | 状態 |
+|------|------|
+| 設計レビュー | 完了（v1.1 で指摘対応） |
+| 実装承認 | 待機中 |
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2025-01-11 | 初版作成 |
+| 1.1 | 2025-01-11 | レビュー指摘対応: type/source 関係明確化、ルーティングフロー追加、hash 参照修正、エッジケース追加 |
+
+---
+
+*作成日: 2025-01-11*
+*バージョン: 1.1*

--- a/docs/workflow/deep-research-implementation.md
+++ b/docs/workflow/deep-research-implementation.md
@@ -1,0 +1,594 @@
+# Deep Research 抽出機能 - 実装ワークフロー
+
+## 概要
+
+設計書 `docs/design/deep-research-extraction.md` v1.1 に基づく実装ワークフロー。
+
+## 依存関係図
+
+```
+Phase 1: 型定義
+    │
+    ▼
+Phase 2: Extractor 実装
+    │
+    ├── 2.1 セレクタ定義
+    │       │
+    │       ▼
+    ├── 2.2 検出メソッド
+    │       │
+    │       ▼
+    ├── 2.3 抽出メソッド
+    │       │
+    │       ▼
+    └── 2.4 ルーティング統合
+            │
+            ▼
+Phase 3: マークダウン変換
+    │
+    ▼
+Phase 4: テスト実装
+    │
+    ├── 4.1 テストヘルパー
+    │       │
+    │       ▼
+    └── 4.2 ユニットテスト
+            │
+            ▼
+Phase 5: 検証
+```
+
+---
+
+## Phase 1: 型定義の拡張
+
+### タスク 1.1: ConversationData 型拡張
+
+**ファイル**: `src/lib/types.ts`
+
+**変更内容**:
+```typescript
+export interface ConversationData {
+  id: string;
+  title: string;
+  url: string;
+  source: 'gemini' | 'claude' | 'perplexity';
+  type?: 'conversation' | 'deep-research';  // 追加
+  messages: ConversationMessage[];
+  extractedAt: Date;
+  metadata: ConversationMetadata;
+}
+```
+
+**検証方法**:
+- TypeScript コンパイルエラーなし
+- 既存テスト全てパス
+
+---
+
+### タスク 1.2: NoteFrontmatter 型拡張
+
+**ファイル**: `src/lib/types.ts`
+
+**変更内容**:
+```typescript
+export interface NoteFrontmatter {
+  id: string;
+  title: string;
+  source: string;
+  type?: string;  // 追加
+  url: string;
+  created: string;
+  modified: string;
+  tags: string[];
+  message_count: number;
+}
+```
+
+**検証方法**:
+- TypeScript コンパイルエラーなし
+
+---
+
+## Phase 2: GeminiExtractor 拡張
+
+### タスク 2.1: DEEP_RESEARCH_SELECTORS 定義
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**追加位置**: `SELECTORS` 定義の直後
+
+**変更内容**:
+```typescript
+const DEEP_RESEARCH_SELECTORS = {
+  panel: [
+    'deep-research-immersive-panel',
+  ],
+  title: [
+    'deep-research-immersive-panel h2.title-text.gds-title-s',
+    'deep-research-immersive-panel .title-text',
+    'toolbar h2.title-text',
+  ],
+  content: [
+    '#extended-response-markdown-content',
+    'message-content#extended-response-message-content .markdown-main-panel',
+    'structured-content-container[data-test-id="message-content"] .markdown-main-panel',
+  ],
+};
+```
+
+**依存**: なし
+
+---
+
+### タスク 2.2: isDeepResearchVisible() 実装
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**追加位置**: `GeminiExtractor` クラス内、`canExtract()` の後
+
+**変更内容**:
+```typescript
+/**
+ * Deep Research パネルが表示中かどうかを判定
+ */
+isDeepResearchVisible(): boolean {
+  const panel = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.panel);
+  return panel !== null;
+}
+```
+
+**依存**: タスク 2.1
+
+---
+
+### タスク 2.3: getDeepResearchTitle() 実装
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**追加位置**: `isDeepResearchVisible()` の後
+
+**変更内容**:
+```typescript
+/**
+ * Deep Research レポートのタイトルを取得
+ */
+getDeepResearchTitle(): string {
+  const titleEl = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.title);
+  if (titleEl?.textContent) {
+    return this.sanitizeText(titleEl.textContent).substring(0, 200);
+  }
+  return 'Untitled Deep Research Report';
+}
+```
+
+**依存**: タスク 2.1
+
+---
+
+### タスク 2.4: extractDeepResearchContent() 実装
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**追加位置**: `getDeepResearchTitle()` の後
+
+**変更内容**:
+```typescript
+/**
+ * Deep Research レポートの本文を抽出
+ */
+extractDeepResearchContent(): string {
+  const contentEl = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.content);
+  if (contentEl) {
+    return sanitizeHtml(contentEl.innerHTML);
+  }
+  return '';
+}
+```
+
+**依存**: タスク 2.1
+
+---
+
+### タスク 2.5: extractDeepResearch() 実装
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**追加位置**: `extractDeepResearchContent()` の後
+
+**変更内容**:
+```typescript
+/**
+ * Deep Research レポートを抽出
+ */
+extractDeepResearch(): ExtractionResult {
+  const title = this.getDeepResearchTitle();
+  const content = this.extractDeepResearchContent();
+
+  if (!content) {
+    return {
+      success: false,
+      error: 'Deep Research content not found',
+      warnings: ['Panel is visible but content element is empty or missing'],
+    };
+  }
+
+  const titleHash = this.generateHashValue(title);
+  const conversationId = `deep-research-${titleHash}`;
+
+  return {
+    success: true,
+    data: {
+      id: conversationId,
+      title,
+      url: window.location.href,
+      source: 'gemini',
+      type: 'deep-research',
+      messages: [
+        {
+          id: 'report-0',
+          role: 'assistant',
+          content,
+          htmlContent: content,
+          index: 0,
+        },
+      ],
+      extractedAt: new Date(),
+      metadata: {
+        messageCount: 1,
+        userMessageCount: 0,
+        assistantMessageCount: 1,
+        hasCodeBlocks: content.includes('<code') || content.includes('```'),
+      },
+    },
+  };
+}
+```
+
+**依存**: タスク 2.2, 2.3, 2.4, Phase 1
+
+---
+
+### タスク 2.6: extract() メソッド修正
+
+**ファイル**: `src/content/extractors/gemini.ts`
+
+**変更箇所**: 既存の `extract()` メソッド内
+
+**変更内容**: `if (!this.canExtract())` チェックの直後に追加
+```typescript
+// Deep Research パネルが表示中の場合はレポートを抽出
+if (this.isDeepResearchVisible()) {
+  console.info('[G2O] Deep Research panel detected, extracting report');
+  return this.extractDeepResearch();
+}
+
+console.info('[G2O] Extracting normal conversation');
+```
+
+**依存**: タスク 2.5
+
+---
+
+## Phase 3: マークダウン変換拡張
+
+### タスク 3.1: conversationToNote() 修正
+
+**ファイル**: `src/content/markdown.ts`
+
+**変更箇所 1**: frontmatter 生成部分
+```typescript
+const frontmatter: NoteFrontmatter = {
+  id: `${data.source}_${data.id}`,
+  title: data.title,
+  source: data.source,
+  ...(data.type && { type: data.type }),  // 追加
+  url: data.url,
+  created: data.extractedAt.toISOString(),
+  modified: now,
+  tags: data.type === 'deep-research'     // 変更
+    ? ['ai-research', 'deep-research', data.source]
+    : ['ai-conversation', data.source],
+  message_count: data.messages.length,
+};
+```
+
+**変更箇所 2**: body 生成部分
+```typescript
+// Deep Research の場合は本文をそのまま変換
+let body: string;
+if (data.type === 'deep-research') {
+  body = htmlToMarkdown(data.messages[0].content);
+} else {
+  // 通常会話のフォーマット（既存ロジック）
+  const bodyParts: string[] = [];
+  for (const message of data.messages) {
+    const formatted = formatMessage(message.content, message.role, options);
+    bodyParts.push(formatted);
+  }
+  body = bodyParts.join('\n\n');
+}
+```
+
+**依存**: Phase 1
+
+---
+
+## Phase 4: テスト実装
+
+### タスク 4.1: DOM ヘルパー追加
+
+**ファイル**: `test/fixtures/dom-helpers.ts`
+
+**追加位置**: ファイル末尾
+
+**変更内容**:
+```typescript
+/**
+ * Deep Research パネル DOM 構造を作成
+ */
+export function createDeepResearchDOM(
+  title: string,
+  content: string
+): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">${title}</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+          <structured-content-container data-test-id="message-content">
+            <message-content id="extended-response-message-content">
+              <div id="extended-response-markdown-content" 
+                   class="markdown markdown-main-panel">
+                ${content}
+              </div>
+            </message-content>
+          </structured-content-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}
+
+/**
+ * パネルのみ（コンテンツなし）の DOM を作成
+ */
+export function createEmptyDeepResearchPanel(): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">Test Report</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}
+```
+
+**依存**: なし
+
+---
+
+### タスク 4.2: Deep Research テスト追加
+
+**ファイル**: `test/extractors/gemini.test.ts`
+
+**追加位置**: 既存の `describe` ブロックの後
+
+**変更内容**:
+```typescript
+describe('Deep Research extraction', () => {
+  describe('isDeepResearchVisible', () => {
+    it('returns true when panel is present', () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Test Report', '<p>Content</p>'));
+      expect(extractor.isDeepResearchVisible()).toBe(true);
+    });
+
+    it('returns false when panel is not present', () => {
+      setGeminiLocation('test123');
+      loadFixture('<div>No panel</div>');
+      expect(extractor.isDeepResearchVisible()).toBe(false);
+    });
+  });
+
+  describe('getDeepResearchTitle', () => {
+    it('extracts title from panel', () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Hawaii Travel Report', '<p>Content</p>'));
+      expect(extractor.getDeepResearchTitle()).toBe('Hawaii Travel Report');
+    });
+
+    it('returns default title when not found', () => {
+      setGeminiLocation('test123');
+      loadFixture('<deep-research-immersive-panel></deep-research-immersive-panel>');
+      expect(extractor.getDeepResearchTitle()).toBe('Untitled Deep Research Report');
+    });
+  });
+
+  describe('extractDeepResearchContent', () => {
+    it('extracts content from panel', () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Test', '<h1>Report</h1><p>Content</p>'));
+      const content = extractor.extractDeepResearchContent();
+      expect(content).toContain('<h1>Report</h1>');
+      expect(content).toContain('<p>Content</p>');
+    });
+
+    it('returns empty string when content not found', () => {
+      setGeminiLocation('test123');
+      loadFixture(createEmptyDeepResearchPanel());
+      expect(extractor.extractDeepResearchContent()).toBe('');
+    });
+  });
+
+  describe('extractDeepResearch', () => {
+    it('returns successful result with report data', () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Test Report', '<h1>Title</h1><p>Content</p>'));
+      
+      const result = extractor.extractDeepResearch();
+      
+      expect(result.success).toBe(true);
+      expect(result.data?.type).toBe('deep-research');
+      expect(result.data?.source).toBe('gemini');
+      expect(result.data?.title).toBe('Test Report');
+      expect(result.data?.messages.length).toBe(1);
+      expect(result.data?.messages[0].role).toBe('assistant');
+    });
+
+    it('returns error when content is empty', () => {
+      setGeminiLocation('test123');
+      loadFixture(createEmptyDeepResearchPanel());
+      
+      const result = extractor.extractDeepResearch();
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('content not found');
+    });
+
+    it('generates consistent ID from title for overwrite', () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Same Title', '<p>Content 1</p>'));
+      const result1 = extractor.extractDeepResearch();
+      
+      clearFixture();
+      loadFixture(createDeepResearchDOM('Same Title', '<p>Content 2</p>'));
+      const result2 = extractor.extractDeepResearch();
+      
+      expect(result1.data?.id).toBe(result2.data?.id);
+    });
+  });
+
+  describe('extract routing', () => {
+    it('extracts Deep Research when panel is visible', async () => {
+      setGeminiLocation('test123');
+      loadFixture(createDeepResearchDOM('Report', '<p>Content</p>'));
+      
+      const result = await extractor.extract();
+      
+      expect(result.success).toBe(true);
+      expect(result.data?.type).toBe('deep-research');
+    });
+
+    it('extracts normal conversation when panel is not visible', async () => {
+      setGeminiLocation('test123');
+      const html = createGeminiConversationDOM([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi' },
+      ]);
+      loadFixture(html);
+      
+      const result = await extractor.extract();
+      
+      expect(result.success).toBe(true);
+      expect(result.data?.type).toBeUndefined();
+    });
+
+    it('prioritizes Deep Research when both exist', async () => {
+      setGeminiLocation('test123');
+      const conversationHtml = createGeminiConversationDOM([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi' },
+      ]);
+      const deepResearchHtml = createDeepResearchDOM('Report', '<p>Content</p>');
+      loadFixture(conversationHtml + deepResearchHtml);
+      
+      const result = await extractor.extract();
+      
+      expect(result.success).toBe(true);
+      expect(result.data?.type).toBe('deep-research');
+    });
+  });
+});
+```
+
+**依存**: タスク 4.1, Phase 2
+
+---
+
+## Phase 5: 検証
+
+### タスク 5.1: 型チェック
+
+**コマンド**:
+```bash
+npm run build
+```
+
+**期待結果**: エラーなし
+
+---
+
+### タスク 5.2: 既存テスト実行
+
+**コマンド**:
+```bash
+npm run test
+```
+
+**期待結果**: 全テストパス（既存テスト + 新規テスト）
+
+---
+
+### タスク 5.3: Lint チェック
+
+**コマンド**:
+```bash
+npm run lint
+```
+
+**期待結果**: エラーなし
+
+---
+
+## 実装順序サマリー
+
+| 順序 | タスク | ファイル | 依存 |
+|-----|-------|---------|------|
+| 1 | 1.1, 1.2 | `src/lib/types.ts` | なし |
+| 2 | 2.1 | `src/content/extractors/gemini.ts` | なし |
+| 3 | 2.2, 2.3, 2.4 | `src/content/extractors/gemini.ts` | 2.1 |
+| 4 | 2.5 | `src/content/extractors/gemini.ts` | 2.2-2.4, Phase 1 |
+| 5 | 2.6 | `src/content/extractors/gemini.ts` | 2.5 |
+| 6 | 3.1 | `src/content/markdown.ts` | Phase 1 |
+| 7 | 4.1 | `test/fixtures/dom-helpers.ts` | なし |
+| 8 | 4.2 | `test/extractors/gemini.test.ts` | 4.1, Phase 2 |
+| 9 | 5.1-5.3 | (コマンド実行) | Phase 1-4 |
+
+---
+
+## 並列実行可能なタスク
+
+以下のタスクは並列実行可能:
+- タスク 1.1 と 1.2（同一ファイル内だが独立）
+- タスク 2.2, 2.3, 2.4（全て 2.1 に依存するが相互依存なし）
+- タスク 4.1（他のタスクと独立）
+
+---
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|------|
+| セレクタが実際のDOMと一致しない | `test/fixtures/deep-research-sample.html` で事前検証済み |
+| 既存テストが失敗する | Phase 1 で optional フィールドのみ追加し後方互換性維持 |
+| `extract()` の既存ロジック破壊 | Deep Research 分岐を先に追加し、else で既存処理 |
+
+---
+
+*作成日: 2025-01-11*
+*設計書バージョン: v1.1*

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "build:zip": "npm run build && cd dist && zip -r ../gemini2obsidian-$(node -p \"require('../package.json').version\").zip . -x '*.DS_Store' -x '.vite/*' && cd ..",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian",
   "type": "module",
   "scripts": {
@@ -9,6 +9,7 @@
     "build:zip": "npm run build && cd dist && zip -r ../gemini2obsidian-$(node -p \"require('../package.json').version\").zip . -x '*.DS_Store' -x '.vite/*' && cd ..",
     "lint": "eslint src/",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css,html}\"",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -82,9 +82,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
    * Sanitize text content
    */
   protected sanitizeText(text: string): string {
-    return text
-      .replace(/\s+/g, ' ')
-      .trim();
+    return text.replace(/\s+/g, ' ').trim();
   }
 
   /**

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -13,28 +13,16 @@ import type { ExtractionResult, ConversationMessage } from '../../lib/types';
  */
 const SELECTORS = {
   // Conversation turn container (each Q&A pair)
-  conversationTurn: [
-    '.conversation-container',
-    '[class*="conversation-container"]',
-  ],
+  conversationTurn: ['.conversation-container', '[class*="conversation-container"]'],
 
   // User query element (Angular component)
-  userQuery: [
-    'user-query',
-    '[class*="user-query"]',
-  ],
+  userQuery: ['user-query', '[class*="user-query"]'],
 
   // Query text lines (multiple lines per query)
-  queryTextLine: [
-    '.query-text-line',
-    'p[class*="query-text-line"]',
-  ],
+  queryTextLine: ['.query-text-line', 'p[class*="query-text-line"]'],
 
   // Model response element (Angular component)
-  modelResponse: [
-    'model-response',
-    '[class*="model-response"]',
-  ],
+  modelResponse: ['model-response', '[class*="model-response"]'],
 
   // Model response markdown content
   modelResponseContent: [
@@ -151,7 +139,9 @@ export class GeminiExtractor extends BaseExtractor {
     const userQueries = this.queryAllWithFallback<HTMLElement>(SELECTORS.userQuery);
     const modelResponses = this.queryAllWithFallback<HTMLElement>(SELECTORS.modelResponse);
 
-    console.info(`[G2O] Fallback: Found ${userQueries.length} user queries, ${modelResponses.length} model responses`);
+    console.info(
+      `[G2O] Fallback: Found ${userQueries.length} user queries, ${modelResponses.length} model responses`
+    );
 
     // Interleave based on DOM order
     const allElements: Array<{ element: Element; type: 'user' | 'assistant' }> = [];
@@ -168,9 +158,10 @@ export class GeminiExtractor extends BaseExtractor {
 
     // Extract content
     allElements.forEach((item, index) => {
-      const content = item.type === 'user'
-        ? this.extractUserQueryContent(item.element)
-        : this.extractModelResponseContent(item.element);
+      const content =
+        item.type === 'user'
+          ? this.extractUserQueryContent(item.element)
+          : this.extractModelResponseContent(item.element);
 
       if (content) {
         messages.push({
@@ -300,8 +291,8 @@ export class GeminiExtractor extends BaseExtractor {
             messageCount: messages.length,
             userMessageCount: userCount,
             assistantMessageCount: assistantCount,
-            hasCodeBlocks: messages.some(m =>
-              m.content.includes('<code') || m.content.includes('```')
+            hasCodeBlocks: messages.some(
+              m => m.content.includes('<code') || m.content.includes('```')
             ),
           },
         },

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -39,11 +39,9 @@ function throttle<T extends (...args: unknown[]) => void>(
  * Uses MutationObserver instead of fixed timeout
  */
 function waitForConversationContainer(): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     // Check if already exists
-    const existing = document.querySelector(
-      '.conversation-container, [class*="conversation"]'
-    );
+    const existing = document.querySelector('.conversation-container, [class*="conversation"]');
     if (existing) {
       resolve();
       return;
@@ -51,9 +49,7 @@ function waitForConversationContainer(): Promise<void> {
 
     // Use MutationObserver to watch for container
     const observer = new MutationObserver((_mutations, obs) => {
-      const container = document.querySelector(
-        '.conversation-container, [class*="conversation"]'
-      );
+      const container = document.querySelector('.conversation-container, [class*="conversation"]');
       if (container) {
         obs.disconnect();
         resolve();
@@ -113,9 +109,7 @@ async function handleSync(): Promise<void> {
     const settings = await getSettings();
 
     if (!settings.obsidianApiKey) {
-      showErrorToast(
-        'Please configure your Obsidian API key in the extension settings'
-      );
+      showErrorToast('Please configure your Obsidian API key in the extension settings');
       setButtonLoading(false);
       return;
     }
@@ -152,7 +146,7 @@ async function handleSync(): Promise<void> {
 
     // Show warnings if any
     if (validation.warnings.length > 0) {
-      validation.warnings.forEach((warning) => {
+      validation.warnings.forEach(warning => {
         console.warn('[G2O] Warning:', warning);
       });
     }
@@ -189,9 +183,7 @@ async function handleSync(): Promise<void> {
     }
   } catch (error) {
     console.error('[G2O] Sync error:', error);
-    showErrorToast(
-      error instanceof Error ? error.message : 'An unexpected error occurred'
-    );
+    showErrorToast(error instanceof Error ? error.message : 'An unexpected error occurred');
   } finally {
     setButtonLoading(false);
   }

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -3,7 +3,12 @@
  */
 
 import TurndownService from 'turndown';
-import type { ConversationData, ObsidianNote, NoteFrontmatter, TemplateOptions } from '../lib/types';
+import type {
+  ConversationData,
+  ObsidianNote,
+  NoteFrontmatter,
+  TemplateOptions,
+} from '../lib/types';
 import { generateHash } from '../lib/hash';
 
 // Initialize Turndown with custom rules
@@ -17,11 +22,8 @@ const turndown = new TurndownService({
 
 // Custom rule for code blocks with language detection
 turndown.addRule('codeBlocks', {
-  filter: (node) => {
-    return (
-      node.nodeName === 'PRE' &&
-      node.querySelector('code') !== null
-    );
+  filter: node => {
+    return node.nodeName === 'PRE' && node.querySelector('code') !== null;
   },
   replacement: (content, node) => {
     const codeElement = (node as HTMLElement).querySelector('code');
@@ -39,10 +41,10 @@ turndown.addRule('codeBlocks', {
 
 // Custom rule for inline code
 turndown.addRule('inlineCode', {
-  filter: (node) => {
+  filter: node => {
     return node.nodeName === 'CODE' && node.parentNode?.nodeName !== 'PRE';
   },
-  replacement: (content) => {
+  replacement: content => {
     return `\`${content}\``;
   },
 });
@@ -99,9 +101,7 @@ turndown.addRule('tables', {
  */
 export function htmlToMarkdown(html: string): string {
   // Clean up HTML before conversion
-  const cleaned = html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/&nbsp;/g, ' ');
+  const cleaned = html.replace(/<br\s*\/?>/gi, '\n').replace(/&nbsp;/g, ' ');
 
   return turndown.turndown(cleaned);
 }
@@ -167,10 +167,7 @@ function formatMessage(
 /**
  * Convert conversation data to Obsidian note
  */
-export function conversationToNote(
-  data: ConversationData,
-  options: TemplateOptions
-): ObsidianNote {
+export function conversationToNote(data: ConversationData, options: TemplateOptions): ObsidianNote {
   const now = new Date().toISOString();
 
   // Generate frontmatter

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -25,7 +25,7 @@ export function sendMessage<K extends keyof MessageResponseMap>(
   message: ExtensionMessage & { action: K }
 ): Promise<MessageResponseMap[K]> {
   return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(message, (response) => {
+    chrome.runtime.sendMessage(message, response => {
       if (chrome.runtime.lastError) {
         reject(new Error(chrome.runtime.lastError.message ?? 'Unknown error'));
         return;

--- a/src/lib/obsidian-api.ts
+++ b/src/lib/obsidian-api.ts
@@ -106,19 +106,13 @@ export class ObsidianApiClient {
       }
 
       if (!response.ok) {
-        throw this.createError(
-          response.status,
-          `Failed to get file: ${response.statusText}`
-        );
+        throw this.createError(response.status, `Failed to get file: ${response.statusText}`);
       }
 
       return await response.text();
     } catch (error) {
       if (isNetworkError(error)) {
-        throw this.createError(
-          0,
-          'Request timed out. Please check your connection.'
-        );
+        throw this.createError(0, 'Request timed out. Please check your connection.');
       }
       throw error;
     }
@@ -143,17 +137,11 @@ export class ObsidianApiClient {
       });
 
       if (!response.ok) {
-        throw this.createError(
-          response.status,
-          `Failed to save file: ${response.statusText}`
-        );
+        throw this.createError(response.status, `Failed to save file: ${response.statusText}`);
       }
     } catch (error) {
       if (isNetworkError(error)) {
-        throw this.createError(
-          0,
-          'Request timed out. Please check your connection.'
-        );
+        throw this.createError(0, 'Request timed out. Please check your connection.');
       }
       throw error;
     }
@@ -184,12 +172,7 @@ export class ObsidianApiClient {
  * Type guard for ObsidianApiError
  */
 export function isObsidianApiError(error: unknown): error is ObsidianApiError {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'status' in error &&
-    'message' in error
-  );
+  return typeof error === 'object' && error !== null && 'status' in error && 'message' in error;
 }
 
 /**

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -26,7 +26,7 @@ const DEFAULT_SECURE_SETTINGS: SecureSettings = {
 
 const DEFAULT_SYNC_SETTINGS: SyncSettings = {
   obsidianPort: 27123,
-  vaultPath: '03_Extra/Gemini',
+  vaultPath: 'AI/Gemini',
   templateOptions: DEFAULT_TEMPLATE_OPTIONS,
 };
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,12 +6,7 @@
  * - storage.sync: Non-sensitive settings - synced across devices
  */
 
-import type {
-  ExtensionSettings,
-  SecureSettings,
-  SyncSettings,
-  TemplateOptions,
-} from './types';
+import type { ExtensionSettings, SecureSettings, SyncSettings, TemplateOptions } from './types';
 
 const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
   includeId: true,
@@ -55,12 +50,9 @@ export async function getSettings(): Promise<ExtensionSettings> {
 
     return {
       obsidianApiKey:
-        localResult.secureSettings?.obsidianApiKey ??
-        DEFAULT_SECURE_SETTINGS.obsidianApiKey,
-      obsidianPort:
-        syncResult.settings?.obsidianPort ?? DEFAULT_SYNC_SETTINGS.obsidianPort,
-      vaultPath:
-        syncResult.settings?.vaultPath ?? DEFAULT_SYNC_SETTINGS.vaultPath,
+        localResult.secureSettings?.obsidianApiKey ?? DEFAULT_SECURE_SETTINGS.obsidianApiKey,
+      obsidianPort: syncResult.settings?.obsidianPort ?? DEFAULT_SYNC_SETTINGS.obsidianPort,
+      vaultPath: syncResult.settings?.vaultPath ?? DEFAULT_SYNC_SETTINGS.vaultPath,
       templateOptions: {
         ...DEFAULT_TEMPLATE_OPTIONS,
         ...syncResult.settings?.templateOptions,
@@ -78,9 +70,7 @@ export async function getSettings(): Promise<ExtensionSettings> {
  * Separates secure settings (API Key) to local storage
  * and non-sensitive settings to sync storage.
  */
-export async function saveSettings(
-  settings: Partial<ExtensionSettings>
-): Promise<void> {
+export async function saveSettings(settings: Partial<ExtensionSettings>): Promise<void> {
   try {
     const current = await getSettings();
 
@@ -156,10 +146,7 @@ export async function migrateSettings(): Promise<void> {
     }
   } catch (error) {
     // On migration failure, keep sync intact and retry on next startup
-    console.error(
-      '[G2O] Migration failed, will retry on next startup:',
-      error
-    );
+    console.error('[G2O] Migration failed, will retry on next startup:', error);
     // Don't throw - existing functionality should continue working
   }
 }
@@ -173,9 +160,7 @@ export interface SyncInfo {
   contentHash: string;
 }
 
-export async function getLastSync(
-  conversationId: string
-): Promise<SyncInfo | null> {
+export async function getLastSync(conversationId: string): Promise<SyncInfo | null> {
   try {
     const result = await chrome.storage.local.get('lastSync');
     const lastSync = result.lastSync || {};
@@ -189,10 +174,7 @@ export async function getLastSync(
 /**
  * Save last sync info for a conversation
  */
-export async function saveLastSync(
-  conversationId: string,
-  info: SyncInfo
-): Promise<void> {
+export async function saveLastSync(conversationId: string, info: SyncInfo): Promise<void> {
   try {
     const result = await chrome.storage.local.get('lastSync');
     const lastSync = result.lastSync || {};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface ConversationData {
   title: string;
   url: string;
   source: 'gemini' | 'claude' | 'perplexity';
+  type?: 'conversation' | 'deep-research';
   messages: ConversationMessage[];
   extractedAt: Date;
   metadata: ConversationMetadata;
@@ -55,6 +56,7 @@ export interface NoteFrontmatter {
   id: string;
   title: string;
   source: string;
+  type?: string;
   url: string;
   created: string;
   modified: string;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -41,17 +41,12 @@ export type CalloutType = (typeof ALLOWED_CALLOUT_TYPES)[number];
 /**
  * calloutタイプのバリデーション
  */
-export function validateCalloutType(
-  type: string,
-  defaultType: CalloutType
-): CalloutType {
+export function validateCalloutType(type: string, defaultType: CalloutType): CalloutType {
   const normalized = type.toUpperCase().trim();
   if (ALLOWED_CALLOUT_TYPES.includes(normalized as CalloutType)) {
     return normalized as CalloutType;
   }
-  console.warn(
-    `[G2O] Invalid callout type "${type}", using default "${defaultType}"`
-  );
+  console.warn(`[G2O] Invalid callout type "${type}", using default "${defaultType}"`);
   return defaultType;
 }
 
@@ -92,9 +87,7 @@ export function validateApiKey(key: string): string {
   // Obsidian REST API は SHA-256 ハッシュ（64文字の16進数）を生成
   // ただし、ユーザーが手動で設定した場合も考慮して柔軟に対応
   if (trimmed.length !== 64) {
-    console.warn(
-      `[G2O] API key length is ${trimmed.length}, expected 64 (SHA-256 hex)`
-    );
+    console.warn(`[G2O] API key length is ${trimmed.length}, expected 64 (SHA-256 hex)`);
   }
 
   // 16進数形式のバリデーション（警告のみ、ブロックしない）

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "88",

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -1,130 +1,128 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title data-i18n="extName">Obsidian AI Exporter</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <div class="container">
-    <header class="header">
-      <h1>
-        <span class="logo">📥</span>
-        <span data-i18n="extName">Obsidian AI Exporter</span>
-      </h1>
-      <p class="subtitle" data-i18n="extDescription">Export AI conversations to Obsidian</p>
-    </header>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title data-i18n="extName">Obsidian AI Exporter</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="container">
+      <header class="header">
+        <h1>
+          <span class="logo">📥</span>
+          <span data-i18n="extName">Obsidian AI Exporter</span>
+        </h1>
+        <p class="subtitle" data-i18n="extDescription">Export AI conversations to Obsidian</p>
+      </header>
 
-    <main class="settings">
-      <section class="section">
-        <h2 data-i18n="settings_title">Settings</h2>
+      <main class="settings">
+        <section class="section">
+          <h2 data-i18n="settings_title">Settings</h2>
 
-        <div class="form-group">
-          <label for="apiKey" data-i18n="settings_apiKey">API Key</label>
-          <input
-            type="password"
-            id="apiKey"
-            data-i18n-placeholder="settings_apiKeyPlaceholder"
-            placeholder="Enter your Local REST API key"
-            autocomplete="off"
-          >
-          <p class="help">From Obsidian → Settings → Local REST API</p>
-        </div>
-
-        <div class="form-row">
           <div class="form-group">
-            <label for="port" data-i18n="settings_port">Port</label>
+            <label for="apiKey" data-i18n="settings_apiKey">API Key</label>
             <input
-              type="number"
-              id="port"
-              value="27123"
-              min="1024"
-              max="65535"
-            >
+              type="password"
+              id="apiKey"
+              data-i18n-placeholder="settings_apiKeyPlaceholder"
+              placeholder="Enter your Local REST API key"
+              autocomplete="off"
+            />
+            <p class="help">From Obsidian → Settings → Local REST API</p>
           </div>
 
-          <div class="form-group flex-grow">
-            <label for="vaultPath" data-i18n="settings_vaultPath">Vault Path</label>
-            <input
-              type="text"
-              id="vaultPath"
-              data-i18n-placeholder="settings_vaultPathPlaceholder"
-              placeholder="AI/Gemini"
-            >
+          <div class="form-row">
+            <div class="form-group">
+              <label for="port" data-i18n="settings_port">Port</label>
+              <input type="number" id="port" value="27123" min="1024" max="65535" />
+            </div>
+
+            <div class="form-group flex-grow">
+              <label for="vaultPath" data-i18n="settings_vaultPath">Vault Path</label>
+              <input
+                type="text"
+                id="vaultPath"
+                data-i18n-placeholder="settings_vaultPathPlaceholder"
+                placeholder="AI/Gemini"
+              />
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section class="section">
-        <h2 data-i18n="settings_messageFormat">Message Format</h2>
+        <section class="section">
+          <h2 data-i18n="settings_messageFormat">Message Format</h2>
 
-        <div class="form-group">
-          <label for="messageFormat" data-i18n="settings_messageFormat">Message Format</label>
-          <select id="messageFormat">
-            <option value="callout" data-i18n="settings_format_callout">Callout (Recommended)</option>
-            <option value="blockquote" data-i18n="settings_format_blockquote">Blockquote</option>
-            <option value="plain" data-i18n="settings_format_plain">Plain Markdown</option>
-          </select>
-        </div>
-
-        <div class="form-row">
           <div class="form-group">
-            <label for="userCallout" data-i18n="settings_userCallout">User Callout</label>
-            <input type="text" id="userCallout" value="QUESTION">
+            <label for="messageFormat" data-i18n="settings_messageFormat">Message Format</label>
+            <select id="messageFormat">
+              <option value="callout" data-i18n="settings_format_callout">
+                Callout (Recommended)
+              </option>
+              <option value="blockquote" data-i18n="settings_format_blockquote">Blockquote</option>
+              <option value="plain" data-i18n="settings_format_plain">Plain Markdown</option>
+            </select>
           </div>
-          <div class="form-group">
-            <label for="assistantCallout" data-i18n="settings_assistantCallout">Assistant Callout</label>
-            <input type="text" id="assistantCallout" value="NOTE">
+
+          <div class="form-row">
+            <div class="form-group">
+              <label for="userCallout" data-i18n="settings_userCallout">User Callout</label>
+              <input type="text" id="userCallout" value="QUESTION" />
+            </div>
+            <div class="form-group">
+              <label for="assistantCallout" data-i18n="settings_assistantCallout"
+                >Assistant Callout</label
+              >
+              <input type="text" id="assistantCallout" value="NOTE" />
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section class="section">
-        <h2 data-i18n="settings_frontmatter">Frontmatter Fields</h2>
-        <div class="checkbox-grid">
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeId" checked>
-            <span data-i18n="settings_includeId">ID</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeTitle" checked>
-            <span data-i18n="settings_includeTitle">Title</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeTags" checked>
-            <span data-i18n="settings_includeTags">Tags</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeSource" checked>
-            <span data-i18n="settings_includeSource">Source & URL</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeDates" checked>
-            <span data-i18n="settings_includeDates">Dates</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="includeMessageCount" checked>
-            <span data-i18n="settings_includeMessageCount">Message Count</span>
-          </label>
-        </div>
-      </section>
-    </main>
+        <section class="section">
+          <h2 data-i18n="settings_frontmatter">Frontmatter Fields</h2>
+          <div class="checkbox-grid">
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeId" checked />
+              <span data-i18n="settings_includeId">ID</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeTitle" checked />
+              <span data-i18n="settings_includeTitle">Title</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeTags" checked />
+              <span data-i18n="settings_includeTags">Tags</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeSource" checked />
+              <span data-i18n="settings_includeSource">Source & URL</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeDates" checked />
+              <span data-i18n="settings_includeDates">Dates</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeMessageCount" checked />
+              <span data-i18n="settings_includeMessageCount">Message Count</span>
+            </label>
+          </div>
+        </section>
+      </main>
 
-    <footer class="actions">
-      <button id="testBtn" class="btn secondary">
-        <span class="btn-icon">🔌</span>
-        <span data-i18n="settings_testConnection">Test Connection</span>
-      </button>
-      <button id="saveBtn" class="btn primary">
-        <span class="btn-icon">💾</span>
-        <span data-i18n="settings_save">Save Settings</span>
-      </button>
-    </footer>
+      <footer class="actions">
+        <button id="testBtn" class="btn secondary">
+          <span class="btn-icon">🔌</span>
+          <span data-i18n="settings_testConnection">Test Connection</span>
+        </button>
+        <button id="saveBtn" class="btn primary">
+          <span class="btn-icon">💾</span>
+          <span data-i18n="settings_save">Save Settings</span>
+        </button>
+      </footer>
 
-    <div id="status" class="status" role="status" aria-live="polite"></div>
-  </div>
+      <div id="status" class="status" role="status" aria-live="polite"></div>
+    </div>
 
-  <script type="module" src="index.ts"></script>
-</body>
+    <script type="module" src="index.ts"></script>
+  </body>
 </html>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -5,11 +5,7 @@
 
 import { getSettings, saveSettings } from '../lib/storage';
 import type { ExtensionSettings, TemplateOptions } from '../lib/types';
-import {
-  validateCalloutType,
-  validateVaultPath,
-  validateApiKey,
-} from '../lib/validation';
+import { validateCalloutType, validateVaultPath, validateApiKey } from '../lib/validation';
 
 /**
  * Get localized message with fallback
@@ -206,10 +202,7 @@ async function handleSave(): Promise<void> {
     try {
       settings.obsidianApiKey = validateApiKey(settings.obsidianApiKey);
     } catch (error) {
-      showStatus(
-        error instanceof Error ? error.message : 'Invalid API key',
-        'error'
-      );
+      showStatus(error instanceof Error ? error.message : 'Invalid API key', 'error');
       elements.saveBtn.disabled = false;
       return;
     }
@@ -225,10 +218,7 @@ async function handleSave(): Promise<void> {
     try {
       settings.vaultPath = validateVaultPath(settings.vaultPath);
     } catch (error) {
-      showStatus(
-        error instanceof Error ? error.message : 'Invalid vault path',
-        'error'
-      );
+      showStatus(error instanceof Error ? error.message : 'Invalid vault path', 'error');
       elements.saveBtn.disabled = false;
       return;
     }
@@ -291,7 +281,8 @@ async function handleTest(): Promise<void> {
       showStatus(response.error || getMessage('toast_error_connectionFailed'), 'error');
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : getMessage('toast_error_connectionFailed');
+    const message =
+      error instanceof Error ? error.message : getMessage('toast_error_connectionFailed');
     showStatus(message, 'error');
     console.error('[G2O Popup] Test error:', error);
   } finally {

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -110,9 +110,9 @@ label {
   margin-bottom: 6px;
 }
 
-input[type="text"],
-input[type="password"],
-input[type="number"],
+input[type='text'],
+input[type='password'],
+input[type='number'],
 select {
   width: 100%;
   padding: 10px 12px;
@@ -121,7 +121,9 @@ select {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
 }
 
 input:focus,
@@ -167,7 +169,7 @@ select {
   background: var(--bg-tertiary);
 }
 
-.checkbox-label input[type="checkbox"] {
+.checkbox-label input[type='checkbox'] {
   width: 16px;
   height: 16px;
   accent-color: var(--accent-primary);
@@ -257,8 +259,14 @@ select {
 
 /* Animations */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .status:not(:empty) {

--- a/test/fixtures/deep-research-sample.html
+++ b/test/fixtures/deep-research-sample.html
@@ -1,0 +1,151 @@
+<!--
+  Deep Research Sample HTML for Testing
+
+  Structure extracted from actual Gemini Deep Research panel.
+  Used for unit testing the Deep Research extractor functionality.
+-->
+
+<!-- Normal conversation (should be ignored when Deep Research is visible) -->
+<div class="conversation-container" id="normal-conversation">
+  <user-query>
+    <div class="query-content">
+      <p class="query-text-line">ハワイ旅行の準備について教えて</p>
+    </div>
+  </user-query>
+  <model-response>
+    <div class="response-content">
+      <div class="markdown markdown-main-panel">
+        <p>ハワイ旅行の準備について、Deep Researchで詳しく調査します。</p>
+      </div>
+    </div>
+  </model-response>
+</div>
+
+<!-- Deep Research Immersive Panel (main extraction target) -->
+<deep-research-immersive-panel
+  _nghost-ng-c775579162=""
+  class="ng-tns-c775579162-18 ng-star-inserted"
+  style="">
+
+  <!-- Toolbar with title -->
+  <toolbar _ngcontent-ng-c775579162="" class="ng-tns-c775579162-18" _nghost-ng-c3137383066="">
+    <div _ngcontent-ng-c3137383066="" class="toolbar has-title">
+      <div _ngcontent-ng-c3137383066="" class="left-panel">
+        <mat-icon
+          _ngcontent-ng-c3137383066=""
+          role="img"
+          data-test-id="immersive-icon"
+          class="mat-icon notranslate gds-icon-l google-symbols mat-ligature-font mat-icon-no-color ng-star-inserted"
+          aria-hidden="true"
+          data-mat-icon-type="font"
+          data-mat-icon-name="travel_explore"
+          fonticon="travel_explore">
+        </mat-icon>
+        <h2 _ngcontent-ng-c3137383066="" class="title-text gds-title-s ng-star-inserted">
+          ハワイ旅行準備と現地注意点レポート
+        </h2>
+      </div>
+      <div _ngcontent-ng-c3137383066="" class="action-buttons">
+        <!-- TOC menu (not extracted) -->
+        <toc-menu _ngcontent-ng-c775579162="" _nghost-ng-c1860874392="" class="ng-tns-c775579162-18 ng-star-inserted">
+        </toc-menu>
+      </div>
+    </div>
+  </toolbar>
+
+  <!-- Main content container -->
+  <div _ngcontent-ng-c775579162="" class="container ng-tns-c775579162-18">
+    <!-- Thinking panel (not extracted) -->
+    <thinking-panel _ngcontent-ng-c775579162="" class="ng-tns-c775579162-18">
+      <div class="thinking-content">
+        <p>Searching for Hawaii travel information...</p>
+        <p>Analyzing local regulations...</p>
+      </div>
+    </thinking-panel>
+
+    <!-- Response container with actual content -->
+    <response-container
+      _ngcontent-ng-c775579162=""
+      _nghost-ng-c4226368718=""
+      class="ng-tns-c775579162-18 ng-star-inserted">
+      <div _ngcontent-ng-c4226368718="" class="response-container-content">
+        <div class="response-content-wrapper">
+
+          <!-- Structured content container - main target -->
+          <structured-content-container
+            _ngcontent-ng-c775579162=""
+            data-test-id="message-content"
+            _nghost-ng-c78217833=""
+            class="ng-tns-c775579162-18 ng-star-inserted">
+
+            <!-- Message content wrapper -->
+            <message-content
+              _ngcontent-ng-c78217833=""
+              _nghost-ng-c1904670458=""
+              id="extended-response-message-content"
+              class="ng-star-inserted">
+
+              <!-- Markdown content - actual report content -->
+              <div
+                _ngcontent-ng-c1904670458=""
+                inline-copy-host=""
+                class="markdown markdown-main-panel stronger enable-updated-hr-color"
+                id="extended-response-markdown-content"
+                aria-live="off"
+                aria-busy="false"
+                dir="ltr"
+                style="--animation-duration: 400ms; --fade-animation-function: linear;">
+
+                <!-- Report content starts here -->
+                <h1 data-path-to-node="0">2026年3月ハワイ（オアフ島）渡航における観光インフラ・法制度・リスク管理に関する包括的調査報告書</h1>
+
+                <h2 data-path-to-node="1">1. はじめに</h2>
+                <p data-path-to-node="2">本レポートは、2026年3月にハワイ・オアフ島への渡航を計画されている方向けに、観光インフラ、法制度、およびリスク管理に関する包括的な情報を提供することを目的としています。</p>
+
+                <h2 data-path-to-node="3">2. 渡航準備</h2>
+                <h3 data-path-to-node="4">2.1 必要書類</h3>
+                <ul data-path-to-node="5">
+                  <li>有効なパスポート（残存有効期間6ヶ月以上推奨）</li>
+                  <li>ESTA（電子渡航認証システム）の事前申請</li>
+                  <li>往復航空券の予約確認書</li>
+                  <li>宿泊先の予約確認書</li>
+                </ul>
+
+                <h3 data-path-to-node="6">2.2 推奨持ち物</h3>
+                <p data-path-to-node="7">以下のアイテムを持参することを推奨します：</p>
+                <ol data-path-to-node="8">
+                  <li>日焼け止め（SPF50以上、リーフセーフ製品）</li>
+                  <li>サングラス</li>
+                  <li>軽量の羽織りもの</li>
+                  <li>防水バッグ</li>
+                </ol>
+
+                <h2 data-path-to-node="9">3. 現地での注意事項</h2>
+                <h3 data-path-to-node="10">3.1 環境保護規制</h3>
+                <p data-path-to-node="11">ハワイでは<strong>サンゴ礁保護</strong>のため、特定の化学物質を含む日焼け止めの使用が禁止されています。オキシベンゾンやオクチノキサートを含まない製品を使用してください。</p>
+
+                <h3 data-path-to-node="12">3.2 交通ルール</h3>
+                <p data-path-to-node="13">レンタカーを利用する場合：</p>
+                <ul data-path-to-node="14">
+                  <li>右側通行</li>
+                  <li>赤信号での右折は一時停止後に可能（一部例外あり）</li>
+                  <li>スクールバス停車時は追い越し禁止</li>
+                </ul>
+
+                <h2 data-path-to-node="15">4. まとめ</h2>
+                <p data-path-to-node="16">ハワイへの渡航は適切な準備と現地ルールの理解があれば、安全で楽しい旅行となります。本レポートの情報を参考に、充実した旅をお楽しみください。</p>
+
+                <!-- Report content ends here -->
+              </div>
+            </message-content>
+          </structured-content-container>
+
+        </div>
+      </div>
+      <div _ngcontent-ng-c4226368718="" class="response-container-footer"></div>
+    </response-container>
+  </div>
+
+  <!-- End of report marker -->
+  <div _ngcontent-ng-c775579162="" class="end-of-report-marker"></div>
+</deep-research-immersive-panel>

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -249,3 +249,54 @@ export function createGeminiPage(
     </div>
   `);
 }
+
+
+/**
+ * Create Deep Research パネル DOM 構造
+ */
+export function createDeepResearchDOM(title: string, content: string): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">${title}</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+          <structured-content-container data-test-id="message-content">
+            <message-content id="extended-response-message-content">
+              <div id="extended-response-markdown-content" 
+                   class="markdown markdown-main-panel">
+                ${content}
+              </div>
+            </message-content>
+          </structured-content-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}
+
+/**
+ * Create パネルのみ（コンテンツなし）の DOM
+ */
+export function createEmptyDeepResearchPanel(): string {
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">Test Report</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+  `;
+}

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -53,7 +53,7 @@ describe('storage', () => {
 
       expect(settings.obsidianApiKey).toBe('');
       expect(settings.obsidianPort).toBe(27123);
-      expect(settings.vaultPath).toBe('03_Extra/Gemini');
+      expect(settings.vaultPath).toBe('AI/Gemini');
       expect(settings.templateOptions.messageFormat).toBe('callout');
     });
 


### PR DESCRIPTION
## Summary

- Add Deep Research report extraction from Gemini's immersive panel
- Detect `deep-research-immersive-panel` and extract title/content
- Generate hash-based IDs for same-title overwrite support
- Skip validation warnings for single-message Deep Research reports
- Bump version to 0.3.3

## Changes

- **src/content/extractors/gemini.ts**: Deep Research selectors, detection, and extraction methods
- **src/content/extractors/base.ts**: Skip conversation-specific validation for deep-research type
- **src/content/markdown.ts**: Handle deep-research format in conversationToNote()
- **src/lib/types.ts**: Add `type` field for content discrimination
- **test/extractors/gemini.test.ts**: 12 new tests for Deep Research extraction
- **docs/**: Design specification and implementation workflow

## Test plan

- [x] All 337 tests pass
- [x] Build succeeds
- [x] Lint passes (warnings only)
- [ ] Manual test: Extract Deep Research report from Gemini
- [ ] Manual test: Verify no false warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)