### PR TITLE
fix: update conversation ID extraction for new URL patterns

### DIFF
--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -79,12 +79,14 @@ export class ChatGPTExtractor extends BaseExtractor {
   /**
    * Extract conversation ID from URL
    *
-   * URL format: https://chatgpt.com/c/{uuid} or https://chatgpt.com/g/{uuid}
+   * URL formats:
+   *   https://chatgpt.com/c/{uuid}
+   *   https://chatgpt.com/g/{gpt-slug}/c/{uuid}
    * @returns UUID string or null if not found
    */
   getConversationId(): string | null {
-    // Match /c/{uuid} or /g/{uuid} pattern
-    const match = window.location.pathname.match(/\/[cg]\/([a-f0-9-]+)/i);
+    // Match /c/{uuid} pattern (works for both regular and custom GPT URLs)
+    const match = window.location.pathname.match(/\/c\/([a-f0-9-]+)/i);
     return match ? match[1] : null;
   }
 

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -193,10 +193,11 @@ export class GeminiExtractor extends BaseExtractor {
   /**
    * Get conversation ID from URL
    * URL format: https://gemini.google.com/app/{conversationId}
+   *          or https://gemini.google.com/gem/{conversationId}
    */
   getConversationId(): string | null {
-    const match = window.location.pathname.match(/\/app\/([a-f0-9]+)/i);
-    return match ? match[1] : null;
+    const match = window.location.pathname.match(/\/(app|gem)\/([a-f0-9]+)/i);
+    return match ? match[2] : null;
   }
 
   /**

--- a/test/extractors/chatgpt.test.ts
+++ b/test/extractors/chatgpt.test.ts
@@ -96,7 +96,7 @@ describe('ChatGPTExtractor', () => {
       expect(extractor.getConversationId()).toBe('6789abcd-ef01-2345-6789-abcdef012345');
     });
 
-    it('extracts UUID from /g/{uuid} URL (GPT mode)', () => {
+    it('extracts UUID from /g/{gptSlug}/c/{uuid} URL (custom GPT mode)', () => {
       setChatGPTLocation('abcd1234-5678-90ab-cdef-1234567890ab', 'g');
       expect(extractor.getConversationId()).toBe('abcd1234-5678-90ab-cdef-1234567890ab');
     });
@@ -475,14 +475,14 @@ describe('ChatGPTExtractor', () => {
       expect(result.data?.source).toBe('chatgpt');
     });
 
-    it('handles /g/ URL prefix for GPT mode', async () => {
+    it('handles /g/{gptSlug}/c/{uuid} URL for custom GPT mode', async () => {
       // Use a valid hex UUID format that matches the extractor's regex
       const gptModeId = 'abcd1234-5678-90ab-cdef-1234567890ab';
       createChatGPTPage(gptModeId, [
         { role: 'user', content: 'GPT mode test' },
         { role: 'assistant', content: '<p>Response from custom GPT</p>' },
       ], 'g');
-      // Verify the ID extraction works with /g/ prefix
+      // Verify the ID extraction works with /g/{slug}/c/{uuid} path
       expect(extractor.getConversationId()).toBe(gptModeId);
       const result = await extractor.extract();
       expect(result.success).toBe(true);

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -641,14 +641,23 @@ export function createChatGPTConversationDOM(messages: ChatGPTConversationMessag
  * Set window.location for ChatGPT URL testing
  *
  * @param conversationId UUID format or custom ID
- * @param prefix URL prefix: 'c' for chat, 'g' for GPT mode
+ * @param prefix URL prefix: 'c' for regular chat, 'g' for custom GPT mode
+ *
+ * URL formats:
+ *   prefix='c': https://chatgpt.com/c/{conversationId}
+ *   prefix='g': https://chatgpt.com/g/{gptSlug}/c/{conversationId}
  */
 export function setChatGPTLocation(conversationId: string, prefix: 'c' | 'g' = 'c'): void {
+  const gptSlug = 'g-abc123-test-gpt';
+  const pathname =
+    prefix === 'g'
+      ? `/g/${gptSlug}/c/${conversationId}`
+      : `/c/${conversationId}`;
   Object.defineProperty(window, 'location', {
     value: {
       hostname: 'chatgpt.com',
-      pathname: `/${prefix}/${conversationId}`,
-      href: `https://chatgpt.com/${prefix}/${conversationId}`,
+      pathname,
+      href: `https://chatgpt.com${pathname}`,
       origin: 'https://chatgpt.com',
       protocol: 'https:',
       host: 'chatgpt.com',


### PR DESCRIPTION
## Summary

- Update Gemini extractor to handle `/gem/` path in addition to `/app/` for Gem conversations
- Fix ChatGPT extractor to correctly extract conversation ID from `/g/{gpt-slug}/c/{uuid}` custom GPT URLs
- Update test helpers and test descriptions to reflect actual URL patterns

## Test plan

- [x] All 549 tests pass
- [x] `npm run build` succeeds
- [ ] Verify extraction works on `https://gemini.google.com/app/{id}` URLs
- [ ] Verify extraction works on `https://gemini.google.com/gem/{id}` URLs
- [ ] Verify extraction works on `https://chatgpt.com/c/{uuid}` URLs
- [ ] Verify extraction works on `https://chatgpt.com/g/{slug}/c/{uuid}` custom GPT URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)