### PR TITLE
✨ feat: add Deep Research inline link extraction

### DIFF
--- a/docs/design/deep-research-links-extraction.md
+++ b/docs/design/deep-research-links-extraction.md
@@ -1,0 +1,640 @@
+# Deep Research リンク抽出機能 設計書
+
+## 1. 概要
+
+### 1.1 目的
+Deep Research レポートに含まれるインライン引用を**インラインリンク形式**（`[タイトル](URL)`）に変換し、Obsidian に保存する。
+
+### 1.2 スコープ
+- インライン引用（`<sup data-turn-source-index>`）の検出
+- ドキュメント末尾のソースリスト抽出（URL・タイトル）
+- 引用のインラインリンク変換（`<sup>` → `[タイトル](URL)`）
+- URL・タイトルのセキュリティサニタイズ
+
+### 1.3 スコープ外
+- 脚注形式（`[^N]`）での出力（**不採用**：インラインリンク形式を採用）
+- References セクションの出力（**不要**：インラインリンクで完結）
+- サムネイル画像の取得・保存
+- ソースの信頼性評価
+- リンク先コンテンツのプリフェッチ
+- 元レポートとの番号一致（**不要**：ユーザー要件）
+
+---
+
+## 2. HTML 構造分析
+
+### 2.1 インライン引用構造
+
+```html
+<!-- 文中の引用マーカー -->
+<source-footnote _nghost-ng-c55987025="" class="ng-star-inserted">
+  <sup _ngcontent-ng-c55987025="" 
+       class="superscript" 
+       data-turn-source-index="1">
+    <!-- 実際の番号は CSS で表示 -->
+  </sup>
+</source-footnote>
+```
+
+**セレクタ**:
+- `source-footnote` - 引用要素
+- `sup.superscript[data-turn-source-index]` - 引用番号
+
+**属性**:
+- `data-turn-source-index`: **1ベース**のソースインデックス番号
+  - 検証日: 2025-01-12
+  - 検証方法: カルーセル展開時のURL比較
+  - 検証結果: `data-turn-source-index="1"` → ソースリスト[0]のURLと一致
+  - 変換式: `sourceListIndex = data-turn-source-index - 1`
+  - 注意: 0は存在しない（1から開始）
+
+### 2.2 ソースカルーセル構造（インライン展開）
+
+```html
+<sources-carousel-inline _nghost-ng-c3078843332="">
+  <sources-carousel id="sources" _nghost-ng-c389433453="">
+    <div class="carousel-content">
+      <div data-test-id="sources-carousel-source" class="sources-carousel-source">
+        <!-- ソースカード（動的ローディング） -->
+      </div>
+    </div>
+  </sources-carousel>
+</sources-carousel-inline>
+```
+
+**注意**: カルーセル内のソース詳細は動的にロードされるため、直接のリンク取得は困難。
+
+### 2.3 ドキュメント末尾のソースリスト構造
+
+```html
+<deep-research-source-lists _nghost-ng-c3369699991="">
+  <collapsible-button data-test-id="used-sources-button">
+    <span class="gds-title-m">レポートに使用されているソース</span>
+  </collapsible-button>
+  
+  <!-- ソースリスト本体 -->
+  <div id="used-sources-list">
+    <!-- 各ソースアイテム -->
+    <a data-test-id="browse-web-item-link" 
+       href="https://example.com/article"
+       target="_blank" rel="noopener">
+      <span data-test-id="title" class="sub-title">Article Title</span>
+      <span data-test-id="domain-name" class="display-name">example.com</span>
+    </a>
+  </div>
+</deep-research-source-lists>
+```
+
+### 2.4 Browse チップ構造（代替ソース）
+
+```html
+<a data-test-id="browse-chip-link" 
+   class="browse-chip" 
+   href="https://www.help.cbp.gov/s/article/Article-1282"
+   target="_blank" rel="noopener noreferrer">
+  <span data-test-id="title" class="sub-title">ESTA - How do I pay...</span>
+  <span data-test-id="domain-name" class="display-name">help.cbp.gov</span>
+</a>
+```
+
+---
+
+## 3. 設計
+
+### 3.1 セレクタ定義
+
+```typescript
+// src/content/extractors/gemini.ts に追加
+
+const DEEP_RESEARCH_LINK_SELECTORS = {
+  // インライン引用
+  inlineCitation: [
+    'source-footnote sup.superscript[data-turn-source-index]',
+    'sup.superscript[data-turn-source-index]',
+  ],
+  
+  // ソースリストコンテナ
+  sourceListContainer: [
+    'deep-research-source-lists',
+    '#used-sources-list',
+  ],
+  
+  // ソースリスト内のリンク
+  sourceListItem: [
+    'a[data-test-id="browse-web-item-link"]',
+    'a[data-test-id="browse-chip-link"]',
+  ],
+  
+  // ソースタイトル
+  sourceTitle: [
+    '[data-test-id="title"]',
+    '.sub-title',
+  ],
+  
+  // ソースドメイン
+  sourceDomain: [
+    '[data-test-id="domain-name"]',
+    '.display-name',
+  ],
+};
+```
+
+### 3.2 型定義
+
+```typescript
+// src/lib/types.ts に追加
+
+/**
+ * Deep Research のソース情報
+ */
+export interface DeepResearchSource {
+  /** ソースリスト内の0ベースインデックス（DOM順） */
+  index: number;
+  /** ソースURL */
+  url: string;
+  /** ソースタイトル */
+  title: string;
+  /** ドメイン名 */
+  domain: string;
+}
+
+/**
+ * Deep Research リンク抽出結果
+ * 
+ * 設計方針: ソースリストのみを保持し、インライン引用は
+ * HTML→Markdown変換時に data-turn-source-index から直接処理する
+ */
+export interface DeepResearchLinks {
+  /** ソース一覧（ソースリストのDOM順、0ベースインデックス） */
+  sources: DeepResearchSource[];
+}
+
+// ConversationData の拡張
+export interface ConversationData {
+  // ... 既存フィールド
+
+  /** Deep Research のリンク情報（optional） */
+  links?: DeepResearchLinks;
+}
+```
+
+**設計決定**:
+- `InlineCitation` 型は**不要**
+- インライン引用はHTML変換時に `data-turn-source-index` 属性から直接処理
+- ソースリストは `Map<number, DeepResearchSource>` として `data-turn-source-index` → ソース情報をマッピング
+
+### 3.3 抽出ロジック
+
+```typescript
+// src/content/extractors/gemini.ts に追加
+
+/**
+ * ソースリストを抽出し、data-turn-source-index でアクセス可能な Map を構築
+ * 
+ * 重要: data-turn-source-index は 1ベース
+ * ソースリストの DOM 順（0ベース）との対応:
+ *   data-turn-source-index="N" → sourceList[N-1]
+ */
+extractSourceList(): DeepResearchSource[] {
+  const sources: DeepResearchSource[] = [];
+  
+  // ソースリスト内のリンクを取得
+  const sourceLinks = document.querySelectorAll(
+    DEEP_RESEARCH_LINK_SELECTORS.sourceListItem.join(',')
+  );
+  
+  sourceLinks.forEach((link, index) => {
+    const anchor = link as HTMLAnchorElement;
+    const url = anchor.href;
+    
+    // タイトルを取得
+    const titleEl = anchor.querySelector(
+      DEEP_RESEARCH_LINK_SELECTORS.sourceTitle.join(',')
+    );
+    const title = titleEl?.textContent?.trim() || 'Unknown Title';
+    
+    // ドメインを取得（URLパース失敗に備えてtry-catch）
+    const domainEl = anchor.querySelector(
+      DEEP_RESEARCH_LINK_SELECTORS.sourceDomain.join(',')
+    );
+    let domain = domainEl?.textContent?.trim() || '';
+    if (!domain) {
+      try {
+        domain = new URL(url).hostname;
+      } catch {
+        domain = 'unknown';
+      }
+    }
+    
+    sources.push({
+      index,  // 0ベースの配列インデックス
+      url,
+      title: this.sanitizeText(title),
+      domain,
+    });
+  });
+  
+  return sources;
+}
+
+/**
+ * ソースリストから data-turn-source-index でアクセス可能な Map を構築
+ * 
+ * @param sources extractSourceList() の結果
+ * @returns Map<data-turn-source-index, DeepResearchSource>
+ * 
+ * 使用例:
+ *   const map = buildSourceMap(sources);
+ *   const source = map.get(5); // data-turn-source-index="5" に対応するソース
+ */
+buildSourceMap(sources: DeepResearchSource[]): Map<number, DeepResearchSource> {
+  const map = new Map<number, DeepResearchSource>();
+  
+  sources.forEach((source, arrayIndex) => {
+    // data-turn-source-index は 1ベース
+    // arrayIndex=0 → data-turn-source-index=1
+    const turnSourceIndex = arrayIndex + 1;
+    map.set(turnSourceIndex, source);
+  });
+  
+  return map;
+}
+
+/**
+ * Deep Research リンク情報を抽出
+ */
+extractDeepResearchLinks(): DeepResearchLinks {
+  const sources = this.extractSourceList();
+  
+  return {
+    sources,
+  };
+}
+```
+
+**注記**: `extractInlineCitations()` は不要。インライン引用の処理は Markdown 変換時に行う。
+
+### 3.4 Markdown 変換（インラインリンク方式）
+
+```typescript
+// src/content/markdown.ts に追加
+
+/**
+ * URLをサニタイズ（危険なスキームを除去）
+ */
+function sanitizeUrl(url: string): string {
+  const dangerousSchemes = ['javascript:', 'data:', 'vbscript:'];
+  const lowerUrl = url.toLowerCase().trim();
+  
+  for (const scheme of dangerousSchemes) {
+    if (lowerUrl.startsWith(scheme)) {
+      return ''; // 危険なURLは空文字を返す
+    }
+  }
+  
+  return url;
+}
+
+/**
+ * Markdownリンクテキスト用のエスケープ
+ */
+function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+}
+
+/**
+ * Markdownリンク用のURLエスケープ
+ */
+function escapeMarkdownLinkUrl(url: string): string {
+  return url.replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+/**
+ * インライン引用をインラインリンク形式に変換
+ * 
+ * 変換前: <source-footnote><sup data-turn-source-index="N">...</sup></source-footnote>
+ * 変換後: [タイトル](URL)
+ * 
+ * 重要: data-turn-source-index は 1ベース
+ *       sourceMap.get(N) で対応するソースを取得
+ * 
+ * @param html 変換対象のHTML
+ * @param sourceMap buildSourceMap() で構築した Map
+ */
+function convertInlineCitationsToLinks(
+  html: string,
+  sourceMap: Map<number, DeepResearchSource>
+): string {
+  // パターン1: source-footnote でラップされている場合
+  let result = html.replace(
+    /<source-footnote[^>]*>[\s\S]*?<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>[\s\S]*?<\/source-footnote>/gi,
+    (match, indexStr) => {
+      const index = parseInt(indexStr, 10);
+      const source = sourceMap.get(index);
+      if (source) {
+        const safeTitle = escapeMarkdownLinkText(source.title);
+        const safeUrl = escapeMarkdownLinkUrl(sanitizeUrl(source.url));
+        if (safeUrl) {
+          return `[${safeTitle}](${safeUrl})`;
+        }
+        return safeTitle; // URLが無効な場合はタイトルのみ
+      }
+      return ''; // ソースが見つからない場合は削除
+    }
+  );
+  
+  // パターン2: sup要素が直接存在する場合（フォールバック）
+  result = result.replace(
+    /<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>/gi,
+    (match, indexStr) => {
+      const index = parseInt(indexStr, 10);
+      const source = sourceMap.get(index);
+      if (source) {
+        const safeTitle = escapeMarkdownLinkText(source.title);
+        const safeUrl = escapeMarkdownLinkUrl(sanitizeUrl(source.url));
+        if (safeUrl) {
+          return `[${safeTitle}](${safeUrl})`;
+        }
+        return safeTitle;
+      }
+      return '';
+    }
+  );
+  
+  return result;
+}
+
+/**
+ * sources-carousel-inline 要素を除去
+ */
+function removeSourcesCarousel(html: string): string {
+  return html.replace(
+    /<sources-carousel-inline[\s\S]*?<\/sources-carousel-inline>/gi,
+    ''
+  );
+}
+
+/**
+ * Deep Research コンテンツを変換（インラインリンク方式）
+ * 
+ * @param html 変換対象のHTML
+ * @param links extractDeepResearchLinks() の結果
+ */
+function convertDeepResearchContent(
+  html: string,
+  links?: DeepResearchLinks
+): string {
+  let processed = html;
+  
+  // 1. ソースマップを構築
+  let sourceMap = new Map<number, DeepResearchSource>();
+  if (links && links.sources.length > 0) {
+    links.sources.forEach((source, arrayIndex) => {
+      // data-turn-source-index は 1ベース
+      const turnSourceIndex = arrayIndex + 1;
+      sourceMap.set(turnSourceIndex, source);
+    });
+  }
+  
+  // 2. インライン引用をインラインリンクに変換
+  processed = convertInlineCitationsToLinks(processed, sourceMap);
+  
+  // 3. sources-carousel を除去
+  processed = removeSourcesCarousel(processed);
+  
+  // 4. HTML → Markdown 変換
+  const markdown = htmlToMarkdown(processed);
+  
+  // References セクションは生成しない（インラインリンクで完結）
+  
+  return markdown;
+}
+```
+
+**設計ポイント**:
+- 脚注形式（`[^N]`）は不採用 → インラインリンク（`[タイトル](URL)`）を直接挿入
+- `generateFootnoteDefinitions()` と `generateReferencesSection()` は**不要**
+- ソースが見つからない場合は空文字（引用マーカーを削除）
+
+---
+
+## 4. 出力フォーマット
+
+### 4.1 期待される出力例（インラインリンク方式）
+
+```markdown
+---
+id: gemini_deep-research-a1b2c3d4
+title: ハワイ旅行準備と現地注意点レポート
+source: gemini
+type: deep-research
+url: https://gemini.google.com/app/xxx
+created: 2025-01-11T10:00:00.000Z
+modified: 2025-01-11T10:00:00.000Z
+tags:
+  - ai-research
+  - deep-research
+  - gemini
+message_count: 1
+---
+
+# 2026年3月ハワイ渡航に関する調査報告書
+
+## 1. 入国手続き
+
+### 1.1 ESTA申請
+
+2026年現在、ESTA費用は**$40**に改定されている[ESTA - How do I pay for my application?](https://www.help.cbp.gov/s/article/Article-1282)。申請は出発の72時間前までに完了することが推奨される[CBP's Electronic System for Travel Authorization](https://uk.usembassy.gov/cbps-electronic-system-for-travel-authorization-esta/)。
+
+## 2. 交通
+
+スカイライン運賃は**$3.00**である[Honolulu Skyline Rail 2025](https://livinginhawaii.com/honolulu-skyline-rail/)。大型スーツケースは持ち込み不可[Rail Operations](https://www.honolulu.gov/dts/rail-operations)。
+```
+
+### 4.2 フォーマット特徴
+
+| 項目 | 説明 |
+|------|------|
+| インライン引用 | `[タイトル](URL)` 形式のインラインリンク |
+| 脚注定義 | **なし**（インラインリンクで完結） |
+| References セクション | **なし**（インラインリンクで完結） |
+| セキュリティ | URL/タイトルは `sanitizeUrl()` と `escapeMarkdownLinkText()` で処理 |
+
+### 4.3 変換前後の比較
+
+| 変換前（HTML） | 変換後（Markdown） |
+|---------------|-------------------|
+| `テキスト<source-footnote><sup data-turn-source-index="1">...</sup></source-footnote>` | `テキスト[タイトル](URL)` |
+| `<sources-carousel-inline>...</sources-carousel-inline>` | （削除） |
+
+---
+
+## 5. 実装計画
+
+### 5.1 Phase 1: 型定義と基本構造
+
+1. `src/lib/types.ts` に `DeepResearchSource`, `InlineCitation`, `DeepResearchLinks` を追加
+2. `ConversationData` に `links` フィールドを追加
+
+### 5.2 Phase 2: 抽出ロジック
+
+1. `DEEP_RESEARCH_LINK_SELECTORS` を追加
+2. `extractSourceList()` を実装
+3. `buildSourceMap()` を実装
+4. `extractDeepResearchLinks()` を実装
+5. `extractDeepResearch()` を更新してリンク情報を含める
+
+### 5.3 Phase 3: Markdown 変換
+
+1. `sanitizeUrl()` を実装
+2. `escapeMarkdownLinkText()` / `escapeMarkdownLinkUrl()` を実装
+3. `convertInlineCitationsToLinks()` を実装
+4. `removeSourcesCarousel()` を実装
+5. `convertDeepResearchContent()` を実装
+6. `conversationToNote()` を更新
+
+### 5.4 Phase 4: テスト
+
+1. 引用抽出のユニットテスト
+2. ソースリスト抽出のユニットテスト
+3. Markdown 変換のユニットテスト
+4. 統合テスト（サンプル HTML 使用）
+
+---
+
+## 6. 注意事項
+
+### 6.1 DOM の動的性
+
+- `sources-carousel` 内のソースカードは動的にロードされる（遅延読み込み）
+- 折りたたみ状態ではカルーセル内URLは空
+- **解決策**: ドキュメント末尾の `deep-research-source-lists` からURLを取得
+- インライン引用は `data-turn-source-index` 属性から番号を取得（常に存在）
+
+### 6.2 インデックスのオフセット
+
+- `data-turn-source-index` は **1ベース** のインデックス
+  - 検証日: 2025-01-12
+  - 検証方法: カルーセル展開時のURL比較
+- ソースリストの配列は **0ベース**
+- **変換式**: `sourceListIndex = data-turn-source-index - 1`
+- 例: `data-turn-source-index="1"` → `sources[0]`
+
+### 6.3 重複ソースの扱い
+
+- 同一ソースが複数の文で引用される場合がある
+- 各引用位置に同じインラインリンクを挿入（重複OK）
+- 脚注方式と異なり、重複管理は不要
+
+### 6.4 欠損データの処理
+
+| 状況 | 処理 |
+|------|------|
+| ソースリストに存在しない `data-turn-source-index` | 引用マーカーを削除（空文字） |
+| URL が無効（危険スキーム） | タイトルのみテキスト出力 |
+| タイトルが空 | "Unknown Title" を使用 |
+| ドメイン取得失敗 | "unknown" を使用 |
+
+### 6.5 セキュリティ考慮事項
+
+#### URLサニタイズ
+- `javascript:`, `data:`, `vbscript:` スキームは除去
+- 無効なURLは空文字を返す
+- `sanitizeUrl()` で検証してからMarkdownに出力
+
+#### Markdownエスケープ
+- タイトル内の `[` `]` → `\[` `\]` にエスケープ
+- URL内の `(` `)` → `%28` `%29` にエスケープ
+- XSS防止のため、外部データは必ずエスケープ
+
+#### 検証順序
+```
+URL取得 → sanitizeUrl() → escapeMarkdownLinkUrl() → Markdown出力
+タイトル取得 → escapeMarkdownLinkText() → Markdown出力
+```
+
+### 6.6 インラインリンク方式の利点
+
+| 観点 | 脚注方式 | インラインリンク方式 |
+|------|---------|-------------------|
+| 実装複雑度 | 高（脚注定義管理必要） | 低（直接置換） |
+| 出力の可読性 | 本文がシンプル | リンク情報が即座に分かる |
+| Obsidian互換性 | 脚注プラグイン依存 | 標準Markdown |
+| 重複管理 | 必要 | 不要 |
+| ユーザー要件 | ❌ | ✅（採用） |
+
+---
+
+## 7. テスト計画
+
+### 7.1 ユニットテスト
+
+| テスト項目 | 説明 |
+|-----------|------|
+| `extractSourceList()` | URL、タイトル、ドメインの抽出 |
+| `buildSourceMap()` | 1ベースインデックスへのマッピング |
+| `convertInlineCitationsToLinks()` | HTML → `[タイトル](URL)` 変換 |
+| `sanitizeUrl()` | 危険スキームの除去 |
+| `escapeMarkdownLinkText()` | `[]` のエスケープ |
+| `escapeMarkdownLinkUrl()` | `()` のエンコード |
+
+### 7.2 エッジケース
+
+| シナリオ | 期待結果 |
+|---------|---------|
+| 引用なし | 本文のみ（インラインリンクなし） |
+| ソースリストなし | 本文のみ、警告ログ |
+| ソースリストに存在しない `data-turn-source-index` | 引用マーカー削除（空文字） |
+| 重複引用（同じインデックス複数回） | 各位置に同じリンクを挿入 |
+| 無効なURL（`javascript:`） | タイトルのみテキスト出力 |
+| 日本語タイトル | 正しくエスケープ |
+| タイトルに `[]` 含む | `\[\]` にエスケープ |
+| URLに `()` 含む | `%28%29` にエンコード |
+| URL解析失敗 | domain を 'unknown' にフォールバック |
+| `data-turn-source-index="1"` | `sources[0]` に対応（1ベース確認） |
+
+---
+
+## 8. 影響範囲
+
+### 8.1 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/lib/types.ts` | `DeepResearchSource`, `DeepResearchLinks` 追加 |
+| `src/content/extractors/gemini.ts` | `extractSourceList()`, `buildSourceMap()`, `extractDeepResearchLinks()` 追加 |
+| `src/content/markdown.ts` | `convertInlineCitationsToLinks()`, `convertDeepResearchContent()` 追加 |
+| `test/extractors/gemini.test.ts` | リンク抽出テスト追加 |
+| `test/markdown.test.ts` | インラインリンク変換テスト追加 |
+
+### 8.2 後方互換性
+
+- `ConversationData.links` は optional
+- 既存のレポート抽出機能に影響なし
+- リンク情報がない場合は従来通りの出力
+
+---
+
+## 9. 承認
+
+| 項目 | 状態 |
+|------|------|
+| 設計レビュー | 待機中 |
+| 実装承認 | 待機中 |
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2025-01-11 | 初版作成 |
+| 1.1 | 2025-01-11 | レビュー指摘対応: Set→配列、URLバリデーション、セキュリティ対応 |
+| 2.0 | 2025-01-12 | 大幅改訂: 脚注形式からインラインリンク形式に変更、`data-turn-source-index` を1ベースに修正（検証済み）、`InlineCitation`型削除、Referencesセクション削除 |
+
+---
+
+*作成日: 2025-01-11*
+*更新日: 2025-01-12*
+*バージョン: 2.0*
+*前提: deep-research-extraction.md v1.1*

--- a/docs/investigation/inline-citation-collapsed-state.md
+++ b/docs/investigation/inline-citation-collapsed-state.md
@@ -1,0 +1,370 @@
+# インライン引用の折りたたみ状態に関する調査レポート
+
+## 調査目的
+
+Deep Research レポートにおいて、インラインリンク（カルーセル）が展開されていない状態でも、引用番号（`data-turn-source-index`）を取得できるかどうかを調査する。
+
+---
+
+## 調査対象ファイル
+
+| ファイル | 状態 | サイズ |
+|----------|------|--------|
+| `data/gemini-deep-research-collapsed.html` | 折りたたみ状態 | 小 |
+| `data/gemini-deep-research-expanded.html` | 展開状態 | 大 |
+
+---
+
+## DOM 構造比較
+
+### 折りたたみ状態（collapsed）
+
+```html
+<source-footnote class="ng-star-inserted">
+  <sup class="superscript" data-turn-source-index="5">
+    <!---->
+  </sup>
+</source-footnote>
+```
+
+**特徴**:
+- `data-turn-source-index="5"` は**存在する** ✅
+- `<sup>` 内のテキストは**空**（コメントノードのみ）
+- `class="superscript"` に `visible` クラスが**ない**
+
+### 展開状態（expanded）
+
+```html
+<source-footnote class="ng-star-inserted">
+  <sup class="superscript visible" data-turn-source-index="5">
+     1 
+    <!---->
+  </sup>
+</source-footnote>
+```
+
+**特徴**:
+- `data-turn-source-index="5"` は**存在する** ✅
+- `<sup>` 内に表示番号 ` 1 ` が**存在する**
+- `class="superscript visible"` に `visible` クラスが**ある**
+
+---
+
+## sources-carousel の比較
+
+### 折りたたみ状態
+
+```html
+<sources-carousel style="display: flex; visibility: hidden;">
+  <div class="container hide">
+    <div class="sources-carousel-source hide">
+      <!---->  <!-- 空 -->
+    </div>
+  </div>
+</sources-carousel>
+```
+
+**特徴**:
+- `visibility: hidden` で非表示
+- `class="hide"` が付与
+- カルーセル内のソースカードは**空**（遅延ロード未実行）
+
+### 展開状態
+
+```html
+<sources-carousel style="display: flex; visibility: visible;">
+  <div class="container">
+    <div class="sources-carousel-source">
+      <card-renderer>
+        <url-source-card>
+          <a href="https://www.nasa.gov/...">
+            <span class="source-card-title">SEH 2.0 Fundamentals...</span>
+          </a>
+        </url-source-card>
+      </card-renderer>
+    </div>
+  </div>
+</sources-carousel>
+```
+
+**特徴**:
+- `visibility: visible` で表示
+- `class="hide"` が**ない**
+- ソースカードが**動的にロードされている**
+
+---
+
+## 結論
+
+### 折りたたみ状態でも取得可能なデータ
+
+| データ | 取得可否 | セレクタ |
+|--------|----------|----------|
+| 引用インデックス番号 | ✅ 可能 | `sup[data-turn-source-index]` |
+| 引用の文書内位置 | ✅ 可能 | 親要素から特定可能 |
+
+### 折りたたみ状態では取得不可能なデータ
+
+| データ | 取得可否 | 理由 |
+|--------|----------|------|
+| インラインカルーセル内のURL | ❌ 不可 | 遅延ロードで空 |
+| インラインカルーセル内のタイトル | ❌ 不可 | 遅延ロードで空 |
+| 表示番号（`1`, `2` など） | ❌ 不可 | 展開時のみ表示 |
+
+---
+
+## 設計への影響
+
+### 現在の設計書の前提
+
+設計書 v1.1 では以下の2箇所からデータを取得する方針：
+
+1. **インライン引用**: `data-turn-source-index` から引用番号を取得
+2. **ドキュメント末尾のソースリスト**: URL/タイトル/ドメインを取得
+
+### 調査結果との整合性
+
+| 設計方針 | 調査結果 | 判定 |
+|----------|----------|------|
+| `data-turn-source-index` から番号取得 | 折りたたみ状態でも取得可能 | ✅ 問題なし |
+| ソースリストからURL取得 | ドキュメント末尾のリストは常に存在 | ✅ 問題なし |
+
+---
+
+## 重要な発見
+
+### インデックス番号の不一致
+
+折りたたみ状態のサンプルでは：
+- `data-turn-source-index="5"` （0ベースのソースインデックス）
+
+展開状態のサンプルでは：
+- `data-turn-source-index="5"` + 表示番号 ` 1 `
+
+**観察**: 
+- `data-turn-source-index` は**0ベースのソースインデックス**
+- 表示番号（` 1 `）は**文書内での出現順序**（異なる番号体系）
+
+### ソースリストとの対応
+
+`gemini-elements-sample.html` の調査結果：
+- インライン引用で使用されている `data-turn-source-index`: 約30種類（非連続）
+- ドキュメント末尾のソースリスト項目数: 116件
+
+**観察**:
+- ソースリストには全ソースが含まれる
+- インライン引用は一部のソースのみを参照
+- インデックスは連続していない（1, 2, 3, 5, 10, 11, 13, 15...）
+
+---
+
+## 結論サマリー
+
+**質問**: 折りたたみ状態でもインラインリンクの存在を判断できるか？
+
+**回答**: **はい、可能です。**
+
+理由：
+1. `data-turn-source-index` 属性は折りたたみ状態でも DOM に存在する
+2. この属性値を使って、ドキュメント末尾のソースリストとマッピングできる
+3. インラインカルーセル内のデータは不要（ソースリストで代替可能）
+
+---
+
+## 推奨事項
+
+1. **現在の設計書の方針を維持**: インライン引用は `data-turn-source-index` から取得、URL情報はソースリストから取得
+2. **カルーセル内データは無視**: 遅延ロードの問題を回避
+3. **インデックスマッピングの検証**: ソースリストのインデックスが `data-turn-source-index` と一致するか要確認
+
+---
+
+## 追加調査が必要な項目
+
+- [x] ソースリスト内の各項目に対応するインデックス番号の特定方法
+- [x] `data-turn-source-index` とソースリストの順序の対応関係
+- [x] 現在の実装の分析とインデックスマッピング問題の解決策
+
+---
+
+## 追加調査結果（2025-01-12）
+
+### 現在の実装分析
+
+#### extractSourceList() の実装
+
+```typescript
+// src/content/extractors/gemini.ts:164-199
+extractSourceList(): DeepResearchSource[] {
+  const sources: DeepResearchSource[] = [];
+  const selector = DEEP_RESEARCH_LINK_SELECTORS.sourceListItem.join(',');
+  const sourceLinks = document.querySelectorAll(selector);
+
+  sourceLinks.forEach((link, index) => {  // ← 問題箇所: forEach の index を使用
+    // ...
+    sources.push({
+      index,  // ← 連続する 0, 1, 2, 3... を割り当て
+      url,
+      title: this.sanitizeText(title),
+      domain,
+    });
+  });
+  return sources;
+}
+```
+
+**問題点**:
+- `forEach` のコールバックで取得する `index` は配列の連続インデックス（0, 1, 2, 3...）
+- しかし `data-turn-source-index` の値は非連続（1, 2, 3, 5, 10, 11, 13...）
+- このミスマッチにより、インライン引用とソースリストの正確なマッピングができない
+
+#### DEEP_RESEARCH_LINK_SELECTORS
+
+```typescript
+// src/content/extractors/gemini.ts:74-91
+DEEP_RESEARCH_LINK_SELECTORS = {
+  inlineCitation: [
+    'source-footnote sup.superscript[data-turn-source-index]',
+    'sup.superscript[data-turn-source-index]',
+  ],
+  sourceListContainer: ['deep-research-source-lists', '#used-sources-list'],
+  sourceListItem: [
+    'a[data-test-id="browse-web-item-link"]',
+    'a[data-test-id="browse-chip-link"]',
+  ],
+  // ...
+};
+```
+
+---
+
+### インデックスマッピング問題の詳細分析
+
+#### サンプルデータの調査結果
+
+| データソース | 値の特徴 |
+|-------------|----------|
+| `data-turn-source-index` | 非連続（1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 13, 15...） |
+| `forEach` の `index` | 連続（0, 1, 2, 3, 4, 5...） |
+| 表示脚注番号 | 連続（1, 2, 3...、出現順） |
+
+#### gemini-elements-sample.html の具体的データ
+
+インライン引用で使用されている `data-turn-source-index` 値（出現頻度順）：
+```
+1(3回), 2(2回), 3(2回), 5(2回), 6(1回), 7(3回), 8(1回), 9(2回),
+10(1回), 11(1回), 13(2回), 15(2回), 16(1回), 18(1回), 19(1回),
+20(2回), 21(2回), 22(2回), 24(3回), 25(2回), 26(1回), 27(1回),
+28(1回), 29(3回), 32(1回), 33(1回), 34(1回), 36(1回), 38(1回),
+39(2回), 41(2回), 43(1回), 45(2回), 47(1回)
+```
+
+**欠番**: 0, 4, 12, 14, 17, 23, 30, 31, 35, 37, 40, 42, 44, 46
+
+---
+
+### 解決策の分析
+
+#### 方法A: ソースリスト要素から直接インデックスを取得（推奨）
+
+**前提**: ソースリストの各項目がDOMに `data-turn-source-index` 相当の属性を持っている場合
+
+**調査結果**:
+- `a[data-test-id="browse-web-item-link"]` には `data-turn-source-index` 属性は**存在しない**
+- ソースリスト要素のDOMは純粋なリンクリストで、インデックス属性を持たない
+
+**結論**: この方法は**使用不可**
+
+#### 方法B: 出現順序ベースのマッピング
+
+**アプローチ**:
+1. インライン引用から `data-turn-source-index` の**ユニークな値**を出現順に収集
+2. ソースリストも出現順に収集
+3. 両者を出現順でマッピング
+
+**仮説**: ソースリストの順序 = `data-turn-source-index` の出現順序（昇順）
+
+**検証が必要な点**:
+- ソースリストが `data-turn-source-index` の昇順で並んでいるか
+- それとも文書内での初出順序か
+
+**リスク**: 順序の仮定が間違っている場合、全マッピングがズレる
+
+#### 方法C: インラインカルーセル展開による直接取得
+
+**アプローチ**:
+1. 各インライン引用のカルーセルをプログラムで展開（click イベント発火）
+2. 展開後のカルーセル内からURLを直接取得
+3. `data-turn-source-index` とURLを直接紐付け
+
+**メリット**:
+- 確実なマッピング
+- インデックスの順序に依存しない
+
+**デメリット**:
+- DOM操作が重い（全引用を展開する必要）
+- 遅延ロードの完了を待つ必要がある
+- ユーザー体験への影響（UIが変化する）
+
+#### 方法D: 両方のデータソースから独立して番号付け（現在の設計書方針）
+
+**アプローチ**:
+1. インライン引用: `data-turn-source-index` を脚注番号として使用
+2. ソースリスト: 全URLを独立してReferencesセクションに出力
+3. マッピングは諦め、両者を別々に扱う
+
+**メリット**:
+- 実装がシンプル
+- マッピング失敗のリスクがない
+
+**デメリット**:
+- 脚注とReferencesの番号が一致しない可能性
+- ユーザーにとって分かりにくい
+
+---
+
+### ✅ 解決済み: インデックスマッピング問題（2025-01-12）
+
+#### 検証結果
+
+ユーザーによるカルーセル展開検証により、マッピング規則が判明：
+
+```
+data-turn-source-index は 1ベース
+ソースリストの配列は 0ベース
+変換式: sourceListIndex = data-turn-source-index - 1
+```
+
+**検証手順**:
+1. `data-turn-source-index="1"` のカルーセルをクリック
+2. 展開されたURLを取得:
+   - `https://www.nasa.gov/reference/2-0-fundamentals-of-systems-engineering/`
+   - `https://nodis3.gsfc.nasa.gov/displayAll.cfm?...`
+3. ソースリスト[0], [1] のURLと比較 → **一致**
+
+#### 採用方針
+
+**インラインリンク方式**を採用（脚注形式は不採用）
+
+```
+変換前: テキスト<sup data-turn-source-index="N">...</sup>
+変換後: テキスト[タイトル](URL)
+```
+
+**理由**:
+- ユーザー要件: 「ナンバリングが元のレポートとマッチすることは重要ではありません」
+- シンプルな出力形式が望ましい
+- Referencesセクション不要
+
+#### 設計書への反映
+
+`docs/design/deep-research-links-extraction.md` v2.0 に反映済み:
+- `data-turn-source-index` を1ベースに修正
+- `InlineCitation` 型削除
+- `convertInlineCitationsToLinks()` を新規追加
+- `generateFootnoteDefinitions()`, `generateReferencesSection()` 削除
+
+---
+
+*更新日: 2025-01-12*
+*調査者: Claude*

--- a/docs/workflow/deep-research-links-implementation.md
+++ b/docs/workflow/deep-research-links-implementation.md
@@ -1,0 +1,195 @@
+# Deep Research リンク抽出機能 - 実装ワークフロー
+
+## ワークフロー概要
+
+| 項目 | 内容 |
+|------|------|
+| 設計書 | [../design/deep-research-links-extraction.md](../design/deep-research-links-extraction.md) v1.1 |
+| 総フェーズ数 | 4 |
+| 変更ファイル数 | 5 |
+| 依存関係 | Phase 1 → Phase 2 → Phase 3 → Phase 4（順序依存） |
+
+---
+
+## Phase 1: 型定義と基本構造
+
+**目的**: 新しいインターフェースを追加し、既存の型を拡張
+
+### タスク 1.1: 新規インターフェース追加
+- **ファイル**: `src/lib/types.ts`
+- **追加内容**:
+  - `DeepResearchSource` インターフェース（4フィールド）
+  - `InlineCitation` インターフェース（2フィールド）
+  - `DeepResearchLinks` インターフェース（3フィールド）
+
+### タスク 1.2: ConversationData 拡張
+- **ファイル**: `src/lib/types.ts`
+- **変更内容**: `links?: DeepResearchLinks` フィールドを追加
+
+### 検証基準
+- TypeScript コンパイルエラーなし
+- 既存テストがすべてパス
+
+---
+
+## Phase 2: 抽出ロジック実装
+
+**目的**: Gemini DOM からリンク/引用情報を抽出
+
+### タスク 2.1: セレクタ定義追加
+- **ファイル**: `src/content/extractors/gemini.ts`
+- **追加内容**: `DEEP_RESEARCH_LINK_SELECTORS` 定数
+
+### タスク 2.2: extractInlineCitations() 実装
+- **ファイル**: `src/content/extractors/gemini.ts`
+- **機能**: `data-turn-source-index` 属性から引用番号を抽出
+
+### タスク 2.3: extractSourceList() 実装
+- **ファイル**: `src/content/extractors/gemini.ts`
+- **機能**: ソースリストから URL/タイトル/ドメインを抽出
+- **注意**: URL パース失敗時の try-catch 必須
+
+### タスク 2.4: extractDeepResearchLinks() 実装
+- **ファイル**: `src/content/extractors/gemini.ts`
+- **機能**: 上記2メソッドを統合、`usedIndices` 配列を生成
+
+### タスク 2.5: extractDeepResearch() 更新
+- **ファイル**: `src/content/extractors/gemini.ts`
+- **変更内容**: リンク情報を抽出結果に含める
+
+### 検証基準
+- `npm run lint` エラーなし
+- `npm run build` 成功
+
+---
+
+## Phase 3: Markdown 変換実装
+
+**目的**: HTML を脚注付き Markdown に変換
+
+### タスク 3.1: セキュリティ関数追加
+- **ファイル**: `src/content/markdown.ts`
+- **追加関数**:
+  - `sanitizeUrl()` - 危険なスキーム除去
+  - `escapeMarkdownLinkText()` - `[]` エスケープ
+  - `escapeMarkdownLinkUrl()` - `()` エンコード
+
+### タスク 3.2: HTML 変換関数追加
+- **ファイル**: `src/content/markdown.ts`
+- **追加関数**:
+  - `convertInlineCitations()` - `<sup>` → `[^N]`
+  - `removeSourcesCarousel()` - カルーセル除去
+
+### タスク 3.3: 出力生成関数追加
+- **ファイル**: `src/content/markdown.ts`
+- **追加関数**:
+  - `generateFootnoteDefinitions()` - 脚注定義生成（`---` 区切り線含む）
+  - `generateReferencesSection()` - References セクション生成
+
+### タスク 3.4: convertDeepResearchContent() 実装
+- **ファイル**: `src/content/markdown.ts`
+- **機能**: 上記関数を統合した変換パイプライン
+
+### タスク 3.5: conversationToNote() 更新
+- **ファイル**: `src/content/markdown.ts`
+- **変更内容**: Deep Research 時に `convertDeepResearchContent()` を使用
+
+### 検証基準
+- `npm run lint` エラーなし
+- `npm run build` 成功
+
+---
+
+## Phase 4: テスト実装
+
+**目的**: 新機能の品質保証
+
+### タスク 4.1: dom-helpers.ts 拡張
+- **ファイル**: `test/fixtures/dom-helpers.ts`
+- **追加内容**: 引用/ソースリスト付き DOM 生成ヘルパー
+
+### タスク 4.2: gemini.test.ts 拡張
+- **ファイル**: `test/extractors/gemini.test.ts`
+- **追加テスト**:
+  - `extractInlineCitations()` テスト
+  - `extractSourceList()` テスト
+  - `extractDeepResearchLinks()` テスト
+  - リンク情報付き Deep Research 抽出テスト
+
+### タスク 4.3: markdown.test.ts 拡張
+- **ファイル**: `test/content/markdown.test.ts`
+- **追加テスト**:
+  - `sanitizeUrl()` テスト（危険スキーム除去）
+  - `escapeMarkdownLinkText()` テスト
+  - `convertInlineCitations()` テスト
+  - `generateFootnoteDefinitions()` テスト
+  - `generateReferencesSection()` テスト
+  - エッジケーステスト（設計書 Section 7.2）
+
+### 検証基準
+- `npm run test` 全テストパス
+- カバレッジ低下なし
+
+---
+
+## 依存関係図
+
+```
+Phase 1 (types.ts)
+    │
+    ▼
+Phase 2 (gemini.ts) ─── imports types
+    │
+    ▼
+Phase 3 (markdown.ts) ─── imports types
+    │
+    ▼
+Phase 4 (tests) ─── validates all
+```
+
+---
+
+## 実装順序チェックリスト
+
+| # | タスク | ファイル | 依存 | 状態 |
+|---|--------|----------|------|------|
+| 1.1 | 新規インターフェース追加 | types.ts | なし | [ ] |
+| 1.2 | ConversationData 拡張 | types.ts | 1.1 | [ ] |
+| 2.1 | セレクタ定義追加 | gemini.ts | 1.2 | [ ] |
+| 2.2 | extractInlineCitations() | gemini.ts | 2.1 | [ ] |
+| 2.3 | extractSourceList() | gemini.ts | 2.1 | [ ] |
+| 2.4 | extractDeepResearchLinks() | gemini.ts | 2.2, 2.3 | [ ] |
+| 2.5 | extractDeepResearch() 更新 | gemini.ts | 2.4 | [ ] |
+| 3.1 | セキュリティ関数追加 | markdown.ts | 1.2 | [ ] |
+| 3.2 | HTML 変換関数追加 | markdown.ts | 3.1 | [ ] |
+| 3.3 | 出力生成関数追加 | markdown.ts | 3.1 | [ ] |
+| 3.4 | convertDeepResearchContent() | markdown.ts | 3.2, 3.3 | [ ] |
+| 3.5 | conversationToNote() 更新 | markdown.ts | 3.4 | [ ] |
+| 4.1 | dom-helpers.ts 拡張 | dom-helpers.ts | 2.5 | [ ] |
+| 4.2 | gemini.test.ts 拡張 | gemini.test.ts | 4.1 | [ ] |
+| 4.3 | markdown.test.ts 拡張 | markdown.test.ts | 3.5 | [ ] |
+
+---
+
+## 品質ゲート
+
+各フェーズ完了時に以下を確認：
+
+```bash
+npm run lint      # ESLint エラーなし
+npm run build     # TypeScript コンパイル成功
+npm run test      # 全テストパス
+```
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|----------|
+| 1.0 | 2025-01-11 | 初版作成 |
+
+---
+
+*作成日: 2025-01-11*
+*設計書: deep-research-links-extraction.md v1.1*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ export default [
         setTimeout: 'readonly',
         fetch: 'readonly',
         HTMLElement: 'readonly',
+        HTMLAnchorElement: 'readonly',
         HTMLButtonElement: 'readonly',
         HTMLInputElement: 'readonly',
         HTMLSelectElement: 'readonly',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian",
   "type": "module",
   "scripts": {

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -10,21 +10,45 @@ import DOMPurify from 'dompurify';
  *
  * 設計方針:
  * - USE_PROFILES: { html: true } でデフォルトの安全なHTML許可リストを使用
- * - ALLOWED_ATTRで必要な属性のみ追加許可
+ * - ADD_ATTRで data-turn-source-index を追加許可（USE_PROFILESと併用可能）
+ * - FORBID_ATTRでその他のdata-*属性を禁止
  * - FORBID_TAGSでstyleを追加禁止（CSSインジェクション防止）
  *
  * 注意: USE_PROFILESとALLOWED_TAGSは併用不可（公式ドキュメント）
+ * 注意: USE_PROFILESとALLOWED_ATTRも併用すると上書きされる
+ *       → ADD_ATTRを使用して既存の許可リストに追加する
  *
  * USE_PROFILES: { html: true } が自動除去するもの:
  * - <script>, <style>, <iframe>, <object>, <embed> 等の危険なタグ
  * - 全てのイベントハンドラ属性（onclick, onerror, onload等約70種）
  * - javascript:, vbscript:, data: 等の危険なURIスキーム
+ *
+ * data-turn-source-index について:
+ * - Deep Research のインライン引用で使用される属性
+ * - この属性はソースリストへのインデックス（1ベース）を保持
+ * - convertInlineCitationsToLinks() で使用するため許可が必要
  */
 export function sanitizeHtml(html: string): string {
-  return DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true }, // デフォルトの安全なHTML（SVG/MathML除外）
-    ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class'], // 必要な属性のみ
-    FORBID_TAGS: ['style'], // CSSインジェクション防止
-    ALLOW_DATA_ATTR: false, // data-*属性を禁止
+  // uponSanitizeAttribute hook to selectively allow data-turn-source-index
+  // while blocking other data-* attributes
+  DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+    // Allow data-turn-source-index attribute
+    if (data.attrName === 'data-turn-source-index') {
+      data.forceKeepAttr = true;
+    }
+    // Block other data-* attributes
+    else if (data.attrName.startsWith('data-')) {
+      data.keepAttr = false;
+    }
   });
+
+  const result = DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true }, // デフォルトの安全なHTML（SVG/MathML除外）
+    FORBID_TAGS: ['style'], // CSSインジェクション防止
+  });
+
+  // Remove the hook after use to avoid affecting other sanitization calls
+  DOMPurify.removeHook('uponSanitizeAttribute');
+
+  return result;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,9 +23,40 @@ export interface ConversationData {
   url: string;
   source: 'gemini' | 'claude' | 'perplexity';
   type?: 'conversation' | 'deep-research';
+  /** Deep Research link information (optional) */
+  links?: DeepResearchLinks;
   messages: ConversationMessage[];
   extractedAt: Date;
   metadata: ConversationMetadata;
+}
+
+/**
+ * Deep Research source information
+ *
+ * Design: Sources are stored in DOM order (0-based array).
+ * Mapping to data-turn-source-index (1-based):
+ *   data-turn-source-index="N" → sources[N-1]
+ */
+export interface DeepResearchSource {
+  /** 0-based array index (DOM order) */
+  index: number;
+  /** Source URL */
+  url: string;
+  /** Source title */
+  title: string;
+  /** Domain name */
+  domain: string;
+}
+
+/**
+ * Deep Research links extraction result
+ *
+ * Design: Only sources array is stored. Inline citations are processed
+ * during HTML→Markdown conversion using data-turn-source-index attribute.
+ */
+export interface DeepResearchLinks {
+  /** Source list (DOM order, 0-based index) */
+  sources: DeepResearchSource[];
 }
 
 /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "88",

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -280,6 +280,79 @@ export function createDeepResearchDOM(title: string, content: string): string {
   `;
 }
 
+
+/**
+ * Creates Deep Research DOM with inline citations and source list
+ */
+export function createDeepResearchDOMWithLinks(
+  title: string,
+  contentWithCitations: string,
+  sources: Array<{ url: string; title: string; domain: string }>
+): string {
+  // Generate source list HTML
+  const sourceListHtml = sources
+    .map(
+      (source, i) => `
+      <a data-test-id="browse-web-item-link"
+         href="${source.url}"
+         target="_blank" rel="noopener">
+        <span data-test-id="title" class="sub-title">${source.title}</span>
+        <span data-test-id="domain-name" class="display-name">${source.domain}</span>
+      </a>
+    `
+    )
+    .join('\n');
+
+  return `
+    <deep-research-immersive-panel class="ng-star-inserted">
+      <toolbar>
+        <div class="toolbar has-title">
+          <div class="left-panel">
+            <h2 class="title-text gds-title-s">${title}</h2>
+          </div>
+        </div>
+      </toolbar>
+      <div class="container">
+        <response-container>
+          <structured-content-container data-test-id="message-content">
+            <message-content id="extended-response-message-content">
+              <div id="extended-response-markdown-content"
+                   class="markdown markdown-main-panel">
+                ${contentWithCitations}
+              </div>
+            </message-content>
+          </structured-content-container>
+        </response-container>
+      </div>
+    </deep-research-immersive-panel>
+    <deep-research-source-lists>
+      <collapsible-button data-test-id="used-sources-button">
+        <span class="gds-title-m">レポートに使用されているソース</span>
+      </collapsible-button>
+      <div id="used-sources-list">
+        ${sourceListHtml}
+      </div>
+    </deep-research-source-lists>
+  `;
+}
+
+/**
+ * Create inline citation HTML element
+ */
+/**
+ * Create inline citation element
+ * 
+ * Note: data-turn-source-index is 1-based (verified 2025-01-12)
+ * Mapping: sources[N] -> data-turn-source-index = N + 1
+ * 
+ * @param arrayIndex 0-based index in sources array
+ * @returns HTML string with 1-based data-turn-source-index
+ */
+export function createInlineCitation(arrayIndex: number): string {
+  const turnSourceIndex = arrayIndex + 1; // Convert to 1-based
+  return `<source-footnote class="ng-star-inserted"><sup class="superscript" data-turn-source-index="${turnSourceIndex}"></sup></source-footnote>`;
+}
+
 /**
  * Create パネルのみ（コンテンツなし）の DOM
  */

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -69,10 +69,24 @@ describe('sanitizeHtml', () => {
   });
 
   describe('enforces attribute restrictions', () => {
-    it('removes data-* attributes', () => {
+    it('removes general data-* attributes', () => {
       expect(sanitizeHtml('<div data-id="secret">Content</div>')).toBe(
         '<div>Content</div>'
       );
+    });
+
+    it('keeps data-turn-source-index attribute (Deep Research citations)', () => {
+      // This attribute is explicitly allowed for inline citation processing
+      expect(
+        sanitizeHtml('<sup data-turn-source-index="5">1</sup>')
+      ).toBe('<sup data-turn-source-index="5">1</sup>');
+    });
+
+    it('keeps data-turn-source-index in source-footnote structure', () => {
+      const html =
+        '<source-footnote><sup data-turn-source-index="1">1</sup></source-footnote>';
+      const result = sanitizeHtml(html);
+      expect(result).toContain('data-turn-source-index="1"');
     });
 
     it('keeps id attributes (allowed by DOMPurify profile)', () => {


### PR DESCRIPTION
## Summary

- Extract sources from Deep Research reports (`deep-research-source-lists` container)
- Convert inline citations (`<sup data-turn-source-index>`) to `[Title](URL)` inline links
- Use `<a>` tags during HTML processing to let Turndown handle Markdown conversion, avoiding double-escaping issues (`\[...\]` → `[...]`)
- Add DOMPurify hook to preserve `data-turn-source-index` attribute while blocking other data-* attributes
- Support 1-based index mapping (`data-turn-source-index` → sources array)

### Security

- Sanitize URLs (block `javascript:`, `data:`, `vbscript:` schemes)
- HTML-escape titles before insertion into anchor tags
- DOMPurify sanitization preserves citation attributes only

### Output Format

```markdown
Text[Source Title](https://example.com/article) continues here.
```

## Test plan

- [x] All 366 tests passing
- [x] Build succeeds
- [x] Lint passes (warnings only)
- [ ] Manual test: Extract Deep Research report with inline citations
- [ ] Verify Markdown output has clean links without escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)