### PR TITLE
✨ feat: add ChatGPT conversation extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 # Build output
 dist/
 gemini2obsidian-*.zip
+obsidian-ai-exporter-*.zip
 
 # IDE
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,22 @@ source: gemini
 
 - **Gemini** (`gemini.google.com`): Conversations and Deep Research reports
 - **Claude** (`claude.ai`): Conversations, Extended Thinking, and Artifacts with inline citations
+- **ChatGPT** (`chatgpt.com`): Conversations (including custom GPTs via `/g/` URLs)
+
+## Adding New Platforms
+
+When adding a new platform extractor:
+
+1. Add platform to union types in `src/lib/types.ts` (`source`, `platform`)
+2. Add platform to `BaseExtractor` in `src/content/extractors/base.ts`
+3. Create new extractor class extending `BaseExtractor`
+4. Add routing in `src/content/index.ts` (`getExtractor()`)
+5. Update `waitForConversationContainer()` selectors if needed
+6. **Add origin to `ALLOWED_ORIGINS` in `src/background/index.ts`** ← CRITICAL
+7. Update `src/manifest.json`:
+   - `host_permissions`
+   - `content_scripts.matches`
+8. Add DOM helpers and tests
 
 ## Future Platforms
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Google Gemini と Claude AI の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
+Google Gemini、Claude AI、ChatGPT の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
 
 [English version](README.md)
 
@@ -9,7 +9,7 @@ Google Gemini と Claude AI の会話を Obsidian に保存する Chrome 拡張�
 
 ## 機能
 
-- **マルチプラットフォーム対応**: Google Gemini と Claude AI の両方からエクスポート
+- **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT からエクスポート
 - **ワンクリック保存**: 対応 AI ページに表示される「Sync」ボタンで即座に保存
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
 - **Deep Research 対応**: Gemini Deep Research と Claude Extended Thinking レポートを保存
@@ -81,6 +81,12 @@ Google Gemini と Claude AI の会話を Obsidian に保存する Chrome 拡張�
 ### Claude
 
 1. [claude.ai](https://claude.ai) で会話を開く
+2. 右下に表示される紫色の「Sync」ボタンをクリック
+3. Gemini と同じ出力オプションで会話がエクスポートされます
+
+### ChatGPT
+
+1. [chatgpt.com](https://chatgpt.com) で会話を開く
 2. 右下に表示される紫色の「Sync」ボタンをクリック
 3. Gemini と同じ出力オプションで会話がエクスポートされます
 
@@ -179,7 +185,7 @@ npm run test:coverage
 ## アーキテクチャ
 
 ```
-Content Script (gemini.google.com, claude.ai)
+Content Script (gemini.google.com, claude.ai, chatgpt.com)
     ↓ 会話 / Deep Research / Artifacts を抽出
 Background Service Worker
     ↓ Obsidian に送信
@@ -193,6 +199,7 @@ Obsidian Local REST API (127.0.0.1:27123)
 | `src/content/` | DOM 抽出と UI 用のコンテンツスクリプト |
 | `src/content/extractors/gemini.ts` | Gemini 会話 & Deep Research 抽出 |
 | `src/content/extractors/claude.ts` | Claude 会話 & Artifact 抽出 |
+| `src/content/extractors/chatgpt.ts` | ChatGPT 会話抽出 |
 | `src/background/` | API 通信用のサービスワーカー |
 | `src/popup/` | 設定 UI |
 | `src/lib/` | 共有ユーティリティと型定義 |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Chrome Extension that exports AI conversations from Google Gemini and Claude AI to Obsidian via the Local REST API.
+Chrome Extension that exports AI conversations from Google Gemini, Claude AI, and ChatGPT to Obsidian via the Local REST API.
 
 [日本語版はこちら](README.ja.md)
 
@@ -9,7 +9,7 @@ Chrome Extension that exports AI conversations from Google Gemini and Claude AI 
 
 ## Features
 
-- **Multi-platform support**: Export from both Google Gemini and Claude AI
+- **Multi-platform support**: Export from Google Gemini, Claude AI, and ChatGPT
 - **One-click export**: Floating "Sync" button on supported AI pages
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
 - **Deep Research support**: Export Gemini Deep Research and Claude Extended Thinking reports
@@ -81,6 +81,12 @@ Chrome Extension that exports AI conversations from Google Gemini and Claude AI 
 ### Claude
 
 1. Open a conversation on [claude.ai](https://claude.ai)
+2. Click the purple "Sync" button in the bottom-right corner
+3. The conversation will be exported with the same output options as Gemini
+
+### ChatGPT
+
+1. Open a conversation on [chatgpt.com](https://chatgpt.com)
 2. Click the purple "Sync" button in the bottom-right corner
 3. The conversation will be exported with the same output options as Gemini
 
@@ -179,7 +185,7 @@ npm run test:coverage
 ## Architecture
 
 ```
-Content Script (gemini.google.com, claude.ai)
+Content Script (gemini.google.com, claude.ai, chatgpt.com)
     ↓ extracts conversation / Deep Research / Artifacts
 Background Service Worker
     ↓ sends to Obsidian
@@ -193,6 +199,7 @@ Obsidian Local REST API (127.0.0.1:27123)
 | `src/content/` | Content script for DOM extraction and UI |
 | `src/content/extractors/gemini.ts` | Gemini conversation & Deep Research extractor |
 | `src/content/extractors/claude.ts` | Claude conversation & Artifact extractor |
+| `src/content/extractors/chatgpt.ts` | ChatGPT conversation extractor |
 | `src/background/` | Service worker for API communication |
 | `src/popup/` | Settings UI |
 | `src/lib/` | Shared utilities and types |

--- a/docs/design/DES-003-chatgpt-extractor.md
+++ b/docs/design/DES-003-chatgpt-extractor.md
@@ -1,0 +1,731 @@
+# DES-003: ChatGPT Extractor 設計書
+
+| 項目 | 内容 |
+|------|------|
+| **文書ID** | DES-003 |
+| **バージョン** | 1.1.0 |
+| **作成日** | 2026-01-20 |
+| **更新日** | 2026-01-20 |
+| **ステータス** | Draft (レビュー反映) |
+| **関連計画** | なし |
+
+---
+
+## 1. 概要
+
+### 1.1 目的
+
+ChatGPT (chatgpt.com) の会話データを抽出し、Obsidian にエクスポートする機能を追加する。通常チャットのみ対応（Deep Research は通常チャットとして扱う）。
+
+### 1.2 スコープ
+
+| 含む | 含まない |
+|------|---------|
+| ChatGPT 通常チャット抽出 | ChatGPT API 直接連携 |
+| インライン引用の Markdown 変換 | Deep Research 専用モード（通常会話として扱う） |
+| 既存 Gemini/Claude パターンとの統合 | Custom GPT 特殊対応 |
+| - | 画像/ファイル添付の抽出 |
+
+**注**: Sources ボタン内の引用は、インライン引用と同一の DOM 構造（`span[data-testid="webpage-citation-pill"]`）で表現されるため、インライン引用抽出で自動的にカバーされる。
+
+### 1.3 優先順位
+
+1. **P0**: 通常チャット抽出（User/Assistant メッセージ）
+2. **P1**: インライン引用のリンク変換
+3. **P2**: モデル名メタデータ抽出（オプション）
+
+---
+
+## 2. 機能要件
+
+### 2.1 FR-001: プラットフォーム検出
+
+| ID | 要件 |
+|----|------|
+| FR-001-1 | `hostname === 'chatgpt.com'` で ChatGPT ページを識別する（厳密比較必須） |
+| FR-001-2 | URL パターンから会話 ID を抽出する（形式: `/c/{uuid}`） |
+
+### 2.2 FR-002: 通常チャット抽出
+
+| ID | 要件 |
+|----|------|
+| FR-002-1 | User メッセージを `[data-message-author-role="user"]` から抽出する |
+| FR-002-2 | Assistant メッセージを `[data-message-author-role="assistant"]` から抽出する |
+| FR-002-3 | Markdown コンテンツは `.markdown.prose` から取得する |
+| FR-002-4 | メッセージは DOM 順序で正しくインターリーブする |
+| FR-002-5 | `article[data-turn-id]` を会話ターンの単位として使用する |
+
+### 2.3 FR-003: 引用抽出
+
+| ID | 要件 |
+|----|------|
+| FR-003-1 | インライン引用を `span[data-testid="webpage-citation-pill"] a[href]` から抽出する |
+| FR-003-2 | 引用リンクをそのまま Markdown リンクに変換する |
+| FR-003-3 | 引用元 URL を保持する |
+
+### 2.4 FR-004: 出力形式
+
+| ID | 要件 |
+|----|------|
+| FR-004-1 | Gemini/Claude と同一の Obsidian callout 形式で出力する |
+| FR-004-2 | `source: chatgpt` を YAML frontmatter に設定する |
+| FR-004-3 | アシスタント callout のラベルは「ChatGPT」とする |
+
+---
+
+## 3. 非機能要件
+
+### 3.1 NFR-001: セキュリティ
+
+| ID | 要件 | 根拠 |
+|----|------|------|
+| NFR-001-1 | Hostname は厳密比較 (`===`) を使用する | CodeQL js/incomplete-url-substring-sanitization 対策 |
+| NFR-001-2 | HTML コンテンツは DOMPurify でサニタイズする | XSS 防止 |
+| NFR-001-3 | 悪意のあるサブドメイン攻撃を防止する | `evil-chatgpt.com.attacker.com` を拒否 |
+
+### 3.2 NFR-002: 互換性
+
+| ID | 要件 |
+|----|------|
+| NFR-002-1 | 既存の BaseExtractor を継承する |
+| NFR-002-2 | IConversationExtractor インターフェースを完全実装する |
+| NFR-002-3 | 既存の Markdown 変換パイプラインを再利用する |
+
+### 3.3 NFR-003: テスタビリティ
+
+| ID | 要件 |
+|----|------|
+| NFR-003-1 | 85% 以上のステートメントカバレッジを維持する |
+| NFR-003-2 | 全フォールバックセレクターをテストする |
+| NFR-003-3 | DOM ヘルパーで再現可能なテストフィクスチャを提供する |
+
+---
+
+## 4. システムアーキテクチャ
+
+### 4.1 コンポーネント図
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Chrome Extension                         │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌──────────────┐     ┌──────────────────────────────────────┐ │
+│  │Content Script│     │           Extractors                  │ │
+│  │   index.ts   │────▶│  ┌────────────────┐ ┌──────────────┐ │ │
+│  └──────────────┘     │  │GeminiExtractor │ │ClaudeExtractor│ │ │
+│         │             │  └────────────────┘ └──────────────┘ │ │
+│         │             │  ┌────────────────┐                   │ │
+│         │             │  │ChatGPTExtractor│ ◀── NEW          │ │
+│         │             │  └───────┬────────┘                   │ │
+│         │             │          │                             │ │
+│         │             │          ▼                             │ │
+│         │             │  ┌──────────────────────────────────┐ │ │
+│         │             │  │          BaseExtractor           │ │ │
+│         │             │  └──────────────────────────────────┘ │ │
+│         │             └──────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 ルーティングフロー
+
+```
+URL アクセス
+    │
+    ▼
+┌─────────────────────────────────────┐
+│   Content Script (index.ts)         │
+│   hostname チェック (=== 厳密比較)   │
+└─────────────────────────────────────┘
+    │
+    ├── gemini.google.com ──▶ GeminiExtractor
+    │
+    ├── claude.ai ──▶ ClaudeExtractor
+    │
+    └── chatgpt.com ──▶ ChatGPTExtractor ◀── NEW
+                            │
+                            ▼
+                        extractMessages()
+```
+
+---
+
+## 5. 詳細設計
+
+### 5.1 index.ts の waitForConversationContainer() 変更
+
+#### 5.1.1 現在のセレクター
+
+```typescript
+// src/content/index.ts:63
+const existing = document.querySelector('.conversation-container, [class*="conversation"]');
+```
+
+#### 5.1.2 変更後のセレクター
+
+```typescript
+// ChatGPT 用に article[data-turn-id] を追加
+const existing = document.querySelector(
+  '.conversation-container, [class*="conversation"], article[data-turn-id]'
+);
+```
+
+#### 5.1.3 変更理由
+
+| 変更箇所 | 理由 |
+|----------|------|
+| `article[data-turn-id]` 追加 | ChatGPT は `.conversation-container` や `[class*="conversation"]` を使用しないため、ChatGPT の会話コンテナを検出できない |
+
+---
+
+### 5.2 manifest.json 変更
+
+#### 5.2.1 現在の設定
+
+```json
+{
+  "host_permissions": [
+    "https://gemini.google.com/*",
+    "https://claude.ai/*",
+    "http://127.0.0.1:27123/*"
+  ],
+  "content_scripts": [{
+    "matches": [
+      "https://gemini.google.com/*",
+      "https://claude.ai/*"
+    ],
+    "js": ["src/content/index.ts"],
+    "run_at": "document_idle"
+  }]
+}
+```
+
+#### 5.2.2 変更後の設定
+
+```json
+{
+  "host_permissions": [
+    "https://gemini.google.com/*",
+    "https://claude.ai/*",
+    "https://chatgpt.com/*",
+    "http://127.0.0.1:27123/*"
+  ],
+  "content_scripts": [{
+    "matches": [
+      "https://gemini.google.com/*",
+      "https://claude.ai/*",
+      "https://chatgpt.com/*"
+    ],
+    "js": ["src/content/index.ts"],
+    "run_at": "document_idle"
+  }]
+}
+```
+
+---
+
+### 5.3 セレクター定義
+
+#### 5.3.1 セレクター安定性マトリックス
+
+| セレクター | 安定性 | リスク | フォールバック優先度 | 備考 |
+|-----------|--------|--------|---------------------|------|
+| `article[data-turn-id]` | HIGH | LOW | 1 | data 属性ベース、安定 |
+| `[data-message-author-role]` | HIGH | LOW | 1 | data 属性ベース、安定 |
+| `[data-message-id]` | HIGH | LOW | 1 | data 属性ベース、安定 |
+| `.markdown.prose` | HIGH | LOW | 1 | セマンティッククラス |
+| `.whitespace-pre-wrap` | MEDIUM | MEDIUM | 2 | Tailwind クラス |
+| `[data-testid="webpage-citation-pill"]` | LOW | HIGH | 3 | テスト属性、本番で削除される可能性 |
+| `article[data-turn="user"]` | HIGH | LOW | 1 | data 属性ベース |
+
+#### 5.3.2 通常チャット用セレクター (SELECTORS)
+
+```typescript
+const SELECTORS = {
+  // 会話ターン（各 Q&A ペア）
+  conversationTurn: [
+    'article[data-turn-id]',                    // data 属性 (HIGH)
+    'article[data-testid^="conversation-turn"]', // テスト属性 (LOW)
+  ],
+
+  // User メッセージ
+  userMessage: [
+    '[data-message-author-role="user"] .whitespace-pre-wrap',  // 構造 (HIGH)
+    'article[data-turn="user"] .whitespace-pre-wrap',           // 構造 (HIGH)
+    '.user-message-bubble-color .whitespace-pre-wrap',          // スタイル (MEDIUM)
+  ],
+
+  // Assistant メッセージ
+  assistantResponse: [
+    '[data-message-author-role="assistant"] .markdown.prose',   // 構造 (HIGH)
+    'article[data-turn="assistant"] .markdown.prose',           // 構造 (HIGH)
+    '.markdown.prose.dark\\:prose-invert',                      // スタイル (MEDIUM)
+  ],
+
+  // Markdown コンテンツ
+  markdownContent: [
+    '.markdown.prose',                          // セマンティック (HIGH)
+    '.markdown-new-styling',                    // スタイル (MEDIUM)
+  ],
+
+  // メッセージ ID 属性
+  messageId: [
+    '[data-message-id]',                        // data 属性 (HIGH)
+    '[data-turn-id]',                           // data 属性 (HIGH)
+  ],
+};
+```
+
+#### 5.3.3 引用用セレクター (CITATION_SELECTORS)
+
+```typescript
+const CITATION_SELECTORS = {
+  // インライン引用
+  inlineCitation: [
+    'span[data-testid="webpage-citation-pill"] a[href^="http"]',  // テスト属性 (LOW)
+    'a[target="_blank"][rel="noopener"][href^="http"]',           // 属性 (MEDIUM)
+  ],
+};
+```
+
+#### 5.3.4 メタデータ用セレクター（オプション）
+
+```typescript
+const METADATA_SELECTORS = {
+  // モデル名（P2: オプション機能）
+  modelSlug: [
+    '[data-message-model-slug]',  // data 属性 (HIGH)
+  ],
+};
+```
+
+**注**: `data-message-model-slug` 属性（例: `"gpt-5-2"`）からモデル名を取得可能。P2 優先度のため初期実装では省略可。将来的に frontmatter の `model` フィールドとして追加を検討。
+
+---
+
+### 5.4 クラス設計
+
+#### 5.4.1 ChatGPTExtractor クラス
+
+```typescript
+export class ChatGPTExtractor extends BaseExtractor {
+  readonly platform = 'chatgpt' as const;
+
+  // ========== プラットフォーム検出 ==========
+
+  /**
+   * ChatGPT ページかどうかを判定
+   * 重要: 厳密比較 (===) を使用（CodeQL 対策）
+   */
+  canExtract(): boolean;
+
+  // ========== ID・タイトル取得 ==========
+
+  /**
+   * URL から会話 ID を抽出
+   * 形式: /c/{uuid} または /g/{uuid}
+   * @returns UUID または null
+   */
+  getConversationId(): string | null;
+
+  /**
+   * 会話タイトルを取得
+   * 優先順位: 最初の User メッセージ > デフォルト
+   */
+  getTitle(): string;
+
+  // ========== メッセージ抽出 ==========
+
+  /**
+   * 全メッセージを抽出
+   * User/Assistant を DOM 順序でインターリーブ
+   */
+  extractMessages(): ConversationMessage[];
+
+  /**
+   * User メッセージコンテンツを抽出
+   */
+  private extractUserContent(element: Element): string;
+
+  /**
+   * Assistant レスポンスコンテンツを抽出（HTML）
+   */
+  private extractAssistantContent(element: Element): string;
+
+  // ========== メインエントリポイント ==========
+
+  /**
+   * 抽出メイン処理
+   */
+  async extract(): Promise<ExtractionResult>;
+}
+```
+
+---
+
+### 5.5 型定義の変更
+
+#### 5.5.1 src/lib/types.ts の変更
+
+```typescript
+// ConversationData.source に 'chatgpt' を追加
+export interface ConversationData {
+  // ...
+  source: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';  // chatgpt 追加
+  // ...
+}
+
+// IConversationExtractor.platform に 'chatgpt' を追加
+export interface IConversationExtractor {
+  readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';  // chatgpt 追加
+  // ...
+}
+```
+
+#### 5.5.2 src/content/extractors/base.ts の変更
+
+```typescript
+export abstract class BaseExtractor implements IConversationExtractor {
+  abstract readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';  // chatgpt 追加
+  // ...
+}
+```
+
+---
+
+### 5.6 メソッド仕様
+
+#### 5.6.1 canExtract()
+
+| 項目 | 内容 |
+|------|------|
+| **目的** | ChatGPT ページかどうかを判定 |
+| **入力** | なし |
+| **出力** | `boolean` |
+| **ロジック** | `window.location.hostname === 'chatgpt.com'` (厳密比較必須) |
+| **セキュリティ** | サブドメイン攻撃防止のため `===` を使用 |
+
+#### 5.6.2 getConversationId()
+
+| 項目 | 内容 |
+|------|------|
+| **目的** | URL から会話 ID を抽出 |
+| **入力** | なし |
+| **出力** | `string \| null` |
+| **ロジック** | `/\/c\/([a-f0-9-]+)/i` または `/\/g\/([a-f0-9-]+)/i` でマッチ |
+| **URL例** | `https://chatgpt.com/c/6789abcd-ef01-2345-6789-abcdef012345` |
+
+#### 5.6.3 getTitle()
+
+| 項目 | 内容 |
+|------|------|
+| **目的** | 会話タイトルを取得 |
+| **入力** | なし |
+| **出力** | `string` |
+| **ロジック** | 1. 最初の User メッセージを検索<br>2. 見つかった場合、先頭 100 文字を返却（`MAX_TITLE_LENGTH`）<br>3. 見つからない場合、デフォルト `'Untitled ChatGPT Conversation'` を返却 |
+| **トランケーション** | `substring(0, MAX_TITLE_LENGTH)` で 100 文字に制限 |
+
+#### 5.6.4 extractMessages()
+
+| 項目 | 内容 |
+|------|------|
+| **目的** | 全メッセージを DOM 順序で抽出 |
+| **入力** | なし |
+| **出力** | `ConversationMessage[]` |
+| **ロジック** | 1. `article[data-turn-id]` で各ターンを取得<br>2. `data-turn` 属性で user/assistant を判別<br>3. DOM 順序でソート |
+
+---
+
+### 5.7 エラーハンドリング設計
+
+#### 5.7.1 エラーハンドリングマトリックス
+
+| 状況 | 期待動作 | 戻り値 |
+|------|----------|--------|
+| DOM 要素なし | 警告ログ出力、空配列返却 | `[]` |
+| URL パースエラー | null 返却、フォールバック ID 生成 | `chatgpt-${Date.now()}` |
+| 空の会話 | エラー結果返却 | `{ success: false, error: 'No messages found' }` |
+| サニタイズエラー | 空文字列返却、警告ログ | `''` |
+| セレクター全失敗 | エラー結果返却 | `{ success: false, error: 'Selectors may have changed' }` |
+
+---
+
+### 5.8 DOM 構造マッピング
+
+#### 5.8.1 通常チャット構造
+
+```html
+<div class="flex flex-col text-sm pb-25">
+  <!-- User ターン -->
+  <article
+    data-turn-id="6d1f7499-baef-46c5-ae51-892d9c1e2d03"
+    data-testid="conversation-turn-1"
+    data-turn="user"
+  >
+    <div data-message-author-role="user"
+         data-message-id="6d1f7499-baef-46c5-ae51-892d9c1e2d03">
+      <div class="whitespace-pre-wrap">
+        ユーザーの質問テキスト
+      </div>
+    </div>
+  </article>
+
+  <!-- Assistant ターン -->
+  <article
+    data-turn-id="b6bda243-ac61-4156-82d2-d6df42953db4"
+    data-testid="conversation-turn-2"
+    data-turn="assistant"
+  >
+    <div data-message-author-role="assistant"
+         data-message-id="56d7ef64-7cc6-4736-9711-b8b6d6789351"
+         data-message-model-slug="gpt-5-2">
+      <div class="markdown prose dark:prose-invert w-full break-words light markdown-new-styling">
+        <p>ChatGPT の回答...</p>
+        <!-- インライン引用 -->
+        <span data-testid="webpage-citation-pill">
+          <a href="https://example.com?utm_source=chatgpt.com"
+             target="_blank" rel="noopener">
+            example.com
+          </a>
+        </span>
+      </div>
+    </div>
+  </article>
+</div>
+```
+
+#### 5.8.2 インライン引用構造
+
+```html
+<span class="" data-state="closed">
+  <span class="ms-1 inline-flex max-w-full items-center select-none relative top-[-0.094rem]"
+        data-testid="webpage-citation-pill"
+        style="width: 107px;">
+    <a href="https://example.com?utm_source=chatgpt.com"
+       target="_blank"
+       rel="noopener"
+       alt="https://example.com?utm_source=chatgpt.com"
+       class="flex h-4.5 overflow-hidden rounded-xl px-2 text-[9px] font-medium">
+      <span class="max-w-[15ch] grow truncate overflow-hidden text-center">
+        example.com
+      </span>
+    </a>
+  </span>
+</span>
+```
+
+---
+
+## 6. テスト戦略
+
+### 6.1 テストカテゴリ
+
+| カテゴリ | テスト内容 | ファイル |
+|----------|-----------|----------|
+| プラットフォーム検出 | hostname 判定、URL パターン | `chatgpt.test.ts` |
+| セキュリティ | hostname 攻撃パターン、XSS 防止 | `chatgpt.test.ts` |
+| ID 抽出 | UUID 抽出、フォールバック | `chatgpt.test.ts` |
+| タイトル抽出 | User メッセージ、デフォルト | `chatgpt.test.ts` |
+| メッセージ抽出 | User/Assistant、インターリーブ | `chatgpt.test.ts` |
+| 引用抽出 | インライン引用の抽出 | `chatgpt.test.ts` |
+| フォールバック | 全セレクターのフォールバック | `chatgpt.test.ts` |
+| エラーハンドリング | 各種エラー状況 | `chatgpt.test.ts` |
+
+### 6.2 DOM ヘルパー追加
+
+```typescript
+// test/fixtures/dom-helpers.ts に追加
+
+/**
+ * ChatGPT 会話 DOM を生成
+ */
+export function createChatGPTConversationDOM(
+  messages: Array<{ role: 'user' | 'assistant'; content: string; id?: string }>
+): string;
+
+/**
+ * ChatGPT URL をモック
+ */
+export function setChatGPTLocation(conversationId: string): void;
+
+/**
+ * ChatGPT インライン引用を生成
+ */
+export function createChatGPTInlineCitation(
+  url: string,
+  displayText: string
+): string;
+```
+
+### 6.3 テストケース一覧 (32 テスト)
+
+#### 6.3.1 プラットフォーム検出 (3 テスト)
+
+- [ ] `canExtract()` returns true for chatgpt.com
+- [ ] `canExtract()` returns false for other hosts
+- [ ] `canExtract()` returns false for chat.openai.com (旧ドメイン)
+
+#### 6.3.2 セキュリティテスト (4 テスト)
+
+- [ ] rejects malicious subdomains containing chatgpt.com (`evil-chatgpt.com.attacker.com`)
+- [ ] rejects chatgpt.com as subdomain (`chatgpt.com.evil.com`)
+- [ ] sanitizes XSS script tags in assistant content
+- [ ] sanitizes XSS onerror attributes in content
+
+#### 6.3.3 ID 抽出 (4 テスト)
+
+- [ ] extracts UUID from `/c/{uuid}` URL
+- [ ] extracts UUID from `/g/{uuid}` URL (GPT mode)
+- [ ] returns null for non-chat URLs
+- [ ] generates fallback ID when URL parsing fails
+
+#### 6.3.4 タイトル抽出 (3 テスト)
+
+- [ ] extracts title from first user message
+- [ ] truncates long titles (>100 chars)
+- [ ] returns default title when no content
+
+#### 6.3.5 メッセージ抽出 (6 テスト)
+
+- [ ] extracts user and assistant messages
+- [ ] handles multiple conversation turns
+- [ ] maintains correct message order via data-turn-id
+- [ ] handles empty conversations
+- [ ] extracts HTML content for assistant messages
+- [ ] uses data-message-author-role for role identification
+
+#### 6.3.6 引用抽出 (4 テスト)
+
+- [ ] extracts inline citations from webpage-citation-pill
+- [ ] removes utm_source parameter from URLs
+- [ ] handles missing citations gracefully
+- [ ] handles multiple citations in single message
+
+#### 6.3.7 フォールバックセレクター (5 テスト)
+
+- [ ] conversationTurn primary selector (article[data-turn-id])
+- [ ] conversationTurn secondary selector ([data-testid])
+- [ ] userMessage primary selector ([data-message-author-role])
+- [ ] assistantResponse primary selector
+- [ ] markdownContent fallback chain
+
+#### 6.3.8 エラーハンドリング (3 テスト)
+
+- [ ] returns error when DOM elements not found
+- [ ] returns error for empty conversation
+- [ ] handles sanitization errors gracefully
+
+---
+
+## 7. 実装ファイル一覧
+
+| ファイル | 変更種別 | 内容 |
+|----------|----------|------|
+| `vite.config.ts` (manifest) | 変更 | ChatGPT URL パターン追加 |
+| `src/lib/types.ts` | 変更 | `'chatgpt'` を source/platform 型に追加 |
+| `src/content/extractors/base.ts` | 変更 | platform 型に `'chatgpt'` 追加 |
+| `src/content/index.ts` | 変更 | hostname ルーティング追加 + `waitForConversationContainer()` セレクター修正 |
+| `src/content/extractors/chatgpt.ts` | **新規** | ChatGPTExtractor 実装 |
+| `test/fixtures/dom-helpers.ts` | 変更 | ChatGPT DOM ヘルパー追加 |
+| `test/extractors/chatgpt.test.ts` | **新規** | ChatGPTExtractor テスト (32 cases) |
+
+---
+
+## 8. 引用変換仕様
+
+### 8.1 変換ロジック
+
+ChatGPT のインライン引用は、既存の Turndown HTML→Markdown 変換パイプラインで自然にリンクに変換される。
+
+```html
+<!-- 入力 HTML -->
+<span data-testid="webpage-citation-pill">
+  <a href="https://example.com?utm_source=chatgpt.com">example.com</a>
+</span>
+
+<!-- 出力 Markdown -->
+[example.com](https://example.com)
+```
+
+### 8.2 utm_source パラメータの削除
+
+ChatGPT は URL に `?utm_source=chatgpt.com` を付与する。これを削除して保存する。
+
+```typescript
+function cleanChatGPTUrl(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    urlObj.searchParams.delete('utm_source');
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
+}
+```
+
+---
+
+## 付録
+
+### A. ChatGPT HTML サンプルファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `data/chatgpt-elements-sample.html` | 通常チャット HTML |
+| `data/chatgpt-deep-research-sample.html` | Deep Research（通常会話として処理）HTML |
+
+### B. URL パターン
+
+| プラットフォーム | パターン | 例 |
+|-----------------|----------|-----|
+| Gemini | `/app/{hex-id}` | `/app/abc123def` |
+| Claude | `/chat/{uuid}` | `/chat/1fbb8252-2bec-4ef2-bf1f-88393dd9bb5f` |
+| ChatGPT | `/c/{uuid}` or `/g/{uuid}` | `/c/6789abcd-ef01-2345-6789-abcdef012345` |
+
+### C. 出力形式サンプル
+
+```markdown
+---
+id: chatgpt_6789abcd-ef01-2345-6789-abcdef012345
+title: 'IK Multimedia iLoud Sub 評価'
+source: chatgpt
+extractedAt: '2026-01-20T10:00:00.000Z'
+---
+
+> [!QUESTION] User
+> https://www.ikmultimedia.com/products/iloudsub/ 評価して
+
+> [!NOTE] ChatGPT
+> こちらは **IK Multimedia iLoud Sub** の総合評価レビューです。[IK Multimedia](https://www.ikmultimedia.com/products/iloudsub)
+>
+> ## 製品概要
+> **iLoud Sub** はコンパクトなスタジオ品質サブウーファーです。
+```
+
+### D. Gemini/Claude との DOM 構造比較
+
+| 特徴 | Gemini | Claude | ChatGPT |
+|------|--------|--------|---------|
+| **ターン識別** | `.conversation-container` | `.group` + role判定 | `article[data-turn-id]` |
+| **ユーザーメッセージ** | `user-query` タグ | `.whitespace-pre-wrap` | `[data-message-author-role="user"]` |
+| **アシスタント** | `model-response` タグ | `.font-claude-response` | `[data-message-author-role="assistant"]` |
+| **Markdown** | `.markdown-main-panel` | `.standard-markdown` | `.markdown.prose` |
+| **引用形式** | `data-turn-source-index` | インラインリンク | `data-testid="webpage-citation-pill"` |
+
+### E. content_scripts 実行タイミング
+
+ChatGPT は SPA (Single Page Application) のため、`document_idle` で content script を注入後、URL 変更を監視する必要がある可能性がある。既存の `waitForConversationContainer()` パターンで対応可能か検証が必要。
+
+```typescript
+// 既存の waitForConversationContainer() を ChatGPT 用にも適用
+// article[data-turn-id] が出現するまで待機
+```
+
+---
+
+### F. レビュー対応チェックリスト
+
+- [x] P0: `waitForConversationContainer()` のセレクター変更を Section 5.1 に追加
+- [x] P1: Sources ボタン引用は inline 引用と同一 DOM のため、スコープ表に注記追加
+- [x] P2: モデル名抽出セレクター（`data-message-model-slug`）を Section 5.3.4 に追加
+- [x] P2: `getTitle()` メソッド仕様を Section 5.6.3 に追加
+- [x] セクション番号の整合性を修正（5.1〜5.8）

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -50,6 +50,7 @@
   <ul>
     <li><strong>gemini.google.com</strong>: To extract Gemini conversation content (read-only)</li>
     <li><strong>claude.ai</strong>: To extract Claude conversation content (read-only)</li>
+    <li><strong>chatgpt.com</strong>: To extract ChatGPT conversation content (read-only)</li>
     <li><strong>127.0.0.1 (localhost)</strong>: To save files to your local Obsidian vault (when Obsidian output is enabled)</li>
   </ul>
   <p>No data is ever sent to external servers or third parties.</p>
@@ -72,6 +73,7 @@
     <tr><td>clipboardWrite</td><td>Copy conversation content to clipboard</td></tr>
     <tr><td>Host: gemini.google.com</td><td>Inject the sync button on Gemini pages</td></tr>
     <tr><td>Host: claude.ai</td><td>Inject the sync button on Claude pages</td></tr>
+    <tr><td>Host: chatgpt.com</td><td>Inject the sync button on ChatGPT pages</td></tr>
     <tr><td>Host: 127.0.0.1</td><td>Communicate with Obsidian's local API</td></tr>
   </table>
 

--- a/docs/workflow/WF-003-chatgpt-extractor-implementation.md
+++ b/docs/workflow/WF-003-chatgpt-extractor-implementation.md
@@ -1,0 +1,235 @@
+# WF-003: ChatGPT Extractor 実装ワークフロー
+
+| 項目 | 内容 |
+|------|------|
+| **文書ID** | WF-003 |
+| **関連設計書** | [DES-003-chatgpt-extractor.md](../design/DES-003-chatgpt-extractor.md) |
+| **作成日** | 2026-01-20 |
+| **総タスク数** | 12 |
+| **推定難易度** | Medium |
+
+---
+
+## 実行前提条件
+
+- [ ] 設計書 DES-003 がレビュー済み
+- [ ] `npm run build` が成功する状態
+- [ ] `npm run test` が全て PASS する状態
+
+---
+
+## Phase 1: 型定義の更新
+
+### Task 1.1: types.ts に 'chatgpt' を追加
+
+**ファイル**: `src/lib/types.ts`
+
+**変更内容**:
+```typescript
+// L30: ConversationData.source
+source: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+
+// L257: IConversationExtractor.platform
+readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+```
+
+**検証**: TypeScript コンパイルエラーがないこと
+
+---
+
+### Task 1.2: base.ts の platform 型を更新
+
+**ファイル**: `src/content/extractors/base.ts`
+
+**変更内容**:
+```typescript
+// L18
+abstract readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+```
+
+**検証**: TypeScript コンパイルエラーがないこと
+
+---
+
+## Phase 2: ChatGPTExtractor 実装
+
+### Task 2.1: chatgpt.ts の基本構造を作成
+
+**ファイル**: `src/content/extractors/chatgpt.ts` (新規)
+
+**内容**:
+- SELECTORS 定数定義
+- CITATION_SELECTORS 定数定義
+- ChatGPTExtractor クラスの骨格
+
+**参照**: DES-003 Section 5.3, 5.4
+
+---
+
+### Task 2.2: canExtract() を実装
+
+**仕様**: DES-003 Section 5.6.1
+- `hostname === 'chatgpt.com'` で厳密比較
+
+---
+
+### Task 2.3: getConversationId() を実装
+
+**仕様**: DES-003 Section 5.6.2
+- `/\/c\/([a-f0-9-]+)/i` または `/\/g\/([a-f0-9-]+)/i` でマッチ
+- フォールバック: `chatgpt-${Date.now()}`
+
+---
+
+### Task 2.4: getTitle() を実装
+
+**仕様**: DES-003 Section 5.6.3
+- 最初の User メッセージから取得
+- 100 文字でトランケート
+- デフォルト: `'Untitled ChatGPT Conversation'`
+
+---
+
+### Task 2.5: extractMessages() を実装
+
+**仕様**: DES-003 Section 5.6.4
+- `article[data-turn-id]` でターン取得
+- `data-turn` 属性で role 判別
+- DOM 順序でソート
+
+---
+
+### Task 2.6: extract() を実装
+
+**内容**:
+- canExtract() チェック
+- extractMessages() 呼び出し
+- ConversationData 構築
+- ExtractionResult 返却
+
+---
+
+## Phase 3: Content Script 統合
+
+### Task 3.1: index.ts に ChatGPT ルーティング追加
+
+**ファイル**: `src/content/index.ts`
+
+**変更箇所 1**: getExtractor() 関数 (L115-127)
+```typescript
+if (hostname === 'chatgpt.com') {
+  return new ChatGPTExtractor();
+}
+```
+
+**変更箇所 2**: import 追加
+```typescript
+import { ChatGPTExtractor } from './extractors/chatgpt';
+```
+
+---
+
+### Task 3.2: waitForConversationContainer() セレクター修正
+
+**ファイル**: `src/content/index.ts`
+
+**変更箇所**: L63, L73
+```typescript
+const existing = document.querySelector(
+  '.conversation-container, [class*="conversation"], article[data-turn-id]'
+);
+```
+
+```typescript
+const container = document.querySelector(
+  '.conversation-container, [class*="conversation"], article[data-turn-id]'
+);
+```
+
+---
+
+## Phase 4: Manifest 更新
+
+### Task 4.1: vite.config.ts の manifest に ChatGPT 追加
+
+**ファイル**: `vite.config.ts`
+
+**変更内容**:
+- `host_permissions` に `"https://chatgpt.com/*"` 追加
+- `content_scripts.matches` に `"https://chatgpt.com/*"` 追加
+
+---
+
+## Phase 5: ビルド・動作確認
+
+### Task 5.1: ビルドと基本動作確認
+
+**コマンド**:
+```bash
+npm run build
+npm run lint
+```
+
+**手動検証**:
+1. Chrome に拡張機能をリロード
+2. https://chatgpt.com/ にアクセス
+3. 会話ページで Sync ボタンが表示されることを確認
+4. Sync ボタンをクリックして抽出が成功することを確認
+
+---
+
+## Phase 6: テスト作成（オプション）
+
+### Task 6.1: DOM ヘルパー追加
+
+**ファイル**: `test/fixtures/dom-helpers.ts`
+
+**内容**:
+- `createChatGPTConversationDOM()`
+- `setChatGPTLocation()`
+- `createChatGPTInlineCitation()`
+
+---
+
+### Task 6.2: テストファイル作成
+
+**ファイル**: `test/extractors/chatgpt.test.ts` (新規)
+
+**テストケース**: DES-003 Section 6.3 参照（32 ケース）
+
+---
+
+## 実行順序サマリー
+
+```
+Phase 1: 型定義
+  └─ Task 1.1 → Task 1.2
+
+Phase 2: Extractor 実装
+  └─ Task 2.1 → 2.2 → 2.3 → 2.4 → 2.5 → 2.6
+
+Phase 3: 統合
+  └─ Task 3.1 → Task 3.2
+
+Phase 4: Manifest
+  └─ Task 4.1
+
+Phase 5: 検証
+  └─ Task 5.1
+
+Phase 6: テスト（オプション）
+  └─ Task 6.1 → Task 6.2
+```
+
+---
+
+## チェックポイント
+
+| Phase | 検証項目 |
+|-------|----------|
+| Phase 1 完了 | `npm run build` が成功 |
+| Phase 2 完了 | TypeScript エラーなし |
+| Phase 3 完了 | `npm run build` が成功 |
+| Phase 4 完了 | `npm run build` が成功 |
+| Phase 5 完了 | 手動検証 OK |
+| Phase 6 完了 | `npm run test` が全 PASS |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian, file download, or clipboard",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-ai-exporter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Chrome Extension to export AI conversations from Gemini to Obsidian, file download, or clipboard",
   "type": "module",
   "scripts": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -26,7 +26,11 @@ migrateSettings().catch(error => {
 /**
  * Allowed origins for content script messages (M-02)
  */
-const ALLOWED_ORIGINS = ['https://gemini.google.com', 'https://claude.ai'] as const;
+const ALLOWED_ORIGINS = [
+  'https://gemini.google.com',
+  'https://claude.ai',
+  'https://chatgpt.com',
+] as const;
 
 /**
  * Validate message sender (M-02)
@@ -124,7 +128,7 @@ function validateNoteData(note: ObsidianNote): boolean {
     }
     if (
       typeof note.frontmatter.source !== 'string' ||
-      !['gemini', 'claude', 'perplexity'].includes(note.frontmatter.source)
+      !['gemini', 'claude', 'perplexity', 'chatgpt'].includes(note.frontmatter.source)
     ) {
       return false;
     }

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -15,7 +15,7 @@ import { generateHash } from '../../lib/hash';
  * Provides common functionality for all AI platform extractors
  */
 export abstract class BaseExtractor implements IConversationExtractor {
-  abstract readonly platform: 'gemini' | 'claude' | 'perplexity';
+  abstract readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
 
   abstract canExtract(): boolean;
   abstract extract(): Promise<ExtractionResult>;

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -1,0 +1,300 @@
+/**
+ * ChatGPT Extractor
+ *
+ * Extracts conversations from ChatGPT (chatgpt.com)
+ * Supports normal chat mode (Deep Research treated as normal conversation)
+ *
+ * @see docs/design/DES-003-chatgpt-extractor.md
+ */
+
+import { BaseExtractor } from './base';
+import { sanitizeHtml } from '../../lib/sanitize';
+import type { ConversationMessage, ExtractionResult } from '../../lib/types';
+
+/** Maximum title length for truncation */
+const MAX_TITLE_LENGTH = 100;
+
+/**
+ * CSS Selectors for ChatGPT chat extraction
+ *
+ * Selectors are ordered by stability (HIGH → LOW)
+ * @see DES-003-chatgpt-extractor.md Section 5.3.2
+ */
+const SELECTORS = {
+  // Conversation turn (each Q&A pair)
+  conversationTurn: [
+    'article[data-turn-id]', // data attribute (HIGH)
+    'article[data-testid^="conversation-turn"]', // test attribute (LOW)
+  ],
+
+  // User message
+  userMessage: [
+    '[data-message-author-role="user"] .whitespace-pre-wrap', // Structure (HIGH)
+    'article[data-turn="user"] .whitespace-pre-wrap', // Structure (HIGH)
+    '.user-message-bubble-color .whitespace-pre-wrap', // Style (MEDIUM)
+  ],
+
+  // Assistant message
+  assistantResponse: [
+    '[data-message-author-role="assistant"] .markdown.prose', // Structure (HIGH)
+    'article[data-turn="assistant"] .markdown.prose', // Structure (HIGH)
+    '.markdown.prose.dark\\:prose-invert', // Style (MEDIUM)
+  ],
+
+  // Markdown content
+  markdownContent: [
+    '.markdown.prose', // Semantic (HIGH)
+    '.markdown-new-styling', // Style (MEDIUM)
+  ],
+
+  // Message ID attribute
+  messageId: [
+    '[data-message-id]', // data attribute (HIGH)
+    '[data-turn-id]', // data attribute (HIGH)
+  ],
+};
+
+/**
+ * ChatGPT conversation extractor
+ *
+ * Implements IConversationExtractor interface
+ * @see src/lib/types.ts
+ */
+export class ChatGPTExtractor extends BaseExtractor {
+  readonly platform = 'chatgpt' as const;
+
+  // ========== Platform Detection ==========
+
+  /**
+   * Check if this extractor can handle the current page
+   *
+   * IMPORTANT: Uses strict comparison (===) to prevent
+   * subdomain attacks like "evil-chatgpt.com.attacker.com"
+   * @see NFR-001-1 in design document
+   */
+  canExtract(): boolean {
+    return window.location.hostname === 'chatgpt.com';
+  }
+
+  // ========== ID & Title Extraction ==========
+
+  /**
+   * Extract conversation ID from URL
+   *
+   * URL format: https://chatgpt.com/c/{uuid} or https://chatgpt.com/g/{uuid}
+   * @returns UUID string or null if not found
+   */
+  getConversationId(): string | null {
+    // Match /c/{uuid} or /g/{uuid} pattern
+    const match = window.location.pathname.match(/\/[cg]\/([a-f0-9-]+)/i);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * Get conversation title
+   *
+   * Priority:
+   * 1. First user message content (truncated to MAX_TITLE_LENGTH)
+   * 2. Default title
+   */
+  getTitle(): string {
+    // Try first user message
+    const firstUserContent = this.queryWithFallback<HTMLElement>(SELECTORS.userMessage);
+    if (firstUserContent?.textContent) {
+      const title = this.sanitizeText(firstUserContent.textContent);
+      return title.substring(0, MAX_TITLE_LENGTH);
+    }
+
+    return 'Untitled ChatGPT Conversation';
+  }
+
+  // ========== Message Extraction ==========
+
+  /**
+   * Extract all messages from conversation
+   *
+   * Uses article[data-turn-id] to find conversation turns,
+   * then extracts User/Assistant messages in DOM order
+   * @see FR-002 in design document
+   */
+  extractMessages(): ConversationMessage[] {
+    const messages: ConversationMessage[] = [];
+
+    // Find all conversation turns
+    const turns = this.queryAllWithFallback<HTMLElement>(SELECTORS.conversationTurn);
+
+    if (turns.length === 0) {
+      console.warn('[G2O] No conversation turns found with primary selectors');
+      return messages;
+    }
+
+    // Process each turn
+    turns.forEach((turn, index) => {
+      // Determine role from data-turn attribute or data-message-author-role
+      const turnRole = turn.getAttribute('data-turn');
+      const messageEl = turn.querySelector('[data-message-author-role]');
+      const authorRole = messageEl?.getAttribute('data-message-author-role');
+
+      const role = turnRole || authorRole;
+
+      if (role === 'user') {
+        const content = this.extractUserContent(turn);
+        if (content) {
+          messages.push({
+            id: `user-${index}`,
+            role: 'user',
+            content,
+            index: messages.length,
+          });
+        }
+      } else if (role === 'assistant') {
+        const content = this.extractAssistantContent(turn);
+        if (content) {
+          messages.push({
+            id: `assistant-${index}`,
+            role: 'assistant',
+            content,
+            htmlContent: content,
+            index: messages.length,
+          });
+        }
+      }
+    });
+
+    return messages;
+  }
+
+  /**
+   * Extract user message content (plain text)
+   */
+  private extractUserContent(turnElement: Element): string {
+    // Find user message content within the turn
+    const contentEl = this.queryWithFallback<HTMLElement>(SELECTORS.userMessage, turnElement);
+    if (contentEl?.textContent) {
+      return this.sanitizeText(contentEl.textContent);
+    }
+
+    // Fallback: try to get any .whitespace-pre-wrap content
+    const fallbackEl = turnElement.querySelector('.whitespace-pre-wrap');
+    if (fallbackEl?.textContent) {
+      return this.sanitizeText(fallbackEl.textContent);
+    }
+
+    return '';
+  }
+
+  /**
+   * Extract assistant response content (HTML for markdown conversion)
+   *
+   * All HTML is sanitized via DOMPurify to prevent XSS
+   * Also cleans utm_source parameters from citation URLs
+   * @see NFR-001-2 in design document
+   */
+  private extractAssistantContent(turnElement: Element): string {
+    // Find markdown content within the turn
+    const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, turnElement);
+    if (markdownEl) {
+      // Clean citation URLs before returning
+      const cleanedHtml = this.cleanCitationUrls(markdownEl.innerHTML);
+      return sanitizeHtml(cleanedHtml);
+    }
+
+    // Fallback: try assistantResponse selectors
+    const assistantEl = this.queryWithFallback<HTMLElement>(SELECTORS.assistantResponse, turnElement);
+    if (assistantEl) {
+      const cleanedHtml = this.cleanCitationUrls(assistantEl.innerHTML);
+      return sanitizeHtml(cleanedHtml);
+    }
+
+    return '';
+  }
+
+  /**
+   * Clean utm_source parameter from citation URLs
+   *
+   * ChatGPT adds ?utm_source=chatgpt.com to citation URLs
+   * @see DES-003-chatgpt-extractor.md Section 8.2
+   */
+  private cleanCitationUrls(html: string): string {
+    // Replace utm_source parameter in href attributes
+    return html.replace(
+      /href="([^"]+)\?utm_source=chatgpt\.com"/g,
+      (_, url) => `href="${url}"`
+    ).replace(
+      /href="([^"]+)&utm_source=chatgpt\.com"/g,
+      (_, url) => `href="${url}"`
+    );
+  }
+
+  // ========== Main Entry Point ==========
+
+  /**
+   * Main extraction method
+   *
+   * Extracts normal conversation
+   * (Deep Research is treated as normal conversation)
+   */
+  async extract(): Promise<ExtractionResult> {
+    try {
+      if (!this.canExtract()) {
+        return {
+          success: false,
+          error: 'Not on a ChatGPT page',
+        };
+      }
+
+      console.info('[G2O] Extracting ChatGPT conversation');
+      const messages = this.extractMessages();
+      const warnings: string[] = [];
+
+      if (messages.length === 0) {
+        return {
+          success: false,
+          error: 'No messages found in conversation',
+          warnings: ['Primary selectors may have changed. Check ChatGPT UI for updates.'],
+        };
+      }
+
+      // Check for potential issues
+      const userCount = messages.filter(m => m.role === 'user').length;
+      const assistantCount = messages.filter(m => m.role === 'assistant').length;
+
+      if (userCount === 0) {
+        warnings.push('No user messages found');
+      }
+      if (assistantCount === 0) {
+        warnings.push('No assistant messages found');
+      }
+
+      const conversationId = this.getConversationId() || `chatgpt-${Date.now()}`;
+      const title = this.getTitle();
+
+      return {
+        success: true,
+        data: {
+          id: conversationId,
+          title,
+          url: window.location.href,
+          source: 'chatgpt',
+          messages,
+          extractedAt: new Date(),
+          metadata: {
+            messageCount: messages.length,
+            userMessageCount: userCount,
+            assistantMessageCount: assistantCount,
+            hasCodeBlocks: messages.some(
+              m => m.content.includes('<code') || m.content.includes('```')
+            ),
+          },
+        },
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    } catch (error) {
+      console.error('[G2O] ChatGPT extraction error:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown extraction error',
+      };
+    }
+  }
+}

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -200,7 +200,10 @@ export class ChatGPTExtractor extends BaseExtractor {
     }
 
     // Fallback: try assistantResponse selectors
-    const assistantEl = this.queryWithFallback<HTMLElement>(SELECTORS.assistantResponse, turnElement);
+    const assistantEl = this.queryWithFallback<HTMLElement>(
+      SELECTORS.assistantResponse,
+      turnElement
+    );
     if (assistantEl) {
       const cleanedHtml = this.cleanCitationUrls(assistantEl.innerHTML);
       return sanitizeHtml(cleanedHtml);
@@ -217,13 +220,9 @@ export class ChatGPTExtractor extends BaseExtractor {
    */
   private cleanCitationUrls(html: string): string {
     // Replace utm_source parameter in href attributes
-    return html.replace(
-      /href="([^"]+)\?utm_source=chatgpt\.com"/g,
-      (_, url) => `href="${url}"`
-    ).replace(
-      /href="([^"]+)&utm_source=chatgpt\.com"/g,
-      (_, url) => `href="${url}"`
-    );
+    return html
+      .replace(/href="([^"]+)\?utm_source=chatgpt\.com"/g, (_, url) => `href="${url}"`)
+      .replace(/href="([^"]+)&utm_source=chatgpt\.com"/g, (_, url) => `href="${url}"`);
   }
 
   // ========== Main Entry Point ==========

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -5,6 +5,7 @@
 
 import { GeminiExtractor } from './extractors/gemini';
 import { ClaudeExtractor } from './extractors/claude';
+import { ChatGPTExtractor } from './extractors/chatgpt';
 import type { IConversationExtractor } from '../lib/types';
 import { conversationToNote } from './markdown';
 import {
@@ -60,7 +61,10 @@ const MUTATION_DEBOUNCE_DELAY = 100;
 function waitForConversationContainer(): Promise<void> {
   return new Promise(resolve => {
     // Check if already exists
-    const existing = document.querySelector('.conversation-container, [class*="conversation"]');
+    // ChatGPT uses article[data-turn-id] instead of conversation-container
+    const existing = document.querySelector(
+      '.conversation-container, [class*="conversation"], article[data-turn-id]'
+    );
     if (existing) {
       resolve();
       return;
@@ -70,7 +74,10 @@ function waitForConversationContainer(): Promise<void> {
 
     // Debounced check function
     const checkForContainer = (obs: MutationObserver) => {
-      const container = document.querySelector('.conversation-container, [class*="conversation"]');
+      // ChatGPT uses article[data-turn-id] instead of conversation-container
+      const container = document.querySelector(
+        '.conversation-container, [class*="conversation"], article[data-turn-id]'
+      );
       if (container) {
         obs.disconnect();
         if (debounceTimer) {
@@ -121,6 +128,9 @@ function getExtractor(): IConversationExtractor | null {
   }
   if (hostname === 'claude.ai') {
     return new ClaudeExtractor();
+  }
+  if (hostname === 'chatgpt.com') {
+    return new ChatGPTExtractor();
   }
 
   return null;

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -313,20 +313,40 @@ export function generateContentHash(content: string): string {
 }
 
 /**
+ * Get display label for AI assistant based on source platform
+ */
+function getAssistantLabel(source: string): string {
+  switch (source) {
+    case 'gemini':
+      return 'Gemini';
+    case 'claude':
+      return 'Claude';
+    case 'chatgpt':
+      return 'ChatGPT';
+    case 'perplexity':
+      return 'Perplexity';
+    default:
+      return 'Assistant';
+  }
+}
+
+/**
  * Format a single message according to template options
  */
 function formatMessage(
   content: string,
   role: 'user' | 'assistant',
-  options: TemplateOptions
+  options: TemplateOptions,
+  source: string
 ): string {
   // Convert HTML to Markdown for assistant messages
   const markdown = role === 'assistant' ? htmlToMarkdown(content) : content;
+  const assistantLabel = getAssistantLabel(source);
 
   switch (options.messageFormat) {
     case 'callout': {
       const calloutType = role === 'user' ? options.userCalloutType : options.assistantCalloutType;
-      const label = role === 'user' ? 'User' : 'Gemini';
+      const label = role === 'user' ? 'User' : assistantLabel;
       // Format as Obsidian callout with proper line handling
       const lines = markdown.split('\n');
       const formattedLines = lines.map((line, i) =>
@@ -336,14 +356,14 @@ function formatMessage(
     }
 
     case 'blockquote': {
-      const label = role === 'user' ? '**User:**' : '**Gemini:**';
+      const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
       const lines = markdown.split('\n').map(line => `> ${line}`);
       return `${label}\n${lines.join('\n')}`;
     }
 
     case 'plain':
     default: {
-      const label = role === 'user' ? '**User:**' : '**Gemini:**';
+      const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
       return `${label}\n\n${markdown}`;
     }
   }
@@ -382,7 +402,7 @@ export function conversationToNote(data: ConversationData, options: TemplateOpti
     const bodyParts: string[] = [];
 
     for (const message of data.messages) {
-      const formatted = formatMessage(message.content, message.role, options);
+      const formatted = formatMessage(message.content, message.role, options, data.source);
       bodyParts.push(formatted);
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,7 +27,7 @@ export interface ConversationData {
   id: string;
   title: string;
   url: string;
-  source: 'gemini' | 'claude' | 'perplexity';
+  source: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
   type?: 'conversation' | 'deep-research';
   /** Deep Research link information (optional) */
   links?: DeepResearchLinks;
@@ -254,7 +254,7 @@ export interface ValidationResult {
  * Interface for AI platform extractors
  */
 export interface IConversationExtractor {
-  readonly platform: 'gemini' | 'claude' | 'perplexity';
+  readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
   canExtract(): boolean;
   extract(): Promise<ExtractionResult>;
   getConversationId(): string | null;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "88",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "88",
@@ -16,6 +16,7 @@
   "host_permissions": [
     "https://gemini.google.com/*",
     "https://claude.ai/*",
+    "https://chatgpt.com/*",
     "http://127.0.0.1:27123/*"
   ],
   "content_security_policy": {
@@ -27,7 +28,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://gemini.google.com/*", "https://claude.ai/*"],
+      "matches": ["https://gemini.google.com/*", "https://claude.ai/*", "https://chatgpt.com/*"],
       "js": ["src/content/index.ts"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary

- Add ChatGPT (chatgpt.com) conversation extraction support
- Support both `/c/{uuid}` and `/g/{uuid}` URL formats
- Clean utm_source parameters from citation URLs
- Fix assistant label in callout format (now shows Gemini/Claude/ChatGPT based on source)

## Changes

### New Files

- `src/content/extractors/chatgpt.ts` - ChatGPT extractor implementation
- `test/extractors/chatgpt.test.ts` - 40 test cases
- `docs/design/DES-003-chatgpt-extractor.md` - Design document
- `docs/workflow/WF-003-chatgpt-extractor-implementation.md` - Workflow document

### Modified Files

- `src/lib/types.ts` - Add 'chatgpt' to platform union types
- `src/content/extractors/base.ts` - Update platform type
- `src/content/index.ts` - Add ChatGPT routing
- `src/background/index.ts` - Add chatgpt.com to ALLOWED_ORIGINS and source validation
- `src/manifest.json` - Add chatgpt.com to host_permissions and content_scripts
- `src/content/markdown.ts` - Dynamic assistant label based on source
- `test/fixtures/dom-helpers.ts` - Add ChatGPT DOM helpers
- `CLAUDE.md` - Add platform addition checklist
- `README.md` / `README.ja.md` - Document ChatGPT support
- `docs/privacy.html` - Add chatgpt.com to privacy policy

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 500 tests pass (`npm test`)
- [x] Manual test on chatgpt.com conversation page
- [x] Verify callout labels show correct AI name (Gemini/Claude/ChatGPT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)