### PR TITLE
🔒 Fix CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Principle of least privilege (CodeQL: actions/missing-workflow-permissions)
 
     steps:
       - name: Checkout repository

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -118,7 +118,8 @@ async function initialize(): Promise<void> {
   console.info('[G2O] Content script initializing on:', window.location.href);
 
   // Only run on Gemini conversation pages
-  if (!window.location.hostname.includes('gemini.google.com')) {
+  // Use strict comparison to prevent substring attacks (CodeQL: js/incomplete-url-substring-sanitization)
+  if (window.location.hostname !== 'gemini.google.com') {
     console.info('[G2O] Not a Gemini page, skipping initialization');
     return;
   }

--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -165,15 +165,24 @@ describe('content/index utilities', () => {
   });
 
   describe('initialize behavior', () => {
-    it('checks for gemini.google.com hostname', () => {
-      // Simulate non-Gemini host check
-      const isGeminiPage = 'other.com'.includes('gemini.google.com');
+    it('rejects non-Gemini hostnames', () => {
+      // Use strict comparison to prevent substring attacks
+      const hostname = 'other.com';
+      const isGeminiPage = hostname === 'gemini.google.com';
       expect(isGeminiPage).toBe(false);
     });
 
-    it('recognizes gemini.google.com hostname', () => {
-      const isGeminiPage = 'gemini.google.com'.includes('gemini.google.com');
+    it('accepts gemini.google.com hostname', () => {
+      const hostname = 'gemini.google.com';
+      const isGeminiPage = hostname === 'gemini.google.com';
       expect(isGeminiPage).toBe(true);
+    });
+
+    it('rejects malicious subdomains containing gemini.google.com', () => {
+      // CodeQL: js/incomplete-url-substring-sanitization - ensure substring attacks are blocked
+      const hostname = 'evil-gemini.google.com.attacker.com';
+      const isGeminiPage = hostname === 'gemini.google.com';
+      expect(isGeminiPage).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix 4 GitHub Code Scanning alerts (3 High, 1 Medium)
- Replace `includes()` with strict `===` comparison for hostname validation
- Add explicit workflow permissions following least privilege principle

## Changes

### 1. `src/content/index.ts`

Change hostname validation from substring matching to strict comparison:

```typescript
// Before
if (!window.location.hostname.includes('gemini.google.com'))

// After  
if (window.location.hostname !== 'gemini.google.com')
```

### 2. `test/content/index.test.ts`

- Update existing tests to match new strict comparison behavior
- Add new test case for malicious subdomain attack prevention

### 3. `.github/workflows/ci.yml`

Add explicit permissions declaration:

```yaml
permissions:
  contents: read
```

## Security Context

While manifest.json already restricts the content script to `gemini.google.com`, these changes follow defensive coding principles and resolve the CodeQL static analysis alerts.

## Test plan

- [x] All 358 tests pass
- [x] Build succeeds
- [x] Lint passes (warnings only - existing console statements)
- [ ] GitHub Code Scanning re-runs after merge → alerts resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)