### PR TITLE
fix: remove duplicate .md extension in file download

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -459,7 +459,7 @@ async function handleDownloadToFile(
 ): Promise<OutputResult> {
   try {
     const content = generateNoteContent(note, settings);
-    const filename = `${note.fileName}.md`;
+    const filename = note.fileName;
 
     // Use data URL (Service Worker doesn't support Blob/URL.createObjectURL)
     const base64Content = stringToBase64(content);

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -831,7 +831,7 @@ describe('background/index', () => {
   describe('handleDownloadToFile', () => {
     const validSender = { url: `chrome-extension://${chrome.runtime.id}/popup.html` };
     const validNote: ObsidianNote = {
-      fileName: 'test-conversation',
+      fileName: 'test-conversation.md',
       body: '# Test Content',
       contentHash: 'abc123',
       frontmatter: {


### PR DESCRIPTION
## Summary

- Fixed bug where downloaded files had double `.md.md` extension
- `handleDownloadToFile()` was appending `.md` to `note.fileName` which already includes the extension from `generateFileName()`

## Changes

- Removed redundant `.md` append in `src/background/index.ts:462`

## Test plan

- [x] Build succeeds
- [x] All 478 tests pass
- [ ] Manual test: Download conversation to file, verify `.md` extension (not `.md.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)