### PR TITLE
fix: 🔧 update commitlint config for Release Please compatibility

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,29 +1,25 @@
 /**
- * commitlint configuration with emoji prefix support
+ * commitlint configuration for Release Please compatibility
  *
- * Format: "<emoji> <type>: <subject>"
- * Example: "✨ feat: add new feature"
+ * Format: "<type>: <emoji> <subject>"
+ * Example: "feat: ✨ add new feature"
  *
- * Supported emoji mappings:
- * ✨ feat     - New feature
- * 🐛 fix      - Bug fix
- * 📝 docs     - Documentation
- * 🎨 style    - Code style/formatting
- * ♻️  refactor - Code refactoring
- * ⚡️ perf     - Performance improvement
- * ✅ test     - Tests
- * 🔧 chore    - Build/maintenance
- * 🔒 security - Security fix
+ * This format ensures Release Please can parse the conventional commit type
+ * while preserving emoji in the subject line for visual clarity.
+ *
+ * Supported type-emoji mappings (emoji in subject):
+ * feat     ✨ - New feature
+ * fix      🐛 - Bug fix
+ * docs     📝 - Documentation
+ * style    🎨 - Code style/formatting
+ * refactor ♻️  - Code refactoring
+ * perf     ⚡️ - Performance improvement
+ * test     ✅ - Tests
+ * chore    🔧 - Build/maintenance
+ * security 🔒 - Security fix
  */
 export default {
-  parserPreset: {
-    parserOpts: {
-      // Regex: emoji + space + type + optional(scope) + colon + space + subject
-      headerPattern:
-        /^(?:\p{Emoji_Presentation}|\p{Extended_Pictographic})\s+(\w+)(?:\(([^)]+)\))?:\s+(.+)$/u,
-      headerCorrespondence: ['type', 'scope', 'subject'],
-    },
-  },
+  extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [
       2, // Error level
@@ -45,9 +41,6 @@ export default {
         'release', // Release
       ],
     ],
-    'type-case': [2, 'always', 'lower-case'],
-    'type-empty': [2, 'never'],
-    'subject-empty': [2, 'never'],
     'header-max-length': [2, 'always', 100],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@commitlint/cli": "^20.3.1",
+        "@commitlint/config-conventional": "^20.3.1",
         "@crxjs/vite-plugin": "^2.0.0-beta.23",
         "@types/chrome": "^0.0.268",
         "@types/dompurify": "^3.0.0",
@@ -173,6 +174,20 @@
       },
       "bin": {
         "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.3.1.tgz",
+      "integrity": "sha512-NCzwvxepstBZbmVXsvg49s+shCxlJDJPWxXqONVcAtJH9wWrOlkMQw/zyl+dJmt8lyVopt5mwQ3mR5M2N2rUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.3.1",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
         "node": ">=v18"
@@ -2675,6 +2690,19 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^20.3.1",
+    "@commitlint/config-conventional": "^20.3.1",
     "@crxjs/vite-plugin": "^2.0.0-beta.23",
     "@types/chrome": "^0.0.268",
     "@types/dompurify": "^3.0.0",


### PR DESCRIPTION
## Summary

- Remove custom emoji-prefix parser that Release Please cannot parse
- Extend `@commitlint/config-conventional` for standard parsing
- Move emoji from prefix to subject (e.g., `feat: ✨ add feature`)

## Problem

Release Please could not parse commits with emoji prefix format:

```
❯ commit could not be parsed: cb27ae9 ✨ feat: add Release Please and commitlint integration
❯ error message: Error: unexpected token ' ' at 1:2, valid tokens [(, !, :]
```

## Solution

Change commit format from `✨ feat: subject` to `feat: ✨ subject`

## Test plan

- [x] Verify `echo "feat: ✨ add feature" | npx commitlint` passes
- [x] Verify `echo "fix: 🐛 resolve bug" | npx commitlint` passes
- [x] Verify old format is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)