### PR TITLE
feat: add Perplexity AI conversation extractor

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -36,6 +36,7 @@ const ALLOWED_ORIGINS = [
   'https://gemini.google.com',
   'https://claude.ai',
   'https://chatgpt.com',
+  'https://www.perplexity.ai',
 ] as const;
 
 /**

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -1,0 +1,252 @@
+/**
+ * Perplexity Extractor
+ *
+ * Extracts conversations from Perplexity AI (www.perplexity.ai)
+ * Supports normal chat mode (Deep Research treated as normal conversation)
+ *
+ * @see docs/design/DES-004-perplexity-extractor.md
+ */
+
+import { BaseExtractor, extractErrorMessage } from './base';
+import { sanitizeHtml } from '../../lib/sanitize';
+import type { ConversationMessage, ExtractionResult } from '../../lib/types';
+import { MAX_CONVERSATION_TITLE_LENGTH } from '../../lib/constants';
+
+/**
+ * CSS Selectors for Perplexity chat extraction
+ *
+ * Selectors are ordered by stability (HIGH → LOW)
+ * @see DES-004-perplexity-extractor.md Section 4.1
+ */
+const SELECTORS = {
+  // User query text
+  userQuery: [
+    'span.select-text', // Semantic (HIGH)
+    'div.bg-offset.rounded-2xl span.select-text', // Style (MEDIUM)
+  ],
+
+  // Assistant response content container
+  markdownContent: [
+    'div[id^="markdown-content-"]', // ID pattern (HIGH)
+    '.prose.dark\\:prose-invert', // Style (MEDIUM)
+  ],
+
+  // Prose content within response
+  proseContent: [
+    '.prose.dark\\:prose-invert', // Standard (HIGH)
+    '.prose', // Fallback (LOW)
+  ],
+};
+
+/**
+ * Perplexity conversation extractor
+ *
+ * Implements IConversationExtractor interface
+ * @see src/lib/types.ts
+ */
+export class PerplexityExtractor extends BaseExtractor {
+  readonly platform = 'perplexity' as const;
+
+  // ========== Platform Detection ==========
+
+  /**
+   * Check if this extractor can handle the current page
+   *
+   * IMPORTANT: Uses strict comparison (===) to prevent
+   * subdomain attacks like "evil-www.perplexity.ai.attacker.com"
+   */
+  canExtract(): boolean {
+    return window.location.hostname === 'www.perplexity.ai';
+  }
+
+  // ========== ID & Title Extraction ==========
+
+  /**
+   * Extract conversation ID from URL
+   *
+   * URL format: https://www.perplexity.ai/search/{slug}
+   * @returns Full slug string or null if not found
+   */
+  getConversationId(): string | null {
+    const match = window.location.pathname.match(/\/search\/(.+)$/);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * Get conversation title
+   *
+   * Priority:
+   * 1. First user query text (truncated to MAX_CONVERSATION_TITLE_LENGTH)
+   * 2. Default title
+   */
+  getTitle(): string {
+    const firstQuery = this.queryWithFallback<HTMLElement>(SELECTORS.userQuery);
+    if (firstQuery?.textContent) {
+      const title = this.sanitizeText(firstQuery.textContent);
+      return title.substring(0, MAX_CONVERSATION_TITLE_LENGTH);
+    }
+
+    return 'Untitled Perplexity Conversation';
+  }
+
+  // ========== Message Extraction ==========
+
+  /**
+   * Extract all messages from conversation
+   *
+   * Strategy: Collect user queries and assistant responses independently,
+   * then pair them by sequential index (query[0] ↔ response[0], etc.)
+   * @see DES-004 Section 4.2
+   */
+  extractMessages(): ConversationMessage[] {
+    const messages: ConversationMessage[] = [];
+
+    // Collect all user queries (span.select-text)
+    const queryElements = this.queryAllWithFallback<HTMLElement>(SELECTORS.userQuery);
+
+    // Collect all assistant responses (div[id^="markdown-content-"])
+    const responseElements = this.queryAllWithFallback<HTMLElement>(SELECTORS.markdownContent);
+
+    if (queryElements.length === 0 && responseElements.length === 0) {
+      console.warn('[G2O] No conversation content found with primary selectors');
+      return messages;
+    }
+
+    // Pair queries and responses by sequential index
+    const pairCount = Math.max(queryElements.length, responseElements.length);
+
+    for (let i = 0; i < pairCount; i++) {
+      // Add user message if query exists at this index
+      if (i < queryElements.length) {
+        const content = this.extractUserContent(queryElements[i]);
+        if (content) {
+          messages.push({
+            id: `user-${i}`,
+            role: 'user',
+            content,
+            index: messages.length,
+          });
+        }
+      }
+
+      // Add assistant message if response exists at this index
+      if (i < responseElements.length) {
+        const content = this.extractAssistantContent(responseElements[i]);
+        if (content) {
+          messages.push({
+            id: `assistant-${i}`,
+            role: 'assistant',
+            content,
+            htmlContent: content,
+            index: messages.length,
+          });
+        }
+      }
+    }
+
+    return messages;
+  }
+
+  /**
+   * Extract user query content (plain text)
+   */
+  private extractUserContent(queryElement: HTMLElement): string {
+    if (queryElement.textContent) {
+      return this.sanitizeText(queryElement.textContent);
+    }
+    return '';
+  }
+
+  /**
+   * Extract assistant response content (HTML for markdown conversion)
+   *
+   * Finds the .prose child element and extracts its innerHTML.
+   * All HTML is sanitized via DOMPurify to prevent XSS.
+   */
+  private extractAssistantContent(contentElement: HTMLElement): string {
+    // Find .prose child within the markdown-content container
+    const proseEl = this.queryWithFallback<HTMLElement>(SELECTORS.proseContent, contentElement);
+    if (proseEl) {
+      return sanitizeHtml(proseEl.innerHTML);
+    }
+
+    // Fallback: use the content element's innerHTML directly
+    if (contentElement.innerHTML) {
+      return sanitizeHtml(contentElement.innerHTML);
+    }
+
+    return '';
+  }
+
+  // ========== Main Entry Point ==========
+
+  /**
+   * Main extraction method
+   *
+   * Extracts normal conversation
+   * (Deep Research is treated as normal conversation)
+   */
+  async extract(): Promise<ExtractionResult> {
+    try {
+      if (!this.canExtract()) {
+        return {
+          success: false,
+          error: 'Not on a Perplexity page',
+        };
+      }
+
+      console.info('[G2O] Extracting Perplexity conversation');
+      const messages = this.extractMessages();
+      const warnings: string[] = [];
+
+      if (messages.length === 0) {
+        return {
+          success: false,
+          error: 'No messages found in conversation',
+          warnings: ['Primary selectors may have changed. Check Perplexity UI for updates.'],
+        };
+      }
+
+      // Check for potential issues
+      const userCount = messages.filter(m => m.role === 'user').length;
+      const assistantCount = messages.filter(m => m.role === 'assistant').length;
+
+      if (userCount === 0) {
+        warnings.push('No user messages found');
+      }
+      if (assistantCount === 0) {
+        warnings.push('No assistant messages found');
+      }
+
+      const conversationId = this.getConversationId() || `perplexity-${Date.now()}`;
+      const title = this.getTitle();
+
+      return {
+        success: true,
+        data: {
+          id: conversationId,
+          title,
+          url: window.location.href,
+          source: 'perplexity',
+          messages,
+          extractedAt: new Date(),
+          metadata: {
+            messageCount: messages.length,
+            userMessageCount: userCount,
+            assistantMessageCount: assistantCount,
+            hasCodeBlocks: messages.some(
+              m => m.content.includes('<code') || m.content.includes('```')
+            ),
+          },
+        },
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    } catch (error) {
+      console.error('[G2O] Perplexity extraction error:', error);
+      return {
+        success: false,
+        error: extractErrorMessage(error),
+      };
+    }
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -6,6 +6,7 @@
 import { GeminiExtractor } from './extractors/gemini';
 import { ClaudeExtractor } from './extractors/claude';
 import { ChatGPTExtractor } from './extractors/chatgpt';
+import { PerplexityExtractor } from './extractors/perplexity';
 import type { IConversationExtractor } from '../lib/types';
 import { conversationToNote } from './markdown';
 import {
@@ -63,7 +64,7 @@ function waitForConversationContainer(): Promise<void> {
     // Check if already exists
     // ChatGPT uses article[data-turn-id] instead of conversation-container
     const existing = document.querySelector(
-      '.conversation-container, [class*="conversation"], article[data-turn-id]'
+      '.conversation-container, [class*="conversation"], article[data-turn-id], div[class*="threadContentWidth"]'
     );
     if (existing) {
       resolve();
@@ -76,7 +77,7 @@ function waitForConversationContainer(): Promise<void> {
     const checkForContainer = (obs: MutationObserver) => {
       // ChatGPT uses article[data-turn-id] instead of conversation-container
       const container = document.querySelector(
-        '.conversation-container, [class*="conversation"], article[data-turn-id]'
+        '.conversation-container, [class*="conversation"], article[data-turn-id], div[class*="threadContentWidth"]'
       );
       if (container) {
         obs.disconnect();
@@ -131,6 +132,9 @@ function getExtractor(): IConversationExtractor | null {
   }
   if (hostname === 'chatgpt.com') {
     return new ChatGPTExtractor();
+  }
+  if (hostname === 'www.perplexity.ai') {
+    return new PerplexityExtractor();
   }
 
   return null;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
     "https://gemini.google.com/*",
     "https://claude.ai/*",
     "https://chatgpt.com/*",
+    "https://www.perplexity.ai/*",
     "http://127.0.0.1:27123/*"
   ],
   "content_security_policy": {
@@ -36,7 +37,8 @@
       "matches": [
         "https://gemini.google.com/*",
         "https://claude.ai/*",
-        "https://chatgpt.com/*"
+        "https://chatgpt.com/*",
+        "https://www.perplexity.ai/*"
       ],
       "js": [
         "src/content/index.ts"

--- a/test/extractors/e2e/__snapshots__/perplexity.e2e.test.ts.snap
+++ b/test/extractors/e2e/__snapshots__/perplexity.e2e.test.ts.snap
@@ -1,0 +1,140 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Perplexity E2E Extraction > Chat - Simple Conversation > should generate correct markdown output 1`] = `
+"---
+id: perplexity_e2e-perplexity-chat-001
+title: perplexityのhtml構造をテストするための質問です。「はい」とだけ答えて。
+source: perplexity
+url: "https://www.perplexity.ai/search/e2e-perplexity-chat-001"
+created: "2025-01-01T00:00:00.000Z"
+modified: "2025-01-01T00:00:00.000Z"
+tags:
+  - ai-conversation
+  - perplexity
+message_count: 4
+---
+
+> [!QUESTION] User
+> perplexityのhtml構造をテストするための質問です。「はい」とだけ答えて。
+
+> [!NOTE] Perplexity
+> はい。[perplexity](https://www.perplexity.ai)​
+
+> [!QUESTION] User
+> 次は「いいえ」だけ答えて
+
+> [!NOTE] Perplexity
+> いいえ。[reposub](https://reposub.jp/blogs/ai/perplexity_japanese)​"
+`;
+
+exports[`Perplexity E2E Extraction > Deep Research > should generate correct markdown output 1`] = `
+"---
+id: perplexity_e2e-perplexity-dr-001
+title: Perplexity の提供する機能についてまとめてください。
+source: perplexity
+url: "https://www.perplexity.ai/search/e2e-perplexity-dr-001"
+created: "2025-01-01T00:00:00.000Z"
+modified: "2025-01-01T00:00:00.000Z"
+tags:
+  - ai-conversation
+  - perplexity
+message_count: 2
+---
+
+> [!QUESTION] User
+> Perplexity の提供する機能についてまとめてください。
+
+> [!NOTE] Perplexity
+> ## Perplexity の提供する機能概要
+> 
+> Perplexity は、リアルタイム Web 検索と高度な AI を組み合わせた AI 駆動型検索エンジンです。以下、主要な機能をまとめました。
+> 
+> ## コア機能
+> 
+> **AI 駆動型リアルタイム検索**
+> 
+> Perplexity は Web をリアルタイムで検索し、複数の信頼できる情報源から情報を集約します。回答にはすべて引用元があり、ユーザーは元のソースを容易に確認できます。高度な言語モデル（GPT-5、Claude 4.0 Sonnet など）を活用して、質問の文脈と細微なニュアンスを理解し、明確で会話的な回答を提供します。[perplexity](https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work)​
+> 
+> **会話形式の対話**
+> 
+> Perplexity は専門家と会話するような方式で応答します。ユーザーはフォローアップ質問を行うことができ、AI は前の質問の文脈を記憶して、シームレスな会話を実現します。[perplexity](https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work)​
+> 
+> **メモリ機能**
+> 
+> 最近導入されたメモリ機能により、Perplexity は会話全体で重要な詳細を記憶し、今後の回答をより個人化・効率化します。[perplexity](https://www.perplexity.ai/hub/blog/introducing-ai-assistants-with-memory)​
+> 
+> ## 検索モード
+> 
+> | 検索モード | 説明 | 対応プラン |
+> | --- | --- | --- |
+> | 通常検索 | 基本的な検索モード | すべてのプラン |
+> | Pro Search | 複数のソースから徹底的なリサーチを行い、詳細で整理された回答を提供perplexity​ | Free（限定）、Pro 以上 |
+> | Deep Research（研究モード） | 数十回の自動検索を実行し、数百のソースを読み込み、2～4分で包括的なレポートを生成perplexity​ | Free（月1回）、Pro 以上 |
+> | Best モード | クエリに応じて最適なモデルを自動選択perplexity​ | すべてのプラン |
+> 
+> ## AI モデル選択
+> 
+> Pro 以上のユーザーは複数の先端 AI モデルから選択できます。[perplexity](https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro)​
+> 
+> | モデル | 特性 |
+> | --- | --- |
+> | Sonar | Llama 3.1 70B ベース。高速 Web 検索と要約に特化。高度な推論オプション有perplexity​ |
+> | GPT-5.2 | OpenAI の最新モデル。推論、コーディング、創造性に優れ、幻覚の削減perplexity​ |
+> | Claude Sonnet 4.5 | Anthropic のモデル。効率的なコーディングと技術的推論に長けるperplexity​ |
+> | Gemini 3 Pro | Google のモデル。マルチモーダル理解とコード生成に優れるperplexity​ |
+> | Grok 4.1 | xAI のモデル。テキストと画像に対応perplexity​ |
+> 
+> ## ファイル・コンテンツ管理
+> 
+> **Create files and apps（プロジェクト作成）**
+> 
+> Pro ユーザーは自然言語プロンプトでレポート、スプレッドシート、ダッシュボード、Web アプリケーションを作成できます。AI が研究、分析、情報の集約を自動で処理します。[perplexity](https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work)​
+> 
+> **ファイルアップロード・分析**
+> 
+> PDF、CSV、音声、ビデオ、画像など複数形式のファイルをアップロードし、AI で分析可能です。Pro ユーザーは最大 50 ファイルをスペースにアップロード可能。[perplexity](https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro)​
+> 
+> **ページ機能**
+> 
+> 研究をビジュアルに充実させたコンテンツに変換し、スタイリッシュな情報ページを作成できます。[perplexity](https://www.perplexity.ai/hub/blog/perplexity-pages)​
+> 
+> ## 画像・ビデオ生成
+> 
+> Pro 以上のユーザーは最新の画像・ビデオ生成モデルを使用でき、研究タスクや創造的なプロジェクトを支援します。Enterprise Max では毎月 15 本の 8 秒動画生成が可能。[perplexity+1](https://www.perplexity.ai/help-center/en/articles/11187416-which-perplexity-subscription-plan-is-right-for-you)
+> 
+> ## 内部知識検索
+> 
+> Enterprise ユーザーは Web 検索と組織内ファイルの並行検索が可能です。個別のソースを選択して「Web」「組織ファイル」「Web + 組織ファイル」「なし」から検索方法を選べます。[perplexity](https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features)​
+> 
+> ## その他の機能
+> 
+> **タスク機能**
+> 
+> Pro、Max、Enterprise Pro/Max ユーザーは定期的なアラートをスケジュール設定でき、特定のトピックについて継続的に監視できます。[perplexity](https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features)​
+> 
+> **Comet ブラウザアシスタント**
+> 
+> Perplexity 独自のブラウザで、ブラウザ内でタスクを実行でき、Web を探索しながら質問に答える機能を提供。[perplexity](https://www.perplexity.ai/hub/getting-started)​
+> 
+> **Instant Buy**
+> 
+> 米国ユーザーは Perplexity から直接製品を検索・購入できるシームレスなチェックアウト機能。[perplexity](https://www.perplexity.ai/help-center/en/collections/8935108-perplexity-pro-and-max)​
+> 
+> **Pro Perks プログラム**
+> 
+> Pro ユーザーは旅行、健康・ウェルネス、金融など複数カテゴリーの提携ブランドから独占的なオファーと割引を受け取ります。[perplexity](https://www.perplexity.ai/hub/blog/more-value-in-every-answer-new-benefits-for-every-level-of-perplexity-user)​
+> 
+> ## API とプログラマティックアクセス
+> 
+> **Sonar API**
+> 
+> 開発者向けに軽量で低コストな API を提供し、引用機能とカスタムソース機能を含みます。[perplexity](https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api)​
+> 
+> ## 訂正機能とスペース
+> 
+> **スペース**
+> 
+> チーム協力のための専用スペースを作成でき、カスタム知識ハブと内部ファイル検索が可能です。[perplexity](https://www.perplexity.ai/help-center/en/articles/11187416-which-perplexity-subscription-plan-is-right-for-you)​
+> 
+> Perplexity はこれらの機能を通じて、従来の検索エンジンとの差別化を図り、研究、コンテンツ作成、情報分析の効率化を実現しています。"
+`;

--- a/test/extractors/e2e/helpers.ts
+++ b/test/extractors/e2e/helpers.ts
@@ -15,10 +15,11 @@ import type {
   NoteFrontmatter,
 } from '../../../src/lib/types';
 
-import { loadFixture, setGeminiLocation, setClaudeLocation, setChatGPTLocation } from '../../fixtures/dom-helpers';
+import { loadFixture, setGeminiLocation, setClaudeLocation, setChatGPTLocation, setPerplexityLocation } from '../../fixtures/dom-helpers';
 import { GeminiExtractor } from '../../../src/content/extractors/gemini';
 import { ClaudeExtractor } from '../../../src/content/extractors/claude';
 import { ChatGPTExtractor } from '../../../src/content/extractors/chatgpt';
+import { PerplexityExtractor } from '../../../src/content/extractors/perplexity';
 import { conversationToNote } from '../../../src/content/markdown';
 import { generateNoteContent } from '../../../src/lib/note-generator';
 
@@ -116,7 +117,7 @@ export const DEFAULT_E2E_SETTINGS: ExtensionSettings = {
  * @throws Error if fixture file does not exist
  */
 export function loadFixtureFile(
-  platform: 'gemini' | 'claude' | 'chatgpt',
+  platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity',
   fixtureName: string
 ): string {
   const fixturePath = resolve(FIXTURE_BASE_PATH, platform, `${fixtureName}.html`);
@@ -140,7 +141,7 @@ export function loadFixtureFile(
  * Set window.location for platform
  */
 export function setLocationForPlatform(
-  platform: 'gemini' | 'claude' | 'chatgpt',
+  platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity',
   conversationId: string
 ): void {
   switch (platform) {
@@ -153,13 +154,16 @@ export function setLocationForPlatform(
     case 'chatgpt':
       setChatGPTLocation(conversationId);
       break;
+    case 'perplexity':
+      setPerplexityLocation(conversationId);
+      break;
   }
 }
 
 /**
  * Create extractor for platform
  */
-function createExtractor(platform: 'gemini' | 'claude' | 'chatgpt') {
+function createExtractor(platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity') {
   switch (platform) {
     case 'gemini':
       return new GeminiExtractor();
@@ -167,6 +171,8 @@ function createExtractor(platform: 'gemini' | 'claude' | 'chatgpt') {
       return new ClaudeExtractor();
     case 'chatgpt':
       return new ChatGPTExtractor();
+    case 'perplexity':
+      return new PerplexityExtractor();
   }
 }
 
@@ -182,7 +188,7 @@ function createExtractor(platform: 'gemini' | 'claude' | 'chatgpt') {
  * 6. generateNoteContent final output
  */
 export async function runE2EPipeline(
-  platform: 'gemini' | 'claude' | 'chatgpt',
+  platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity',
   fixtureName: string,
   conversationId: string,
   settings: ExtensionSettings = DEFAULT_E2E_SETTINGS
@@ -260,7 +266,7 @@ export function assertExtractionSuccess(
  */
 export function assertSourcePlatform(
   data: ConversationData,
-  expected: 'gemini' | 'claude' | 'chatgpt'
+  expected: 'gemini' | 'claude' | 'chatgpt' | 'perplexity'
 ): void {
   if (data.source !== expected) {
     throw new Error(
@@ -340,7 +346,7 @@ export function assertFrontmatterFields(
  */
 export function assertCalloutFormat(
   markdown: string,
-  _platform: 'gemini' | 'claude' | 'chatgpt'
+  _platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity'
 ): void {
   if (!markdown.includes('> [!QUESTION]')) {
     throw new Error('User callout (> [!QUESTION]) not found in output');

--- a/test/extractors/e2e/perplexity.e2e.test.ts
+++ b/test/extractors/e2e/perplexity.e2e.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  runE2EPipeline,
+  assertExtractionSuccess,
+  assertSourcePlatform,
+  assertMessageStructure,
+  assertFrontmatterFields,
+  assertCalloutFormat,
+} from './helpers';
+import { clearFixture, resetLocation } from '../../fixtures/dom-helpers';
+
+describe('Perplexity E2E Extraction', () => {
+  beforeEach(() => {
+    clearFixture();
+  });
+
+  afterEach(() => {
+    clearFixture();
+    resetLocation();
+  });
+
+  describe('Chat - Simple Conversation', () => {
+    const FIXTURE = 'chat-simple';
+    const CONVERSATION_ID = 'e2e-perplexity-chat-001';
+
+    it('should extract conversation with valid structure', async () => {
+      const result = await runE2EPipeline('perplexity', FIXTURE, CONVERSATION_ID);
+      assertExtractionSuccess(result);
+
+      assertSourcePlatform(result.conversationData, 'perplexity');
+      assertMessageStructure(result.conversationData, { minCount: 2 });
+      assertFrontmatterFields(result.obsidianNote);
+      assertCalloutFormat(result.finalMarkdown, 'perplexity');
+    });
+
+    it('should generate correct markdown output', async () => {
+      const result = await runE2EPipeline('perplexity', FIXTURE, CONVERSATION_ID);
+      assertExtractionSuccess(result);
+
+      expect(result.finalMarkdown).toMatchSnapshot();
+    });
+  });
+
+  describe('Deep Research', () => {
+    const FIXTURE = 'deep-research';
+    const CONVERSATION_ID = 'e2e-perplexity-dr-001';
+
+    it('should extract deep research as normal conversation', async () => {
+      const result = await runE2EPipeline('perplexity', FIXTURE, CONVERSATION_ID);
+      assertExtractionSuccess(result);
+
+      assertSourcePlatform(result.conversationData, 'perplexity');
+      expect(result.conversationData.type).not.toBe('deep-research');
+      assertMessageStructure(result.conversationData, { minCount: 1 });
+    });
+
+    it('should generate correct markdown output', async () => {
+      const result = await runE2EPipeline('perplexity', FIXTURE, CONVERSATION_ID);
+      assertExtractionSuccess(result);
+
+      expect(result.finalMarkdown).toMatchSnapshot();
+    });
+  });
+});

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PerplexityExtractor } from '../../src/content/extractors/perplexity';
+import {
+  loadFixture,
+  clearFixture,
+  resetLocation,
+  createPerplexityConversationDOM,
+  setPerplexityLocation,
+  setNonPerplexityLocation,
+  createPerplexityInlineCitation,
+  createPerplexityPage,
+} from '../fixtures/dom-helpers';
+
+describe('PerplexityExtractor', () => {
+  let extractor: PerplexityExtractor;
+
+  beforeEach(() => {
+    extractor = new PerplexityExtractor();
+    clearFixture();
+  });
+
+  afterEach(() => {
+    clearFixture();
+    resetLocation();
+  });
+
+  // ========== Platform Detection ==========
+  describe('Platform Detection', () => {
+    describe('platform', () => {
+      it('identifies as perplexity platform', () => {
+        expect(extractor.platform).toBe('perplexity');
+      });
+    });
+
+    describe('canExtract', () => {
+      it('returns true for www.perplexity.ai', () => {
+        setPerplexityLocation('test-slug-abc123');
+        expect(extractor.canExtract()).toBe(true);
+      });
+
+      it('returns false for perplexity.ai (no www)', () => {
+        setNonPerplexityLocation('perplexity.ai');
+        expect(extractor.canExtract()).toBe(false);
+      });
+
+      it('returns false for evil.www.perplexity.ai.attacker.com', () => {
+        setNonPerplexityLocation('evil.www.perplexity.ai.attacker.com');
+        expect(extractor.canExtract()).toBe(false);
+      });
+
+      it('returns false for other domains', () => {
+        setNonPerplexityLocation('chatgpt.com');
+        expect(extractor.canExtract()).toBe(false);
+      });
+    });
+  });
+
+  // ========== URL Extraction ==========
+  describe('Conversation ID Extraction', () => {
+    it('extracts slug from /search/{slug} URL', () => {
+      setPerplexityLocation('perplexitynohtmlgou-zao-wotesu-Y8vT04G0SKap6aQTA8L6hg');
+      expect(extractor.getConversationId()).toBe(
+        'perplexitynohtmlgou-zao-wotesu-Y8vT04G0SKap6aQTA8L6hg'
+      );
+    });
+
+    it('extracts slug with URL-encoded characters', () => {
+      setPerplexityLocation('da-shou-ting-toraba-CG5SwgBvRti46_Hs1jFYAw');
+      expect(extractor.getConversationId()).toBe(
+        'da-shou-ting-toraba-CG5SwgBvRti46_Hs1jFYAw'
+      );
+    });
+
+    it('returns null for non-search paths', () => {
+      setNonPerplexityLocation('www.perplexity.ai', '/hub');
+      expect(extractor.getConversationId()).toBeNull();
+    });
+
+    it('returns null for root path', () => {
+      setNonPerplexityLocation('www.perplexity.ai', '/');
+      expect(extractor.getConversationId()).toBeNull();
+    });
+  });
+
+  // ========== Title Extraction ==========
+  describe('Title Extraction', () => {
+    it('returns first user query text', () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'What is TypeScript?' },
+        { role: 'assistant', content: '<p>TypeScript is...</p>' },
+      ]);
+      expect(extractor.getTitle()).toBe('What is TypeScript?');
+    });
+
+    it('truncates long titles to 100 characters', () => {
+      setPerplexityLocation('test-slug');
+      const longTitle = 'a'.repeat(150);
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: longTitle },
+        { role: 'assistant', content: '<p>Response</p>' },
+      ]);
+      expect(extractor.getTitle().length).toBe(100);
+    });
+
+    it('returns default title when no queries found', () => {
+      setPerplexityLocation('test-slug');
+      loadFixture('<div>Empty page</div>');
+      expect(extractor.getTitle()).toBe('Untitled Perplexity Conversation');
+    });
+  });
+
+  // ========== Message Extraction ==========
+  describe('Message Extraction', () => {
+    it('extracts paired user/assistant messages', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Hello Perplexity' },
+        { role: 'assistant', content: '<p>Hello! How can I help?</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(2);
+      expect(result.data?.messages[0].role).toBe('user');
+      expect(result.data?.messages[1].role).toBe('assistant');
+    });
+
+    it('handles multi-turn conversations', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Question 1' },
+        { role: 'assistant', content: '<p>Answer 1</p>' },
+        { role: 'user', content: 'Question 2' },
+        { role: 'assistant', content: '<p>Answer 2</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(4);
+    });
+
+    it('returns empty array when no content found', () => {
+      setPerplexityLocation('test-slug');
+      loadFixture('<div class="empty-page"></div>');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const messages = extractor.extractMessages();
+
+      expect(messages).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No conversation content found')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('preserves HTML content for assistant messages', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Test' },
+        { role: 'assistant', content: '<p>Response with <strong>bold</strong> text</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.htmlContent).toContain('<strong>');
+    });
+
+    it('handles query without response (pending)', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Pending question' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(1);
+      expect(result.data?.messages[0].role).toBe('user');
+      expect(result.warnings).toContain('No assistant messages found');
+    });
+  });
+
+  // ========== Citation Handling ==========
+  describe('Citation Handling', () => {
+    it('preserves <a href> links after sanitization', async () => {
+      setPerplexityLocation('test-slug');
+      const citationHtml = createPerplexityInlineCitation(
+        'https://example.com',
+        'example'
+      );
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Test citations' },
+        { role: 'assistant', content: `<p>Here is a citation ${citationHtml}</p>` },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).toContain('href="https://example.com"');
+      expect(assistantMsg?.content).toContain('example');
+      // data-pplx-* attributes should be stripped by DOMPurify
+      expect(assistantMsg?.content).not.toContain('data-pplx');
+    });
+  });
+
+  // ========== Full Extraction ==========
+  describe('Full Extraction', () => {
+    it('returns success with valid data', async () => {
+      setPerplexityLocation('test-slug-abc123');
+      createPerplexityPage('test-slug-abc123', [
+        { role: 'user', content: 'Test question' },
+        { role: 'assistant', content: '<p>Test answer</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data?.messages.length).toBe(2);
+    });
+
+    it('sets source to perplexity', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Test' },
+        { role: 'assistant', content: '<p>Response</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.source).toBe('perplexity');
+    });
+
+    it('returns failure when not on Perplexity page', async () => {
+      resetLocation();
+      const result = await extractor.extract();
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Not on a Perplexity page');
+    });
+
+    it('handles empty conversation', async () => {
+      setPerplexityLocation('test-slug');
+      loadFixture('<div class="empty-page"></div>');
+      const result = await extractor.extract();
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No messages found');
+    });
+
+    it('generates fallback ID when URL parsing fails', async () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          hostname: 'www.perplexity.ai',
+          pathname: '/pro',
+          href: 'https://www.perplexity.ai/pro',
+        },
+        writable: true,
+        configurable: true,
+      });
+      loadFixture(createPerplexityConversationDOM([
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: '<p>Hi!</p>' },
+      ]));
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.id).toMatch(/^perplexity-\d+$/);
+    });
+
+    it('sets correct metadata', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Question' },
+        { role: 'assistant', content: '<pre><code>console.log("test")</code></pre>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.metadata.messageCount).toBe(2);
+      expect(result.data?.metadata.userMessageCount).toBe(1);
+      expect(result.data?.metadata.assistantMessageCount).toBe(1);
+      expect(result.data?.metadata.hasCodeBlocks).toBe(true);
+    });
+  });
+
+  // ========== Security Tests ==========
+  describe('Security', () => {
+    it('sanitizes XSS script tags in assistant content', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Test' },
+        { role: 'assistant', content: '<script>alert("xss")</script><p>Safe content</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).not.toContain('<script>');
+      expect(assistantMsg?.content).toContain('Safe content');
+    });
+
+    it('sanitizes XSS onerror attributes in content', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: 'Test' },
+        { role: 'assistant', content: '<img src="x" onerror="alert(1)"><p>Safe</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).not.toContain('onerror');
+    });
+  });
+
+  // ========== Error Handling ==========
+  describe('Error Handling', () => {
+    it('returns error with Error.message in catch block', async () => {
+      setPerplexityLocation('test-slug');
+      const originalQSA = document.querySelectorAll.bind(document);
+      vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
+        if (typeof selector === 'string' && selector.includes('select-text')) {
+          throw new Error('DOM access failed');
+        }
+        return originalQSA(selector);
+      });
+
+      const result = await extractor.extract();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('DOM access failed');
+      vi.restoreAllMocks();
+    });
+
+    it('returns stringified error for non-Error throw in catch block', async () => {
+      setPerplexityLocation('test-slug');
+      const originalQSA = document.querySelectorAll.bind(document);
+      vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
+        if (typeof selector === 'string' && selector.includes('select-text')) {
+          throw 'string error';
+        }
+        return originalQSA(selector);
+      });
+
+      const result = await extractor.extract();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('string error');
+      vi.restoreAllMocks();
+    });
+  });
+
+  // ========== Unicode Content ==========
+  describe('Edge Cases', () => {
+    it('handles unicode content', async () => {
+      setPerplexityLocation('test-slug');
+      createPerplexityPage('test-slug', [
+        { role: 'user', content: '日本語テスト 🎉 emoji test' },
+        { role: 'assistant', content: '<p>こんにちは！</p>' },
+      ]);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages[0].content).toContain('日本語');
+    });
+  });
+});

--- a/test/fixtures/html/perplexity/chat-simple.html
+++ b/test/fixtures/html/perplexity/chat-simple.html
@@ -1,0 +1,2377 @@
+<div class="mx-auto flex w-full flex-col h-full">
+  <div dir="ltr" data-orientation="horizontal" class="contents">
+    <div></div>
+    <div
+      class="h-headerHeight !bg-base/95 @container/header pointer-events-none inset-x-0 top-0 transition-none md:mb-0 relative max-[970px]:md:bg-base border-subtlest ring-subtlest divide-subtlest bg-transparent"
+    >
+      <div
+        class="flex size-full items-center"
+        style="
+          gap: 16px;
+          --left-width: 54px;
+          --expanded-tabs-width: 246.046875px;
+          --gap: 16px;
+          --scrollbar-gutter-offset: 0px;
+          --page-content-width: 720px;
+        "
+      >
+        <div class="pl-md flex-shrink-0" style="width: 54px">
+          <div class="gap-x-sm flex size-full min-w-0 items-center justify-start self-stretch">
+            <div class="pointer-events-auto relative flex items-center">
+              <div class="gap-sm flex min-w-0 items-center">
+                <span class="inline-flex pb-xs -mb-xs"
+                  ><div class="group relative flex cursor-pointer items-center gap-0.5">
+                    <div
+                      class="group-hover:!bg-subtle -inset-three absolute rounded-full duration-150 border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                    ></div>
+                    <div class="relative isolate flex items-center gap-0">
+                      <div
+                        class="text-inverse relative relative z-10 select-none [&amp;&gt;*]:size-6"
+                      >
+                        <div
+                          class="relative flex aspect-square shrink-0 items-center justify-center bg-subtler rounded-full size-5"
+                        >
+                          <div
+                            class="flex items-center justify-center font-sans text-base text-quiet selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                          >
+                            <svg
+                              role="img"
+                              class="inline-flex fill-current shrink-0 size-[65%]"
+                              width="20"
+                              height="20"
+                            >
+                              <use xlink:href="#pplx-icon-user-filled"></use>
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <svg
+                      role="img"
+                      class="inline-flex fill-current shrink-0 group-hover:text-quiet relative size-3 transition-all duration-150 text-quietest"
+                      width="20"
+                      height="20"
+                    >
+                      <use xlink:href="#pplx-icon-chevron-down"></use>
+                    </svg></div
+                ></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pointer-events-none invisible absolute left-[-9999px] top-0 inline-block pl-md"
+          aria-hidden="true"
+        >
+          <div class="gap-x-sm flex size-full min-w-0 items-center justify-start self-stretch">
+            <div class="pointer-events-auto relative flex items-center">
+              <div class="gap-sm flex min-w-0 items-center">
+                <span class="inline-flex pb-xs -mb-xs"
+                  ><div class="group relative flex cursor-pointer items-center gap-0.5">
+                    <div
+                      class="group-hover:!bg-subtle -inset-three absolute rounded-full duration-150 border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                    ></div>
+                    <div class="relative isolate flex items-center gap-0">
+                      <div
+                        class="text-inverse relative relative z-10 select-none [&amp;&gt;*]:size-6"
+                      >
+                        <div
+                          class="relative flex aspect-square shrink-0 items-center justify-center bg-subtler rounded-full size-5"
+                        >
+                          <div
+                            class="flex items-center justify-center font-sans text-base text-quiet selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                          >
+                            <svg
+                              role="img"
+                              class="inline-flex fill-current shrink-0 size-[65%]"
+                              width="20"
+                              height="20"
+                            >
+                              <use xlink:href="#pplx-icon-user-filled"></use>
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <svg
+                      role="img"
+                      class="inline-flex fill-current shrink-0 group-hover:text-quiet relative size-3 transition-all duration-150 text-quietest"
+                      width="20"
+                      height="20"
+                    >
+                      <use xlink:href="#pplx-icon-chevron-down"></use>
+                    </svg></div
+                ></span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex h-full min-w-0 flex-1 items-center [container-name:tabbar] [container-type:inline-size] [margin-left:max(0px,calc((100%-var(--page-content-width))/2-var(--left-width)-var(--gap)-var(--scrollbar-gutter-offset)/2))] opacity-100"
+        >
+          <div
+            class="hideScroll pointer-events-auto inline-flex h-full items-end overflow-x-auto"
+            style="gap: 20px"
+          >
+            <div
+              role="tablist"
+              aria-orientation="horizontal"
+              aria-label="Answer mode tabs"
+              class="flex flex-row flex-nowrap h-[54px] gap-5 relative"
+              tabindex="0"
+              data-orientation="horizontal"
+              style="outline: none"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="radix-:r9i:-content-default"
+                data-state="active"
+                id="radix-:r9i:-trigger-default"
+                class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                tabindex="-1"
+                data-orientation="horizontal"
+                data-radix-collection-item=""
+              >
+                <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                  <use xlink:href="#pplx-icon-custom-perplexity-mark"></use></svg
+                >Answer
+              </button>
+              <div
+                class="pointer-events-none invisible absolute left-[-9999px] top-0 inline-block"
+                aria-hidden="true"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="radix-:r9i:-content-default"
+                  data-state="active"
+                  id="radix-:r9i:-trigger-default"
+                  class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                  tabindex="-1"
+                  data-orientation="horizontal"
+                  data-radix-collection-item=""
+                >
+                  <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                    <use xlink:href="#pplx-icon-custom-perplexity-mark"></use></svg
+                  >Answer
+                </button>
+              </div>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="radix-:r9i:-content-sources"
+                data-state="inactive"
+                id="radix-:r9i:-trigger-sources"
+                class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                tabindex="-1"
+                data-orientation="horizontal"
+                data-radix-collection-item=""
+              >
+                <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                  <use xlink:href="#pplx-icon-world"></use></svg
+                >Links
+              </button>
+              <div
+                class="pointer-events-none invisible absolute left-[-9999px] top-0 inline-block"
+                aria-hidden="true"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="radix-:r9i:-content-sources"
+                  data-state="inactive"
+                  id="radix-:r9i:-trigger-sources"
+                  class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                  tabindex="-1"
+                  data-orientation="horizontal"
+                  data-radix-collection-item=""
+                >
+                  <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                    <use xlink:href="#pplx-icon-world"></use></svg
+                  >Links
+                </button>
+              </div>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="radix-:r9i:-content-images"
+                data-state="inactive"
+                id="radix-:r9i:-trigger-images"
+                class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                tabindex="-1"
+                data-orientation="horizontal"
+                data-radix-collection-item=""
+              >
+                <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                  <use xlink:href="#pplx-icon-photo"></use></svg
+                >Images
+              </button>
+              <div
+                class="pointer-events-none invisible absolute left-[-9999px] top-0 inline-block"
+                aria-hidden="true"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="radix-:r9i:-content-images"
+                  data-state="inactive"
+                  id="radix-:r9i:-trigger-images"
+                  class="group reset interactable font-sans font-medium select-none transition-colors duration-300 relative flex gap-1.5 items-center text-sm text-foreground data-[state=inactive]:opacity-80 data-[state=active]:opacity-100 cursor-pointer py-3.5 data-[state=inactive]:hover:opacity-100"
+                  tabindex="-1"
+                  data-orientation="horizontal"
+                  data-radix-collection-item=""
+                >
+                  <svg role="img" class="inline-flex fill-current shrink-0" width="18" height="18">
+                    <use xlink:href="#pplx-icon-photo"></use></svg
+                  >Images
+                </button>
+              </div>
+              <span
+                class="absolute bottom-0 h-two bg-inverse pointer-events-none transition-[transform,width,opacity] duration-300 ease-in-out"
+                aria-hidden="true"
+                style="transform: translateX(0px); width: 73.8281px; opacity: 1"
+              ></span>
+            </div>
+          </div>
+        </div>
+        <div class="pr-md flex-shrink-0">
+          <div class="gap-x-sm pointer-events-auto relative flex min-w-0 items-center justify-end">
+            <div>
+              <button
+                data-state="closed"
+                aria-label="Thread actions"
+                aria-expanded="false"
+                aria-haspopup="menu"
+                type="button"
+                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex hover:text-foreground hover:bg-subtle px-3 rounded-lg"
+              >
+                <svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16">
+                  <use xlink:href="#pplx-icon-dots"></use>
+                </svg>
+              </button>
+            </div>
+            <div
+              class="transition-all duration-300 flex items-center gap-x-xs md:gap-x-0 opacity-100"
+            >
+              <span
+                ><button
+                  type="button"
+                  class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:bg-subtler data-[state=open]:border-subtle text-quiet border border-solid border-subtler bg-base h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex hover:bg-subtler hover:border-subtle px-3 rounded-lg relative"
+                >
+                  <div
+                    class="flex items-center -ml-0.5"
+                    style="opacity: 1; transition: opacity 150ms 150ms"
+                  >
+                    <svg
+                      role="img"
+                      class="inline-flex fill-current shrink-0"
+                      width="16"
+                      height="16"
+                    >
+                      <use xlink:href="#pplx-icon-share-3"></use>
+                    </svg>
+                  </div>
+                  <span
+                    class="text-box-trim-both pl-1"
+                    style="opacity: 1; transition: opacity 150ms 150ms"
+                    >Share</span
+                  >
+                  <div
+                    class="absolute inset-0 flex items-center justify-center"
+                    style="opacity: 0; transition: opacity 150ms"
+                  ></div></button
+              ></span>
+            </div>
+            <div class="">
+              <button
+                type="button"
+                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:opacity-80 text-inverse bg-super border border-transparent visRefresh2026Colors:bg-button-bg visRefresh2026Colors:shadow-button-primary dark:visRefresh2026Colors:shadow-button-primary-dark h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex hover:opacity-80 px-3 rounded-lg relative"
+              >
+                <div
+                  class="flex items-center -ml-0.5"
+                  style="opacity: 1; transition: opacity 150ms 150ms"
+                >
+                  <svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16">
+                    <use xlink:href="#pplx-icon-download"></use>
+                  </svg>
+                </div>
+                <span
+                  class="text-box-trim-both pl-1"
+                  style="opacity: 1; transition: opacity 150ms 150ms"
+                  >Download Comet</span
+                >
+                <div
+                  class="absolute inset-0 flex items-center justify-center"
+                  style="opacity: 0; transition: opacity 150ms"
+                ></div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="absolute bottom-0 inset-x-0 border-b border-subtlest ring-subtlest divide-subtlest bg-transparent"
+      ></div>
+    </div>
+    <div
+      class="scrollable-container flex flex-1 basis-0 overflow-auto [scrollbar-gutter:stable] scrollbar-subtle"
+    >
+      <div class="mx-auto size-full max-w-none">
+        <div class="erp-sidecar:h-fit erp-sidecar:pb-0 mx-auto h-full">
+          <div class="relative border-subtlest ring-subtlest divide-subtlest bg-base">
+            <div class="px-md md:px-lg overflow-hidden">
+              <div class="max-w-threadContentWidth mx-auto"></div>
+            </div>
+            <div>
+              <div>
+                <div>
+                  <div class="" style="margin-top: 0px; padding-bottom: 0px">
+                    <div
+                      class="pt-[var(--thread-visual-spacing)] md:pt-lg pb-[var(--thread-visual-spacing)] px-[var(--thread-visual-spacing)] border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                    >
+                      <div class="isolate mx-auto flex flex-col max-w-threadContentWidth">
+                        <div
+                          data-state="active"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-default"
+                          id="radix-:r9i:-content-default"
+                          tabindex="0"
+                          class="focus:outline-none"
+                          style=""
+                        >
+                          <div class="flex flex-col gap-y-lg">
+                            <div
+                              class="bg-base erp-sidecar:pt-0 erp-mobile-sidecar:pt-0"
+                              style="opacity: 1; transform: none"
+                            >
+                              <div class="mx-auto max-w-threadContentWidth">
+                                <div class="max-w-threadContentWidth relative isolate z-20 mx-auto">
+                                  <div class="relative z-10">
+                                    <div class="group relative flex items-end gap-0.5">
+                                      <div
+                                        class="-inset-md pointer-events-none absolute select-none"
+                                      ></div>
+                                      <div class="relative min-w-0 flex-1 flex justify-end">
+                                        <div class="flex items-start gap-2">
+                                          <div
+                                            class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 sticky top-sm py-sm pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+                                            aria-hidden="false"
+                                          >
+                                            <button
+                                              aria-label="Edit Query"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-pencil"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              aria-label="Copy Query"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-copy"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div>
+                                            </button>
+                                          </div>
+                                          <div class="group/title relative inline-flex flex-col">
+                                            <div>
+                                              <div
+                                                style="
+                                                  transition: none;
+                                                  overflow: hidden;
+                                                  height: 48px;
+                                                "
+                                              >
+                                                <div>
+                                                  <h1
+                                                    class="group/query relative whitespace-pre-line !text-wrap break-words [word-break:break-word] font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                  >
+                                                    <div
+                                                      class="flex min-w-[48px] items-center justify-center bg-offset text-foreground rounded-2xl p-3 font-sans text-base font-normal select-none max-w-[600px]"
+                                                    >
+                                                      <span
+                                                        class="select-text"
+                                                        style="overflow-wrap: anywhere"
+                                                        >perplexityのhtml構造をテストするための質問です。「はい」とだけ答えて。</span
+                                                      >
+                                                    </div>
+                                                  </h1>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="gap-y-lg flex flex-col">
+                              <div
+                                dir="ltr"
+                                data-orientation="horizontal"
+                                class="grid w-full min-w-0 grid-cols-[minmax(0,1fr)]"
+                              >
+                                <div class="col-start-1 row-start-2" style="opacity: 1">
+                                  <div
+                                    data-state="active"
+                                    data-orientation="horizontal"
+                                    role="tabpanel"
+                                    aria-labelledby="radix-:r9q:-trigger-thread"
+                                    id="radix-:r9q:-content-thread"
+                                    tabindex="0"
+                                    class="focus:outline-none"
+                                    style=""
+                                  >
+                                    <div
+                                      class="border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                    >
+                                      <div class="gap-y-md flex flex-col">
+                                        <div class="flex flex-col gap-sm">
+                                          <div class="flex items-center gap-x-md justify-between">
+                                            <div
+                                              class="flex items-center gap-x-md justify-between w-full"
+                                            >
+                                              <button
+                                                type="button"
+                                                class="reset interactable gap-x-0.5 select-none inline-flex items-center whitespace-nowrap text-quiet text-sm self-start hover:opacity-75 duration-quick rounded-md"
+                                              >
+                                                Reviewed 10 sources<span
+                                                  class="duration-quick transition-transform ease-in-out text-quiet inline-flex rotate-0"
+                                                  ><svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="14"
+                                                    height="14"
+                                                  >
+                                                    <use
+                                                      xlink:href="#pplx-icon-chevron-right"
+                                                    ></use></svg
+                                                ></span>
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="relative font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                        >
+                                          <div class="min-w-0 break-words [word-break:break-word]">
+                                            <div
+                                              dir="auto"
+                                              id="markdown-content-0"
+                                              class="gap-y-md after:clear-both after:block after:content-['']"
+                                            >
+                                              <div
+                                                class="has-inline-images my-2 first:mt-0 [&amp;:has([data-inline-type=image])+&amp;:has([data-inline-type=image])_[data-inline-type=image]]:hidden [&amp;:has(table)_[data-inline-type=image]]:hidden"
+                                              >
+                                                <div class="relative">
+                                                  <div
+                                                    class="prose dark:prose-invert inline leading-relaxed break-words min-w-0 [word-break:break-word] prose-strong:font-medium visRefresh2026Fonts:prose-strong:font-bold [&amp;_&gt;*:first-child]:mt-0"
+                                                  >
+                                                    <p
+                                                      class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                                    >
+                                                      はい。<span class="citation-nbsp"></span
+                                                      ><span
+                                                        class="inline-flex"
+                                                        aria-label="Perplexity AI"
+                                                        data-state="closed"
+                                                        ><span
+                                                          class="citation inline"
+                                                          data-pplx-citation=""
+                                                          data-pplx-citation-url="https://www.perplexity.ai"
+                                                          rel="nofollow noopener"
+                                                          ><a
+                                                            rel="noopener"
+                                                            class="inline-flex max-w-full min-w-0"
+                                                            target="_blank"
+                                                            href="https://www.perplexity.ai"
+                                                            ><span
+                                                              class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                              ><span
+                                                                class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                                ><span
+                                                                  class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                                  >perplexity</span
+                                                                ></span
+                                                              ></span
+                                                            ></a
+                                                          ></span
+                                                        >​</span
+                                                      >
+                                                    </p>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                          <div
+                                            class="-ml-sm gap-xs flex flex-shrink-0 items-center"
+                                          >
+                                            <button
+                                              aria-label="Share"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-share-3"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              data-state="closed"
+                                              aria-label="Download"
+                                              aria-expanded="false"
+                                              aria-haspopup="menu"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-download"></use>
+                                              </svg></button
+                                            ><button
+                                              aria-label="Copy"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-copy"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              data-state="closed"
+                                              aria-label="Rewrite"
+                                              aria-expanded="false"
+                                              aria-haspopup="menu"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-repeat"></use>
+                                              </svg>
+                                            </button>
+                                            <div class="rounded-full">
+                                              <button
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full hover:text-foreground hover:bg-subtle px-3 relative"
+                                              >
+                                                <span
+                                                  class="text-box-trim-both"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                  ><div
+                                                    class="text-quiet font-normal gap-x-sm flex flex-row -ml-0.5"
+                                                  >
+                                                    <svg
+                                                      width="14"
+                                                      height="14"
+                                                      viewBox="0 0 24 24"
+                                                      fill="none"
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                      class="absolute opacity-0"
+                                                    >
+                                                      <defs>
+                                                        <clipPath id="clip-path-default">
+                                                          <path
+                                                            fill-rule="evenodd"
+                                                            clip-rule="evenodd"
+                                                            d="M10.0635 0.704214C9.13824 0.253115 8.09868 0 7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14C8.09868 14 9.13824 13.7469 10.0635 13.2958C8.19825 11.8312 7 9.55552 7 7C7 4.44448 8.19825 2.16882 10.0635 0.704214Z"
+                                                            fill="#D9D9D9"
+                                                          ></path>
+                                                        </clipPath>
+                                                      </defs></svg
+                                                    ><svg
+                                                      width="12"
+                                                      height="12"
+                                                      viewBox="0 0 12 12"
+                                                      fill="none"
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                      class="absolute opacity-0"
+                                                    >
+                                                      <defs>
+                                                        <clipPath id="clip-path-small">
+                                                          <path
+                                                            fill-rule="evenodd"
+                                                            clip-rule="evenodd"
+                                                            d="M8.57242 0.57787C7.7928 0.20734 6.92062 0 6 0C2.68629 0 0 2.68629 0 6C0 9.31371 2.68629 12 6 12C6.92062 12 7.7928 11.7927 8.57242 11.4221C7.00228 10.1385 6 8.18628 6 6C6 3.81372 7.00228 1.86154 8.57242 0.57787Z"
+                                                            fill="#D9D9D9"
+                                                          ></path>
+                                                        </clipPath>
+                                                      </defs>
+                                                    </svg>
+                                                    <div
+                                                      class="gap-xs relative flex shrink-0 items-center"
+                                                    >
+                                                      <div class="ml-xs flex">
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                          style="
+                                                            clip-path: url('#clip-path-default');
+                                                          "
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="perplexity.ai favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=perplexity.ai"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                          style="
+                                                            clip-path: url('#clip-path-default');
+                                                          "
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="unintelligence.ai favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=unintelligence.ai"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="brightdata.com favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=brightdata.com"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                    10 sources
+                                                  </div></span
+                                                >
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </button>
+                                            </div>
+                                          </div>
+                                          <div class="gap-x-xs flex flex-shrink-0 items-center">
+                                            <div
+                                              class="gap-xs flex items-center border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                            >
+                                              <button
+                                                aria-label="Helpful"
+                                                data-state="closed"
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                              >
+                                                <div
+                                                  class="relative flex items-center justify-center"
+                                                >
+                                                  <div
+                                                    class="inline-flex"
+                                                    style="
+                                                      opacity: 1;
+                                                      transition: opacity 150ms 150ms;
+                                                    "
+                                                  >
+                                                    <svg
+                                                      role="img"
+                                                      class="inline-flex fill-current shrink-0"
+                                                      width="16"
+                                                      height="16"
+                                                    >
+                                                      <use xlink:href="#pplx-icon-thumb-up"></use>
+                                                    </svg>
+                                                  </div>
+                                                  <div
+                                                    class="absolute inset-0 flex items-center justify-center"
+                                                    style="opacity: 0; transition: opacity 150ms"
+                                                  ></div>
+                                                </div></button
+                                              ><button
+                                                aria-label="Not helpful"
+                                                data-state="closed"
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                              >
+                                                <div
+                                                  class="relative flex items-center justify-center"
+                                                >
+                                                  <div
+                                                    class="inline-flex"
+                                                    style="
+                                                      opacity: 1;
+                                                      transition: opacity 150ms 150ms;
+                                                    "
+                                                  >
+                                                    <svg
+                                                      role="img"
+                                                      class="inline-flex fill-current shrink-0"
+                                                      width="16"
+                                                      height="16"
+                                                    >
+                                                      <use xlink:href="#pplx-icon-thumb-down"></use>
+                                                    </svg>
+                                                  </div>
+                                                  <div
+                                                    class="absolute inset-0 flex items-center justify-center"
+                                                    style="opacity: 0; transition: opacity 150ms"
+                                                  ></div>
+                                                </div>
+                                              </button>
+                                            </div>
+                                            <div>
+                                              <button
+                                                data-state="closed"
+                                                aria-label="More actions"
+                                                aria-expanded="false"
+                                                aria-haspopup="menu"
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                              >
+                                                <svg
+                                                  role="img"
+                                                  class="inline-flex fill-current shrink-0"
+                                                  width="16"
+                                                  height="16"
+                                                >
+                                                  <use xlink:href="#pplx-icon-dots"></use>
+                                                </svg>
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div class="gap-y-lg flex flex-col first:mt-0"></div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-shopping"
+                          hidden=""
+                          id="radix-:r9i:-content-shopping"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-hotels"
+                          hidden=""
+                          id="radix-:r9i:-content-hotels"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-places"
+                          hidden=""
+                          id="radix-:r9i:-content-places"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-jobs"
+                          hidden=""
+                          id="radix-:r9i:-content-jobs"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-videos"
+                          hidden=""
+                          id="radix-:r9i:-content-videos"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-images"
+                          hidden=""
+                          id="radix-:r9i:-content-images"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-sources"
+                          hidden=""
+                          id="radix-:r9i:-content-sources"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-assets"
+                          hidden=""
+                          id="radix-:r9i:-content-assets"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-news"
+                          hidden=""
+                          id="radix-:r9i:-content-news"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div>
+                  <div
+                    class="erp-sidecar:min-h-[var(--sidecar-content-height)] erp-mobile-sidecar:min-h-[var(--mobile-sidecar-content-height)] min-h-[var(--page-content-height)]"
+                    style="margin-top: 0px; padding-bottom: 130px"
+                  >
+                    <div
+                      class="pt-[var(--thread-visual-spacing)] md:pt-lg pb-[var(--thread-visual-spacing)] px-[var(--thread-visual-spacing)] border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                    >
+                      <div class="isolate mx-auto flex flex-col max-w-threadContentWidth">
+                        <div
+                          data-state="active"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-default"
+                          id="radix-:r9i:-content-default"
+                          tabindex="0"
+                          class="focus:outline-none"
+                          style=""
+                        >
+                          <div class="flex flex-col gap-y-lg">
+                            <div
+                              class="bg-base erp-sidecar:pt-0 erp-mobile-sidecar:pt-0"
+                              style="opacity: 1; transform: none"
+                            >
+                              <div class="mx-auto max-w-threadContentWidth">
+                                <div class="max-w-threadContentWidth relative isolate z-20 mx-auto">
+                                  <div class="relative z-10">
+                                    <div class="group relative flex items-end gap-0.5">
+                                      <div
+                                        class="-inset-md pointer-events-none absolute select-none"
+                                      ></div>
+                                      <div class="relative min-w-0 flex-1 flex justify-end">
+                                        <div class="flex items-start gap-2">
+                                          <div
+                                            class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 sticky top-sm py-sm pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+                                            aria-hidden="false"
+                                          >
+                                            <button
+                                              aria-label="Edit Query"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-pencil"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              aria-label="Copy Query"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-copy"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div>
+                                            </button>
+                                          </div>
+                                          <div class="group/title relative inline-flex flex-col">
+                                            <div>
+                                              <div
+                                                style="
+                                                  transition: none;
+                                                  overflow: hidden;
+                                                  height: 48px;
+                                                "
+                                              >
+                                                <div>
+                                                  <div
+                                                    class="group/query relative whitespace-pre-line !text-wrap break-words [word-break:break-word] font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                  >
+                                                    <div
+                                                      class="flex min-w-[48px] items-center justify-center bg-offset text-foreground rounded-2xl p-3 font-sans text-base font-normal select-none max-w-[600px]"
+                                                    >
+                                                      <span
+                                                        class="select-text"
+                                                        style="overflow-wrap: anywhere"
+                                                        >次は「いいえ」だけ答えて</span
+                                                      >
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="gap-y-lg flex flex-col">
+                              <div
+                                dir="ltr"
+                                data-orientation="horizontal"
+                                class="grid w-full min-w-0 grid-cols-[minmax(0,1fr)]"
+                              >
+                                <div class="col-start-1 row-start-2" style="opacity: 1">
+                                  <div
+                                    data-state="active"
+                                    data-orientation="horizontal"
+                                    role="tabpanel"
+                                    aria-labelledby="radix-:rd0:-trigger-thread"
+                                    id="radix-:rd0:-content-thread"
+                                    tabindex="0"
+                                    class="focus:outline-none"
+                                    style=""
+                                  >
+                                    <div
+                                      class="border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                    >
+                                      <div class="gap-y-md flex flex-col">
+                                        <div class="flex flex-col gap-sm">
+                                          <div class="flex items-center gap-x-md justify-between">
+                                            <div
+                                              class="flex items-center gap-x-md justify-between w-full"
+                                            >
+                                              <button
+                                                type="button"
+                                                class="reset interactable gap-x-0.5 select-none inline-flex items-center whitespace-nowrap text-quiet text-sm self-start hover:opacity-75 duration-quick rounded-md"
+                                              >
+                                                Reviewed 10 sources<span
+                                                  class="duration-quick transition-transform ease-in-out text-quiet inline-flex rotate-0"
+                                                  ><svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="14"
+                                                    height="14"
+                                                  >
+                                                    <use
+                                                      xlink:href="#pplx-icon-chevron-right"
+                                                    ></use></svg
+                                                ></span>
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="relative font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                        >
+                                          <div class="min-w-0 break-words [word-break:break-word]">
+                                            <div
+                                              dir="auto"
+                                              id="markdown-content-1"
+                                              class="gap-y-md after:clear-both after:block after:content-['']"
+                                            >
+                                              <div
+                                                class="has-inline-images my-2 first:mt-0 [&amp;:has([data-inline-type=image])+&amp;:has([data-inline-type=image])_[data-inline-type=image]]:hidden [&amp;:has(table)_[data-inline-type=image]]:hidden"
+                                              >
+                                                <div class="relative">
+                                                  <div
+                                                    class="prose dark:prose-invert inline leading-relaxed break-words min-w-0 [word-break:break-word] prose-strong:font-medium visRefresh2026Fonts:prose-strong:font-bold [&amp;_&gt;*:first-child]:mt-0"
+                                                  >
+                                                    <p
+                                                      class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                                    >
+                                                      いいえ。<span class="citation-nbsp"></span
+                                                      ><span
+                                                        class="inline-flex"
+                                                        aria-label="Perplexityの言語設定を日本語にする"
+                                                        data-state="closed"
+                                                        ><span
+                                                          class="citation inline"
+                                                          data-pplx-citation=""
+                                                          data-pplx-citation-url="https://reposub.jp/blogs/ai/perplexity_japanese"
+                                                          rel="nofollow noopener"
+                                                          ><a
+                                                            rel="noopener"
+                                                            class="inline-flex max-w-full min-w-0"
+                                                            target="_blank"
+                                                            href="https://reposub.jp/blogs/ai/perplexity_japanese"
+                                                            ><span
+                                                              class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                              ><span
+                                                                class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                                ><span
+                                                                  class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                                  >reposub</span
+                                                                ></span
+                                                              ></span
+                                                            ></a
+                                                          ></span
+                                                        >​</span
+                                                      >
+                                                    </p>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div class="flex items-center justify-between">
+                                          <div
+                                            class="-ml-sm gap-xs flex flex-shrink-0 items-center"
+                                          >
+                                            <button
+                                              aria-label="Share"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-share-3"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              data-state="closed"
+                                              aria-label="Download"
+                                              aria-expanded="false"
+                                              aria-haspopup="menu"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-download"></use>
+                                              </svg></button
+                                            ><button
+                                              aria-label="Copy"
+                                              data-state="closed"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <div
+                                                class="relative flex items-center justify-center"
+                                              >
+                                                <div
+                                                  class="inline-flex"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-copy"></use>
+                                                  </svg>
+                                                </div>
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </div></button
+                                            ><button
+                                              data-state="closed"
+                                              aria-label="Rewrite"
+                                              aria-expanded="false"
+                                              aria-haspopup="menu"
+                                              type="button"
+                                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-repeat"></use>
+                                              </svg>
+                                            </button>
+                                            <div class="rounded-full">
+                                              <button
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full hover:text-foreground hover:bg-subtle px-3 relative"
+                                              >
+                                                <span
+                                                  class="text-box-trim-both"
+                                                  style="
+                                                    opacity: 1;
+                                                    transition: opacity 150ms 150ms;
+                                                  "
+                                                  ><div
+                                                    class="text-quiet font-normal gap-x-sm flex flex-row -ml-0.5"
+                                                  >
+                                                    <svg
+                                                      width="14"
+                                                      height="14"
+                                                      viewBox="0 0 24 24"
+                                                      fill="none"
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                      class="absolute opacity-0"
+                                                    >
+                                                      <defs>
+                                                        <clipPath id="clip-path-default">
+                                                          <path
+                                                            fill-rule="evenodd"
+                                                            clip-rule="evenodd"
+                                                            d="M10.0635 0.704214C9.13824 0.253115 8.09868 0 7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14C8.09868 14 9.13824 13.7469 10.0635 13.2958C8.19825 11.8312 7 9.55552 7 7C7 4.44448 8.19825 2.16882 10.0635 0.704214Z"
+                                                            fill="#D9D9D9"
+                                                          ></path>
+                                                        </clipPath>
+                                                      </defs></svg
+                                                    ><svg
+                                                      width="12"
+                                                      height="12"
+                                                      viewBox="0 0 12 12"
+                                                      fill="none"
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                      class="absolute opacity-0"
+                                                    >
+                                                      <defs>
+                                                        <clipPath id="clip-path-small">
+                                                          <path
+                                                            fill-rule="evenodd"
+                                                            clip-rule="evenodd"
+                                                            d="M8.57242 0.57787C7.7928 0.20734 6.92062 0 6 0C2.68629 0 0 2.68629 0 6C0 9.31371 2.68629 12 6 12C6.92062 12 7.7928 11.7927 8.57242 11.4221C7.00228 10.1385 6 8.18628 6 6C6 3.81372 7.00228 1.86154 8.57242 0.57787Z"
+                                                            fill="#D9D9D9"
+                                                          ></path>
+                                                        </clipPath>
+                                                      </defs>
+                                                    </svg>
+                                                    <div
+                                                      class="gap-xs relative flex shrink-0 items-center"
+                                                    >
+                                                      <div class="ml-xs flex">
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                          style="
+                                                            clip-path: url('#clip-path-default');
+                                                          "
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="reposub.jp favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=reposub.jp"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                          style="
+                                                            clip-path: url('#clip-path-default');
+                                                          "
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="reddit.com favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=reddit.com"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                        <div
+                                                          class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                                        >
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 bg-white"
+                                                          ></div>
+                                                          <img
+                                                            class="relative block"
+                                                            alt="youtube.com favicon"
+                                                            width="14"
+                                                            height="14"
+                                                            src="https://www.google.com/s2/favicons?sz=128&amp;domain=youtube.com"
+                                                            style="width: 14px; height: 14px"
+                                                          />
+                                                          <div
+                                                            class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                                          ></div>
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                    10 sources
+                                                  </div></span
+                                                >
+                                                <div
+                                                  class="absolute inset-0 flex items-center justify-center"
+                                                  style="opacity: 0; transition: opacity 150ms"
+                                                ></div>
+                                              </button>
+                                            </div>
+                                          </div>
+                                          <div class="gap-x-xs flex flex-shrink-0 items-center">
+                                            <div>
+                                              <div
+                                                class="gap-xs flex items-center border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                              >
+                                                <button
+                                                  aria-label="Helpful"
+                                                  data-state="closed"
+                                                  type="button"
+                                                  class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                                >
+                                                  <div
+                                                    class="relative flex items-center justify-center"
+                                                  >
+                                                    <div
+                                                      class="inline-flex"
+                                                      style="
+                                                        opacity: 1;
+                                                        transition: opacity 150ms 150ms;
+                                                      "
+                                                    >
+                                                      <svg
+                                                        role="img"
+                                                        class="inline-flex fill-current shrink-0"
+                                                        width="16"
+                                                        height="16"
+                                                      >
+                                                        <use xlink:href="#pplx-icon-thumb-up"></use>
+                                                      </svg>
+                                                    </div>
+                                                    <div
+                                                      class="absolute inset-0 flex items-center justify-center"
+                                                      style="opacity: 0; transition: opacity 150ms"
+                                                    ></div>
+                                                  </div></button
+                                                ><button
+                                                  aria-label="Not helpful"
+                                                  data-state="closed"
+                                                  type="button"
+                                                  class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                                                >
+                                                  <div
+                                                    class="relative flex items-center justify-center"
+                                                  >
+                                                    <div
+                                                      class="inline-flex"
+                                                      style="
+                                                        opacity: 1;
+                                                        transition: opacity 150ms 150ms;
+                                                      "
+                                                    >
+                                                      <svg
+                                                        role="img"
+                                                        class="inline-flex fill-current shrink-0"
+                                                        width="16"
+                                                        height="16"
+                                                      >
+                                                        <use
+                                                          xlink:href="#pplx-icon-thumb-down"
+                                                        ></use>
+                                                      </svg>
+                                                    </div>
+                                                    <div
+                                                      class="absolute inset-0 flex items-center justify-center"
+                                                      style="opacity: 0; transition: opacity 150ms"
+                                                    ></div>
+                                                  </div>
+                                                </button>
+                                              </div>
+                                            </div>
+                                            <div>
+                                              <button
+                                                data-state="closed"
+                                                aria-label="More actions"
+                                                aria-expanded="false"
+                                                aria-haspopup="menu"
+                                                type="button"
+                                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                                              >
+                                                <svg
+                                                  role="img"
+                                                  class="inline-flex fill-current shrink-0"
+                                                  width="16"
+                                                  height="16"
+                                                >
+                                                  <use xlink:href="#pplx-icon-dots"></use>
+                                                </svg>
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div class="gap-y-lg flex flex-col first:mt-0">
+                                <div class="">
+                                  <div
+                                    class="animate-in fade-in duration-100 ease-out md:mt-ml border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                  >
+                                    <div
+                                      class="border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                    >
+                                      <div
+                                        class="flex items-center justify-between border-subtlest ring-subtlest divide-subtlest bg-base"
+                                      >
+                                        <div class="flex w-full items-center justify-between mb-md">
+                                          <div class="">
+                                            <div color="super" class="space-x-sm flex items-center">
+                                              <div
+                                                class="font-sans text-lg font-medium visRefresh2026Fonts:font-bold text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                              >
+                                                Related
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="divide-y border-t border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                      >
+                                        <button
+                                          type="button"
+                                          class="reset interactable py-sm group flex w-full appearance-none items-start gap-[11px]"
+                                        >
+                                          <div
+                                            class="ml-xs duration-quick md:group-hover:!text-super inline-flex flex-none translate-y-px transition-all font-sans text-base font-medium text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0 tabler-icon shrink-0"
+                                              width="18"
+                                              height="18"
+                                            >
+                                              <use xlink:href="#pplx-icon-corner-down-right"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="md:group-hover:!text-super duration-quick overflow-hidden text-ellipsis text-left transition-all font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            Perplexity Labsの日本語IME入力問題の詳細
+                                          </div></button
+                                        ><button
+                                          type="button"
+                                          class="reset interactable py-sm group flex w-full appearance-none items-start gap-[11px]"
+                                        >
+                                          <div
+                                            class="ml-xs duration-quick md:group-hover:!text-super inline-flex flex-none translate-y-px transition-all font-sans text-base font-medium text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0 tabler-icon shrink-0"
+                                              width="18"
+                                              height="18"
+                                            >
+                                              <use xlink:href="#pplx-icon-corner-down-right"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="md:group-hover:!text-super duration-quick overflow-hidden text-ellipsis text-left transition-all font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            Perplexityの言語設定を英語に戻す方法
+                                          </div></button
+                                        ><button
+                                          type="button"
+                                          class="reset interactable py-sm group flex w-full appearance-none items-start gap-[11px]"
+                                        >
+                                          <div
+                                            class="ml-xs duration-quick md:group-hover:!text-super inline-flex flex-none translate-y-px transition-all font-sans text-base font-medium text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0 tabler-icon shrink-0"
+                                              width="18"
+                                              height="18"
+                                            >
+                                              <use xlink:href="#pplx-icon-corner-down-right"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="md:group-hover:!text-super duration-quick overflow-hidden text-ellipsis text-left transition-all font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            Perplexity AIで日本語質問の精度を上げるコツ
+                                          </div></button
+                                        ><button
+                                          type="button"
+                                          class="reset interactable py-sm group flex w-full appearance-none items-start gap-[11px]"
+                                        >
+                                          <div
+                                            class="ml-xs duration-quick md:group-hover:!text-super inline-flex flex-none translate-y-px transition-all font-sans text-base font-medium text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0 tabler-icon shrink-0"
+                                              width="18"
+                                              height="18"
+                                            >
+                                              <use xlink:href="#pplx-icon-corner-down-right"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="md:group-hover:!text-super duration-quick overflow-hidden text-ellipsis text-left transition-all font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            Cometブラウザで日本語学習の活用例
+                                          </div></button
+                                        ><button
+                                          type="button"
+                                          class="reset interactable py-sm group flex w-full appearance-none items-start gap-[11px]"
+                                        >
+                                          <div
+                                            class="ml-xs duration-quick md:group-hover:!text-super inline-flex flex-none translate-y-px transition-all font-sans text-base font-medium text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0 tabler-icon shrink-0"
+                                              width="18"
+                                              height="18"
+                                            >
+                                              <use xlink:href="#pplx-icon-corner-down-right"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="md:group-hover:!text-super duration-quick overflow-hidden text-ellipsis text-left transition-all font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                          >
+                                            Perplexityの設定画面のHTML構造
+                                          </div>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-shopping"
+                          hidden=""
+                          id="radix-:r9i:-content-shopping"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-hotels"
+                          hidden=""
+                          id="radix-:r9i:-content-hotels"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-places"
+                          hidden=""
+                          id="radix-:r9i:-content-places"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-jobs"
+                          hidden=""
+                          id="radix-:r9i:-content-jobs"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-videos"
+                          hidden=""
+                          id="radix-:r9i:-content-videos"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-images"
+                          hidden=""
+                          id="radix-:r9i:-content-images"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-sources"
+                          hidden=""
+                          id="radix-:r9i:-content-sources"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-assets"
+                          hidden=""
+                          id="radix-:r9i:-content-assets"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                        <div
+                          data-state="inactive"
+                          data-orientation="horizontal"
+                          role="tabpanel"
+                          aria-labelledby="radix-:r9i:-trigger-news"
+                          hidden=""
+                          id="radix-:r9i:-content-news"
+                          tabindex="0"
+                          class="focus:outline-none"
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="erp-sidecar:fixed erp-sidecar:w-full bottom-safeAreaInsetBottom p-md pointer-events-none z-10 absolute border-subtlest ring-subtlest divide-subtlest bg-transparent"
+          style="width: calc(100% + 0px)"
+        >
+          <div class="max-w-threadContentWidth mx-auto">
+            <div class="pointer-events-auto">
+              <div class="pointer-events-none h-0"></div>
+              <div>
+                <div class="w-full">
+                  <div class="relative">
+                    <div class="bg-base rounded-2xl">
+                      <div
+                        class="shadow-[0_1px_8px_2px_oklch(var(--foreground-color)/0.05),0_36px_16px_36px_oklch(var(--background-base-color))] dark:shadow-[0_4px_12px_rgba(0,0,0,0.12),0_32px_16px_36px_oklch(var(--dark-background-base-color))] relative rounded-2xl border-subtlest ring-subtlest divide-subtlest bg-subtler"
+                      >
+                        <div class="">
+                          <span class="grow block"
+                            ><div class="relative rounded-2xl">
+                              <div
+                                class="bg-raised w-full outline-none flex items-center border rounded-2xl dark:bg-offset duration-75 transition-all border-dashed border-subtle border-subtler shadow-sm dark:shadow-md shadow-super/10 dark:shadow-black/10 px-0 pt-3 pb-3 gap-y-md grid items-center"
+                              >
+                                <div class="px-3.5 grid-rows-1fr-auto grid grid-cols-3">
+                                  <div
+                                    class="overflow-hidden relative flex h-full w-full col-start-1 col-end-4 pb-3"
+                                  >
+                                    <div class="w-full" style="min-height: 1.5em">
+                                      <template shadowrootmode="closed"
+                                        ><qb-highlighter
+                                          contenteditable="false"
+                                          class="qb--mac-os"
+                                          style="display: none"
+                                          ><qb-div
+                                            spellcheck="false"
+                                            class="qb-highlighter__wrapper"
+                                            style="
+                                              width: 690px !important;
+                                              height: 24px !important;
+                                              transform: none !important;
+                                              transform-origin: 345px 12px !important;
+                                              zoom: 1 !important;
+                                            "
+                                            ><qb-div
+                                              class="qb-highlighter__scroll-element"
+                                              style="
+                                                top: 0px !important;
+                                                left: 0px !important;
+                                                width: 690px !important;
+                                                height: 24px !important;
+                                              "
+                                            ></qb-div></qb-div></qb-highlighter
+                                        ><slot
+                                          style="
+                                            color-scheme: inherit;
+                                            forced-color-adjust: inherit;
+                                            mask: inherit;
+                                            math-depth: inherit;
+                                            position: inherit;
+                                            position-anchor: inherit;
+                                            text-size-adjust: inherit;
+                                            appearance: inherit;
+                                            color: inherit;
+                                            font: inherit;
+                                            font-palette: inherit;
+                                            font-synthesis: inherit;
+                                            position-area: inherit;
+                                            text-orientation: inherit;
+                                            text-rendering: inherit;
+                                            text-spacing-trim: inherit;
+                                            -webkit-font-smoothing: inherit;
+                                            -webkit-locale: inherit;
+                                            -webkit-text-orientation: inherit;
+                                            -webkit-writing-mode: inherit;
+                                            writing-mode: inherit;
+                                            zoom: inherit;
+                                            accent-color: inherit;
+                                            place-content: inherit;
+                                            place-items: inherit;
+                                            place-self: inherit;
+                                            alignment-baseline: inherit;
+                                            anchor-name: inherit;
+                                            anchor-scope: inherit;
+                                            animation-composition: inherit;
+                                            animation: inherit;
+                                            app-region: inherit;
+                                            aspect-ratio: inherit;
+                                            backdrop-filter: inherit;
+                                            backface-visibility: inherit;
+                                            background: inherit;
+                                            background-blend-mode: inherit;
+                                            baseline-shift: inherit;
+                                            baseline-source: inherit;
+                                            block-size: inherit;
+                                            border-block: inherit;
+                                            border: inherit;
+                                            border-radius: inherit;
+                                            border-collapse: inherit;
+                                            border-end-end-radius: inherit;
+                                            border-end-start-radius: inherit;
+                                            border-inline: inherit;
+                                            border-start-end-radius: inherit;
+                                            border-start-start-radius: inherit;
+                                            inset: inherit;
+                                            box-decoration-break: inherit;
+                                            box-shadow: inherit;
+                                            box-sizing: inherit;
+                                            break-after: inherit;
+                                            break-before: inherit;
+                                            break-inside: inherit;
+                                            buffered-rendering: inherit;
+                                            caption-side: inherit;
+                                            caret-animation: inherit;
+                                            caret-color: inherit;
+                                            caret-shape: inherit;
+                                            clear: inherit;
+                                            clip: inherit;
+                                            clip-path: inherit;
+                                            clip-rule: inherit;
+                                            color-interpolation: inherit;
+                                            color-interpolation-filters: inherit;
+                                            color-rendering: inherit;
+                                            columns: inherit;
+                                            column-fill: inherit;
+                                            gap: inherit;
+                                            column-rule: inherit;
+                                            column-span: inherit;
+                                            contain: inherit;
+                                            contain-intrinsic-block-size: inherit;
+                                            contain-intrinsic-size: inherit;
+                                            contain-intrinsic-inline-size: inherit;
+                                            container: inherit;
+                                            content: inherit;
+                                            content-visibility: inherit;
+                                            corner-shape: inherit;
+                                            corner-block-end-shape: inherit;
+                                            corner-block-start-shape: inherit;
+                                            counter-increment: inherit;
+                                            counter-reset: inherit;
+                                            counter-set: inherit;
+                                            cursor: inherit;
+                                            cx: inherit;
+                                            cy: inherit;
+                                            d: inherit;
+                                            display: contents;
+                                            dominant-baseline: inherit;
+                                            dynamic-range-limit: inherit;
+                                            empty-cells: inherit;
+                                            field-sizing: inherit;
+                                            fill: inherit;
+                                            fill-opacity: inherit;
+                                            fill-rule: inherit;
+                                            filter: inherit;
+                                            flex: inherit;
+                                            flex-flow: inherit;
+                                            float: inherit;
+                                            flood-color: inherit;
+                                            flood-opacity: inherit;
+                                            grid: inherit;
+                                            grid-area: inherit;
+                                            height: inherit;
+                                            hyphenate-character: inherit;
+                                            hyphenate-limit-chars: inherit;
+                                            hyphens: inherit;
+                                            image-orientation: inherit;
+                                            image-rendering: inherit;
+                                            initial-letter: inherit;
+                                            inline-size: inherit;
+                                            inset-block: inherit;
+                                            inset-inline: inherit;
+                                            interactivity: inherit;
+                                            interest-delay: inherit;
+                                            interpolate-size: inherit;
+                                            isolation: inherit;
+                                            letter-spacing: inherit;
+                                            lighting-color: inherit;
+                                            line-break: inherit;
+                                            list-style: inherit;
+                                            margin-block: inherit;
+                                            margin: inherit;
+                                            margin-inline: inherit;
+                                            marker: inherit;
+                                            mask-type: inherit;
+                                            math-shift: inherit;
+                                            math-style: inherit;
+                                            max-block-size: inherit;
+                                            max-height: inherit;
+                                            max-inline-size: inherit;
+                                            max-width: inherit;
+                                            min-block-size: inherit;
+                                            min-height: inherit;
+                                            min-inline-size: inherit;
+                                            min-width: inherit;
+                                            mix-blend-mode: inherit;
+                                            object-fit: inherit;
+                                            object-position: inherit;
+                                            object-view-box: inherit;
+                                            offset: inherit;
+                                            opacity: inherit;
+                                            order: inherit;
+                                            orphans: inherit;
+                                            outline: inherit;
+                                            outline-offset: inherit;
+                                            overflow-anchor: inherit;
+                                            overflow-block: inherit;
+                                            overflow-clip-margin: inherit;
+                                            overflow-inline: inherit;
+                                            overflow-wrap: inherit;
+                                            overflow: inherit;
+                                            overlay: inherit;
+                                            overscroll-behavior-block: inherit;
+                                            overscroll-behavior-inline: inherit;
+                                            overscroll-behavior: inherit;
+                                            padding-block: inherit;
+                                            padding: inherit;
+                                            padding-inline: inherit;
+                                            page: inherit;
+                                            page-orientation: inherit;
+                                            paint-order: inherit;
+                                            perspective: inherit;
+                                            perspective-origin: inherit;
+                                            pointer-events: inherit;
+                                            position-try: inherit;
+                                            position-visibility: inherit;
+                                            print-color-adjust: inherit;
+                                            quotes: inherit;
+                                            r: inherit;
+                                            reading-flow: inherit;
+                                            reading-order: inherit;
+                                            resize: inherit;
+                                            rotate: inherit;
+                                            ruby-align: inherit;
+                                            ruby-position: inherit;
+                                            rx: inherit;
+                                            ry: inherit;
+                                            scale: inherit;
+                                            scroll-behavior: inherit;
+                                            scroll-initial-target: inherit;
+                                            scroll-margin-block: inherit;
+                                            scroll-margin: inherit;
+                                            scroll-margin-inline: inherit;
+                                            scroll-marker-group: inherit;
+                                            scroll-padding-block: inherit;
+                                            scroll-padding: inherit;
+                                            scroll-padding-inline: inherit;
+                                            scroll-snap-align: inherit;
+                                            scroll-snap-stop: inherit;
+                                            scroll-snap-type: inherit;
+                                            scroll-target-group: inherit;
+                                            scroll-timeline: inherit;
+                                            scrollbar-color: inherit;
+                                            scrollbar-gutter: inherit;
+                                            scrollbar-width: inherit;
+                                            shape-image-threshold: inherit;
+                                            shape-margin: inherit;
+                                            shape-outside: inherit;
+                                            shape-rendering: inherit;
+                                            size: inherit;
+                                            speak: inherit;
+                                            stop-color: inherit;
+                                            stop-opacity: inherit;
+                                            stroke: inherit;
+                                            stroke-dasharray: inherit;
+                                            stroke-dashoffset: inherit;
+                                            stroke-linecap: inherit;
+                                            stroke-linejoin: inherit;
+                                            stroke-miterlimit: inherit;
+                                            stroke-opacity: inherit;
+                                            stroke-width: inherit;
+                                            tab-size: inherit;
+                                            table-layout: inherit;
+                                            text-align: inherit;
+                                            text-align-last: inherit;
+                                            text-anchor: inherit;
+                                            text-autospace: inherit;
+                                            text-box: inherit;
+                                            text-combine-upright: inherit;
+                                            text-decoration: inherit;
+                                            text-decoration-skip-ink: inherit;
+                                            text-emphasis: inherit;
+                                            text-emphasis-position: inherit;
+                                            text-indent: inherit;
+                                            text-overflow: inherit;
+                                            text-shadow: inherit;
+                                            text-transform: inherit;
+                                            text-underline-offset: inherit;
+                                            text-underline-position: inherit;
+                                            text-wrap: inherit;
+                                            timeline-scope: inherit;
+                                            touch-action: inherit;
+                                            transform: inherit;
+                                            transform-box: inherit;
+                                            transform-origin: inherit;
+                                            transform-style: inherit;
+                                            transition: inherit;
+                                            translate: inherit;
+                                            user-select: inherit;
+                                            vector-effect: inherit;
+                                            vertical-align: inherit;
+                                            view-timeline: inherit;
+                                            view-transition-class: inherit;
+                                            view-transition-group: inherit;
+                                            view-transition-name: inherit;
+                                            visibility: inherit;
+                                            border-spacing: inherit;
+                                            -webkit-box-align: inherit;
+                                            -webkit-box-decoration-break: inherit;
+                                            -webkit-box-direction: inherit;
+                                            -webkit-box-flex: inherit;
+                                            -webkit-box-ordinal-group: inherit;
+                                            -webkit-box-orient: inherit;
+                                            -webkit-box-pack: inherit;
+                                            -webkit-box-reflect: inherit;
+                                            -webkit-line-break: inherit;
+                                            -webkit-line-clamp: inherit;
+                                            -webkit-mask-box-image: inherit;
+                                            -webkit-rtl-ordering: inherit;
+                                            -webkit-ruby-position: inherit;
+                                            -webkit-tap-highlight-color: inherit;
+                                            -webkit-text-combine: inherit;
+                                            -webkit-text-decorations-in-effect: inherit;
+                                            -webkit-text-fill-color: inherit;
+                                            -webkit-text-security: inherit;
+                                            -webkit-text-stroke: inherit;
+                                            -webkit-user-drag: inherit;
+                                            white-space-collapse: inherit;
+                                            widows: inherit;
+                                            width: inherit;
+                                            will-change: inherit;
+                                            word-break: inherit;
+                                            word-spacing: inherit;
+                                            x: inherit;
+                                            y: inherit;
+                                            z-index: inherit;
+                                          "
+                                        ></slot
+                                      ></template>
+                                      <div
+                                        class="overflow-auto max-h-[45vh] lg:max-h-[40vh] sm:max-h-[25vh] outline-none font-sans resize-none caret-super selection:bg-super/30 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super text-foreground bg-transparent placeholder-quieter placeholder:select-none scrollbar-subtle size-full"
+                                        contenteditable="true"
+                                        id="ask-input"
+                                        role="textbox"
+                                        spellcheck="true"
+                                        aria-placeholder="Ask a follow-up"
+                                        data-lexical-editor="true"
+                                        style="
+                                          user-select: text;
+                                          white-space: pre-wrap;
+                                          word-break: break-word;
+                                        "
+                                      ></div>
+                                      <div aria-hidden="true">
+                                        <div
+                                          class="absolute inset-0 pointer-events-none select-none text-quieter"
+                                        >
+                                          Ask a follow-up
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div class="gap-sm flex col-start-1 row-start-2 -ml-two">
+                                    <div class="gap-xs flex items-center">
+                                      <div
+                                        role="radiogroup"
+                                        aria-required="false"
+                                        dir="ltr"
+                                        data-state="closed"
+                                        class="group relative isolate flex h-fit"
+                                        tabindex="0"
+                                        style="outline: none"
+                                      >
+                                        <div
+                                          class="absolute inset-0 bg-super/10 dark:bg-black/[0.18] dark:border dark:border-black/[0.04] rounded-[10px] transition-colors duration-300"
+                                        ></div>
+                                        <div class="p-two flex shrink-0">
+                                          <div class="relative flex shrink-0 items-center">
+                                            <div
+                                              class="pointer-events-none absolute inset-y-0 z-0 bg-white dark:bg-black dark:bg-gradient-to-b dark:from-super/20 dark:to-super/20 border-super dark:border-super/30 border rounded-lg shadow-super/30 dark:shadow-super/5 shadow-[0_1px_3px_0] dark:text-super transition-all duration-100 ease-out"
+                                              style="transform: translateX(0px); width: 36px"
+                                            ></div>
+                                            <button
+                                              type="button"
+                                              role="radio"
+                                              aria-checked="true"
+                                              data-state="checked"
+                                              value="search"
+                                              aria-label="Search"
+                                              class="segmented-control group/segmented-control relative focus:outline-none"
+                                              tabindex="-1"
+                                              data-radix-collection-item=""
+                                            >
+                                              <div>
+                                                <div
+                                                  class="relative z-10 flex h-8 min-w-9 items-center justify-center py-xs gap-xs px-2.5"
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0 transition-colors duration-300 text-super"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-search"></use>
+                                                  </svg>
+                                                </div>
+                                              </div></button
+                                            ><button
+                                              type="button"
+                                              role="radio"
+                                              aria-checked="false"
+                                              data-state="unchecked"
+                                              value="research"
+                                              aria-label="Deep research"
+                                              class="segmented-control group/segmented-control relative focus:outline-none"
+                                              tabindex="-1"
+                                              data-radix-collection-item=""
+                                            >
+                                              <div>
+                                                <div
+                                                  class="relative z-10 flex h-8 min-w-9 items-center justify-center"
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0 transition-colors duration-300 text-quiet group-hover/segmented-control:text-foreground"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-telescope"></use>
+                                                  </svg>
+                                                </div>
+                                              </div></button
+                                            ><button
+                                              type="button"
+                                              role="radio"
+                                              aria-checked="false"
+                                              data-state="unchecked"
+                                              value="studio"
+                                              aria-label="Create files and apps"
+                                              class="segmented-control group/segmented-control relative focus:outline-none"
+                                              tabindex="-1"
+                                              data-radix-collection-item=""
+                                            >
+                                              <div>
+                                                <div
+                                                  class="relative z-10 flex h-8 min-w-9 items-center justify-center"
+                                                >
+                                                  <svg
+                                                    role="img"
+                                                    class="inline-flex fill-current shrink-0 transition-colors duration-300 text-quiet group-hover/segmented-control:text-foreground"
+                                                    width="16"
+                                                    height="16"
+                                                  >
+                                                    <use xlink:href="#pplx-icon-table-plus"></use>
+                                                  </svg>
+                                                </div>
+                                              </div>
+                                            </button>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="flex items-center justify-self-end col-start-3 row-start-2"
+                                  >
+                                    <div
+                                      style="
+                                        position: relative;
+                                        transform: translateY(0px);
+                                        opacity: 1;
+                                      "
+                                    >
+                                      <span class="inline-flex"
+                                        ><button
+                                          aria-label="Choose a model"
+                                          data-state="closed"
+                                          type="button"
+                                          class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-subtle rounded-lg"
+                                        >
+                                          <div class="relative flex items-center justify-center">
+                                            <div
+                                              class="inline-flex"
+                                              style="opacity: 1; transition: opacity 150ms 150ms"
+                                            >
+                                              <span class="inline-flex"
+                                                ><svg
+                                                  role="img"
+                                                  class="inline-flex fill-current shrink-0"
+                                                  width="16"
+                                                  height="16"
+                                                >
+                                                  <use xlink:href="#pplx-icon-cpu"></use></svg
+                                              ></span>
+                                            </div>
+                                            <div
+                                              class="absolute inset-0 flex items-center justify-center"
+                                              style="opacity: 0; transition: opacity 150ms"
+                                            ></div>
+                                          </div></button
+                                      ></span>
+                                    </div>
+                                    <div class="flex items-center">
+                                      <button
+                                        aria-expanded="false"
+                                        aria-haspopup="menu"
+                                        data-state="closed"
+                                        aria-label="Attach files"
+                                        type="button"
+                                        class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-subtle rounded-lg"
+                                      >
+                                        <div class="relative flex items-center justify-center">
+                                          <div
+                                            class="inline-flex"
+                                            style="opacity: 1; transition: opacity 150ms 150ms"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0"
+                                              width="16"
+                                              height="16"
+                                            >
+                                              <use xlink:href="#pplx-icon-paperclip"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="absolute inset-0 flex items-center justify-center"
+                                            style="opacity: 0; transition: opacity 150ms"
+                                          ></div>
+                                        </div></button
+                                      ><input
+                                        multiple=""
+                                        data-testid="file-upload-input"
+                                        accept=".bash,.bat,.c,.coffee,.conf,.config,.cpp,.cs,.css,.csv,.cxx,.dart,.diff,.doc,.docx,.fish,.go,.h,.hpp,.htm,.html,.in,.ini,.ipynb,.java,.js,.json,.jsx,.ksh,.kt,.kts,.latex,.less,.log,.lua,.m,.markdown,.md,.pdf,.php,.pl,.pm,.pptx,.py,.r,.R,.rb,.rmd,.rs,.scala,.sh,.sql,.swift,.t,.tex,.text,.toml,.ts,.tsx,.txt,.xlsx,.xml,.yaml,.yml,.zsh,.jpeg,.jpg,.jpe,.jp2,.png,.gif,.bmp,.tiff,.tif,.svg,.webp,.ico,.avif,.heic,.heif,.mp3,.wav,.aiff,.ogg,.flac,.mp4,.mpeg,.mov,.avi,.flv,.mpg,.webm,.wmv,.3gp"
+                                        type="file"
+                                        style="display: none"
+                                      />
+                                    </div>
+                                    <div class="relative">
+                                      <button
+                                        aria-label="Dictation"
+                                        data-state="closed"
+                                        type="button"
+                                        class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-subtle rounded-lg"
+                                      >
+                                        <div class="relative flex items-center justify-center">
+                                          <div
+                                            class="inline-flex"
+                                            style="opacity: 1; transition: opacity 150ms 150ms"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0"
+                                              width="16"
+                                              height="16"
+                                            >
+                                              <use xlink:href="#pplx-icon-microphone"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="absolute inset-0 flex items-center justify-center"
+                                            style="opacity: 0; transition: opacity 150ms"
+                                          ></div>
+                                        </div>
+                                      </button>
+                                    </div>
+                                    <div class="ml-2">
+                                      <button
+                                        disabled=""
+                                        aria-label="Submit"
+                                        type="button"
+                                        class="reset interactable pointer-events-none select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:opacity-80 text-inverse bg-super border border-transparent visRefresh2026Colors:bg-button-bg visRefresh2026Colors:shadow-button-primary dark:visRefresh2026Colors:shadow-button-primary-dark h-8 text-sm cursor-default opacity-50 inline-flex aspect-[9/8] rounded-lg"
+                                      >
+                                        <div class="relative flex items-center justify-center">
+                                          <div
+                                            class="inline-flex"
+                                            style="opacity: 1; transition: opacity 150ms 150ms"
+                                          >
+                                            <svg
+                                              role="img"
+                                              class="inline-flex fill-current shrink-0"
+                                              width="16"
+                                              height="16"
+                                            >
+                                              <use xlink:href="#pplx-icon-arrow-up"></use>
+                                            </svg>
+                                          </div>
+                                          <div
+                                            class="absolute inset-0 flex items-center justify-center"
+                                            style="opacity: 0; transition: opacity 150ms"
+                                          ></div>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div data-type="portal"></div></div
+                          ></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/fixtures/html/perplexity/deep-research.html
+++ b/test/fixtures/html/perplexity/deep-research.html
@@ -1,0 +1,1738 @@
+<div
+  class="erp-sidecar:min-h-[var(--sidecar-content-height)] erp-mobile-sidecar:min-h-[var(--mobile-sidecar-content-height)] min-h-[var(--page-content-height)]"
+  style="margin-top: 0px; padding-bottom: 130px"
+>
+  <div
+    class="pt-[var(--thread-visual-spacing)] md:pt-lg pb-[var(--thread-visual-spacing)] px-[var(--thread-visual-spacing)] border-subtlest ring-subtlest divide-subtlest bg-transparent"
+  >
+    <div class="isolate mx-auto flex flex-col max-w-threadContentWidth">
+      <div
+        data-state="active"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-default"
+        id="radix-:r29n:-content-default"
+        tabindex="0"
+        class="focus:outline-none"
+        style=""
+      >
+        <div class="flex flex-col gap-y-lg">
+          <div
+            class="bg-base erp-sidecar:pt-0 erp-mobile-sidecar:pt-0"
+            style="opacity: 1; transform: none"
+          >
+            <div class="mx-auto max-w-threadContentWidth">
+              <div class="max-w-threadContentWidth relative isolate z-20 mx-auto">
+                <div class="relative z-10">
+                  <div class="group relative flex items-end gap-0.5">
+                    <div class="-inset-md pointer-events-none absolute select-none"></div>
+                    <div class="relative min-w-0 flex-1 flex justify-end">
+                      <div class="flex items-start gap-2">
+                        <div
+                          class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 sticky top-sm py-sm pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+                          aria-hidden="false"
+                        >
+                          <button
+                            aria-label="Edit Query"
+                            data-state="closed"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                          >
+                            <div class="relative flex items-center justify-center">
+                              <div
+                                class="inline-flex"
+                                style="opacity: 1; transition: opacity 150ms 150ms"
+                              >
+                                <svg
+                                  role="img"
+                                  class="inline-flex fill-current shrink-0"
+                                  width="16"
+                                  height="16"
+                                >
+                                  <use xlink:href="#pplx-icon-pencil"></use>
+                                </svg>
+                              </div>
+                              <div
+                                class="absolute inset-0 flex items-center justify-center"
+                                style="opacity: 0; transition: opacity 150ms"
+                              ></div>
+                            </div></button
+                          ><button
+                            aria-label="Copy Query"
+                            data-state="closed"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                          >
+                            <div class="relative flex items-center justify-center">
+                              <div
+                                class="inline-flex"
+                                style="opacity: 1; transition: opacity 150ms 150ms"
+                              >
+                                <svg
+                                  role="img"
+                                  class="inline-flex fill-current shrink-0"
+                                  width="16"
+                                  height="16"
+                                >
+                                  <use xlink:href="#pplx-icon-copy"></use>
+                                </svg>
+                              </div>
+                              <div
+                                class="absolute inset-0 flex items-center justify-center"
+                                style="opacity: 0; transition: opacity 150ms"
+                              ></div>
+                            </div>
+                          </button>
+                        </div>
+                        <div class="group/title relative inline-flex flex-col">
+                          <div>
+                            <div style="transition: none; overflow: hidden; height: 48px">
+                              <div>
+                                <div
+                                  class="group/query relative whitespace-pre-line !text-wrap break-words [word-break:break-word] font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                >
+                                  <div
+                                    class="flex min-w-[48px] items-center justify-center bg-offset text-foreground rounded-2xl p-3 font-sans text-base font-normal select-none max-w-[600px]"
+                                  >
+                                    <span class="select-text" style="overflow-wrap: anywhere"
+                                      >Perplexity の提供する機能についてまとめてください。</span
+                                    >
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="gap-y-lg flex flex-col">
+            <div
+              dir="ltr"
+              data-orientation="horizontal"
+              class="grid w-full min-w-0 grid-cols-[minmax(0,1fr)]"
+            >
+              <div class="col-start-1 row-start-2" style="opacity: 1">
+                <div
+                  data-state="active"
+                  data-orientation="horizontal"
+                  role="tabpanel"
+                  aria-labelledby="radix-:r2br:-trigger-thread"
+                  id="radix-:r2br:-content-thread"
+                  tabindex="0"
+                  class="focus:outline-none"
+                  style=""
+                >
+                  <div class="border-subtlest ring-subtlest divide-subtlest bg-transparent">
+                    <div class="gap-y-md flex flex-col">
+                      <div class="flex flex-col gap-sm">
+                        <div class="flex items-center gap-x-md justify-between">
+                          <div class="flex items-center gap-x-md justify-between w-full">
+                            <button
+                              type="button"
+                              class="reset interactable gap-x-0.5 select-none inline-flex items-center whitespace-nowrap text-quiet text-sm self-start hover:opacity-75 duration-quick rounded-md"
+                            >
+                              2 steps completed<span
+                                class="duration-quick transition-transform ease-in-out text-quiet inline-flex rotate-0"
+                                ><svg
+                                  role="img"
+                                  class="inline-flex fill-current shrink-0"
+                                  width="14"
+                                  height="14"
+                                >
+                                  <use xlink:href="#pplx-icon-chevron-right"></use></svg
+                              ></span>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="relative font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                      >
+                        <div class="min-w-0 break-words [word-break:break-word]">
+                          <div
+                            dir="auto"
+                            id="markdown-content-2"
+                            class="gap-y-md after:clear-both after:block after:content-['']"
+                          >
+                            <div
+                              class="has-inline-images my-2 first:mt-0 [&amp;:has([data-inline-type=image])+&amp;:has([data-inline-type=image])_[data-inline-type=image]]:hidden [&amp;:has(table)_[data-inline-type=image]]:hidden"
+                            >
+                              <div class="relative">
+                                <div
+                                  class="prose dark:prose-invert inline leading-relaxed break-words min-w-0 [word-break:break-word] prose-strong:font-medium visRefresh2026Fonts:prose-strong:font-bold [&amp;_&gt;*:first-child]:mt-0"
+                                >
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base visRefresh2026Fonts:text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4"
+                                    id="perplexity"
+                                  >
+                                    Perplexity の提供する機能概要
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Perplexity は、リアルタイム Web 検索と高度な AI を組み合わせた
+                                    AI 駆動型検索エンジンです。以下、主要な機能をまとめました。
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    コア機能
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>AI 駆動型リアルタイム検索</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Perplexity は Web
+                                    をリアルタイムで検索し、複数の信頼できる情報源から情報を集約します。回答にはすべて引用元があり、ユーザーは元のソースを容易に確認できます。高度な言語モデル（GPT-5、Claude
+                                    4.0 Sonnet
+                                    など）を活用して、質問の文脈と細微なニュアンスを理解し、明確で会話的な回答を提供します。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="How does Perplexity work? | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>会話形式の対話</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Perplexity
+                                    は専門家と会話するような方式で応答します。ユーザーはフォローアップ質問を行うことができ、AI
+                                    は前の質問の文脈を記憶して、シームレスな会話を実現します。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="How does Perplexity work? | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>メモリ機能</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    最近導入されたメモリ機能により、Perplexity
+                                    は会話全体で重要な詳細を記憶し、今後の回答をより個人化・効率化します。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Introducing AI assistants with memory"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/hub/blog/introducing-ai-assistants-with-memory"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/hub/blog/introducing-ai-assistants-with-memory"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    検索モード
+                                  </h2>
+                                  <div class="group relative">
+                                    <div
+                                      class="w-full overflow-x-auto md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                    >
+                                      <table
+                                        class="border-subtler my-[1em] w-full table-auto border-separate border-spacing-0 border-l border-t"
+                                      >
+                                        <thead class="bg-subtler">
+                                          <tr>
+                                            <th
+                                              class="border-subtler p-sm break-normal border-b border-r text-left align-top"
+                                            >
+                                              検索モード
+                                            </th>
+                                            <th
+                                              class="border-subtler p-sm break-normal border-b border-r text-left align-top"
+                                            >
+                                              説明
+                                            </th>
+                                            <th
+                                              class="border-subtler p-sm break-normal border-b border-r text-left align-top"
+                                            >
+                                              対応プラン
+                                            </th>
+                                          </tr>
+                                        </thead>
+                                        <tbody>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>通常検索</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              基本的な検索モード
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              すべてのプラン
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Pro Search</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              複数のソースから徹底的なリサーチを行い、詳細で整理された回答を提供<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="How does Perplexity work? | Perplexity Help Center"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              Free（限定）、Pro 以上
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Deep Research（研究モード）</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              数十回の自動検索を実行し、数百のソースを読み込み、2～4分で包括的なレポートを生成<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="How does Perplexity work? | Perplexity Help Center"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              Free（月1回）、Pro 以上
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Best モード</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              クエリに応じて最適なモデルを自動選択<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="How does Perplexity work? | Perplexity Help Center"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              すべてのプラン
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                    <div
+                                      class="bg-base border-subtler shadow-subtle pointer-coarse:opacity-100 right-xs absolute bottom-0 flex rounded-lg border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtle [&amp;&gt;*:not(:first-child)]:border-l"
+                                    >
+                                      <div class="flex" style="opacity: 1">
+                                        <button
+                                          aria-label="Copy table"
+                                          type="button"
+                                          class="focus-visible:bg-subtle text-quiet hover:text-foreground aspect-square font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-lg cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-[9/8]"
+                                          data-state="closed"
+                                        >
+                                          <div
+                                            class="flex items-center min-w-0 gap-two justify-center"
+                                          >
+                                            <div
+                                              class="flex shrink-0 items-center justify-center size-4"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-copy"></use>
+                                              </svg>
+                                            </div>
+                                          </div>
+                                        </button>
+                                      </div>
+                                      <div class="flex" style="opacity: 1">
+                                        <button
+                                          aria-label="Download CSV"
+                                          type="button"
+                                          class="focus-visible:bg-subtle text-quiet hover:text-foreground aspect-square font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-lg cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-[9/8]"
+                                          data-state="closed"
+                                        >
+                                          <div
+                                            class="flex items-center min-w-0 gap-two justify-center"
+                                          >
+                                            <div
+                                              class="flex shrink-0 items-center justify-center size-4"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-download"></use>
+                                              </svg>
+                                            </div>
+                                          </div>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    AI モデル選択
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Pro 以上のユーザーは複数の先端 AI モデルから選択できます。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="What is Perplexity Pro? | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <div class="group relative">
+                                    <div
+                                      class="w-full overflow-x-auto md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                                    >
+                                      <table
+                                        class="border-subtler my-[1em] w-full table-auto border-separate border-spacing-0 border-l border-t"
+                                      >
+                                        <thead class="bg-subtler">
+                                          <tr>
+                                            <th
+                                              class="border-subtler p-sm break-normal border-b border-r text-left align-top"
+                                            >
+                                              モデル
+                                            </th>
+                                            <th
+                                              class="border-subtler p-sm break-normal border-b border-r text-left align-top"
+                                            >
+                                              特性
+                                            </th>
+                                          </tr>
+                                        </thead>
+                                        <tbody>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Sonar</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              Llama 3.1 70B ベース。高速 Web
+                                              検索と要約に特化。高度な推論オプション有<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="What advanced AI models are included in my subscription?"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>GPT-5.2</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              OpenAI
+                                              の最新モデル。推論、コーディング、創造性に優れ、幻覚の削減<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="What advanced AI models are included in my subscription?"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Claude Sonnet 4.5</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              Anthropic
+                                              のモデル。効率的なコーディングと技術的推論に長ける<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="What advanced AI models are included in my subscription?"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Gemini 3 Pro</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              Google
+                                              のモデル。マルチモーダル理解とコード生成に優れる<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="What advanced AI models are included in my subscription?"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                          </tr>
+                                          <tr>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              <strong>Grok 4.1</strong>
+                                            </td>
+                                            <td
+                                              class="px-sm border-subtler min-w-[48px] break-normal border-b border-r"
+                                            >
+                                              xAI のモデル。テキストと画像に対応<span
+                                                class="citation-nbsp"
+                                              ></span
+                                              ><span
+                                                class="inline-flex"
+                                                aria-label="What advanced AI models are included in my subscription?"
+                                                data-state="closed"
+                                                ><span
+                                                  class="citation inline"
+                                                  data-pplx-citation=""
+                                                  data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                  rel="nofollow noopener"
+                                                  ><a
+                                                    rel="noopener"
+                                                    class="inline-flex max-w-full min-w-0"
+                                                    target="_blank"
+                                                    href="https://www.perplexity.ai/help-center/en/articles/10354919-what-advanced-ai-models-are-included-in-my-subscription"
+                                                    ><span
+                                                      class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                                      ><span
+                                                        class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                                        ><span
+                                                          class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                          >perplexity</span
+                                                        ></span
+                                                      ></span
+                                                    ></a
+                                                  ></span
+                                                >​</span
+                                              >
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                    <div
+                                      class="bg-base border-subtler shadow-subtle pointer-coarse:opacity-100 right-xs absolute bottom-0 flex rounded-lg border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtle [&amp;&gt;*:not(:first-child)]:border-l"
+                                    >
+                                      <div class="flex" style="opacity: 1">
+                                        <button
+                                          aria-label="Copy table"
+                                          type="button"
+                                          class="focus-visible:bg-subtle text-quiet hover:text-foreground aspect-square font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-lg cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-[9/8]"
+                                          data-state="closed"
+                                        >
+                                          <div
+                                            class="flex items-center min-w-0 gap-two justify-center"
+                                          >
+                                            <div
+                                              class="flex shrink-0 items-center justify-center size-4"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-copy"></use>
+                                              </svg>
+                                            </div>
+                                          </div>
+                                        </button>
+                                      </div>
+                                      <div class="flex" style="opacity: 1">
+                                        <button
+                                          aria-label="Download CSV"
+                                          type="button"
+                                          class="focus-visible:bg-subtle text-quiet hover:text-foreground aspect-square font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-lg cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-[9/8]"
+                                          data-state="closed"
+                                        >
+                                          <div
+                                            class="flex items-center min-w-0 gap-two justify-center"
+                                          >
+                                            <div
+                                              class="flex shrink-0 items-center justify-center size-4"
+                                            >
+                                              <svg
+                                                role="img"
+                                                class="inline-flex fill-current shrink-0"
+                                                width="16"
+                                                height="16"
+                                              >
+                                                <use xlink:href="#pplx-icon-download"></use>
+                                              </svg>
+                                            </div>
+                                          </div>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    ファイル・コンテンツ管理
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>Create files and apps（プロジェクト作成）</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Pro
+                                    ユーザーは自然言語プロンプトでレポート、スプレッドシート、ダッシュボード、Web
+                                    アプリケーションを作成できます。AI
+                                    が研究、分析、情報の集約を自動で処理します。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="How does Perplexity work? | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/10352895-how-does-perplexity-work"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>ファイルアップロード・分析</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    PDF、CSV、音声、ビデオ、画像など複数形式のファイルをアップロードし、AI
+                                    で分析可能です。Pro ユーザーは最大 50
+                                    ファイルをスペースにアップロード可能。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="What is Perplexity Pro? | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/10352901-what-is-perplexity-pro"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>ページ機能</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    研究をビジュアルに充実させたコンテンツに変換し、スタイリッシュな情報ページを作成できます。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Introducing Perplexity Pages"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/hub/blog/perplexity-pages"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/hub/blog/perplexity-pages"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    画像・ビデオ生成
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Pro
+                                    以上のユーザーは最新の画像・ビデオ生成モデルを使用でき、研究タスクや創造的なプロジェクトを支援します。Enterprise
+                                    Max では毎月 15 本の 8 秒動画生成が可能。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="group/trigger inline-flex min-w-0"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline-flex min-w-0"
+                                        style="width: 87px"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/11187416-which-perplexity-subscription-plan-is-right-for-you"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ><span
+                                                class="inline-block ml-xs mr-px inline-block -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset]"
+                                                ><span class="opacity-50">+1</span></span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      ></span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    内部知識検索
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Enterprise ユーザーは Web
+                                    検索と組織内ファイルの並行検索が可能です。個別のソースを選択して「Web」「組織ファイル」「Web
+                                    + 組織ファイル」「なし」から検索方法を選べます。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Perplexity Product Features | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    その他の機能
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>タスク機能</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Pro、Max、Enterprise Pro/Max
+                                    ユーザーは定期的なアラートをスケジュール設定でき、特定のトピックについて継続的に監視できます。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Perplexity Product Features | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/collections/8935118-perplexity-product-features"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>Comet ブラウザアシスタント</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Perplexity 独自のブラウザで、ブラウザ内でタスクを実行でき、Web
+                                    を探索しながら質問に答える機能を提供。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Getting Started with Perplexity"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/hub/getting-started"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/hub/getting-started"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>Instant Buy</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    米国ユーザーは Perplexity
+                                    から直接製品を検索・購入できるシームレスなチェックアウト機能。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Perplexity Pro and Max | Perplexity Help Center"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/collections/8935108-perplexity-pro-and-max"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/collections/8935108-perplexity-pro-and-max"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>Pro Perks プログラム</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Pro
+                                    ユーザーは旅行、健康・ウェルネス、金融など複数カテゴリーの提携ブランドから独占的なオファーと割引を受け取ります。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="More Value In Every Answer: New Benefits For Every Level ..."
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/hub/blog/more-value-in-every-answer-new-benefits-for-every-level-of-perplexity-user"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/hub/blog/more-value-in-every-answer-new-benefits-for-every-level-of-perplexity-user"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    API とプログラマティックアクセス
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>Sonar API</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    開発者向けに軽量で低コストな API
+                                    を提供し、引用機能とカスタムソース機能を含みます。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Introducing the Sonar Pro API"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <h2
+                                    class="mb-2 mt-4 [.has-inline-images_&amp;]:clear-end font-sans visRefresh2026AnswerSerif:font-editorial font-semimedium visRefresh2026Fonts:font-bold text-base first:mt-0"
+                                  >
+                                    訂正機能とスペース
+                                  </h2>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    <strong>スペース</strong>
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    チーム協力のための専用スペースを作成でき、カスタム知識ハブと内部ファイル検索が可能です。<span
+                                      class="citation-nbsp"
+                                    ></span
+                                    ><span
+                                      class="inline-flex"
+                                      aria-label="Which Perplexity Subscription Plan is right for you?"
+                                      data-state="closed"
+                                      ><span
+                                        class="citation inline"
+                                        data-pplx-citation=""
+                                        data-pplx-citation-url="https://www.perplexity.ai/help-center/en/articles/11187416-which-perplexity-subscription-plan-is-right-for-you"
+                                        rel="nofollow noopener"
+                                        ><a
+                                          rel="noopener"
+                                          class="inline-flex max-w-full min-w-0"
+                                          target="_blank"
+                                          href="https://www.perplexity.ai/help-center/en/articles/11187416-which-perplexity-subscription-plan-is-right-for-you"
+                                          ><span
+                                            class="relative -mt-px max-w-full min-w-0 select-none whitespace-nowrap -top-px font-sans text-base text-foreground selection:bg-super/50 selection:text-foreground dark:selection:bg-super/10 dark:selection:text-super"
+                                            ><span
+                                              class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer text-center align-middle font-mono tabular-nums font-normal visRefresh2026Fonts:inline-flex visRefresh2026Fonts:items-center py-[0.1875rem] leading-snug px-[0.3rem] [@media(hover:hover)]:hover:bg-subtler group-data-[state=open]/trigger:bg-subtler border-subtlest ring-subtlest divide-subtlest bg-subtle"
+                                              ><span
+                                                class="inline-block relative -mt-px align-middle visRefresh2026Fonts:!mt-0 visRefresh2026Fonts:![vertical-align:unset] max-w-[25ch] overflow-hidden"
+                                                >perplexity</span
+                                              ></span
+                                            ></span
+                                          ></a
+                                        ></span
+                                      >​</span
+                                    >
+                                  </p>
+                                  <p
+                                    class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"
+                                  >
+                                    Perplexity
+                                    はこれらの機能を通じて、従来の検索エンジンとの差別化を図り、研究、コンテンツ作成、情報分析の効率化を実現しています。
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="flex items-center justify-between">
+                        <div class="-ml-sm gap-xs flex flex-shrink-0 items-center">
+                          <button
+                            aria-label="Share"
+                            data-state="closed"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                          >
+                            <div class="relative flex items-center justify-center">
+                              <div
+                                class="inline-flex"
+                                style="opacity: 1; transition: opacity 150ms 150ms"
+                              >
+                                <svg
+                                  role="img"
+                                  class="inline-flex fill-current shrink-0"
+                                  width="16"
+                                  height="16"
+                                >
+                                  <use xlink:href="#pplx-icon-share-3"></use>
+                                </svg>
+                              </div>
+                              <div
+                                class="absolute inset-0 flex items-center justify-center"
+                                style="opacity: 0; transition: opacity 150ms"
+                              ></div>
+                            </div></button
+                          ><button
+                            data-state="closed"
+                            aria-label="Download"
+                            aria-expanded="false"
+                            aria-haspopup="menu"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                          >
+                            <svg
+                              role="img"
+                              class="inline-flex fill-current shrink-0"
+                              width="16"
+                              height="16"
+                            >
+                              <use xlink:href="#pplx-icon-download"></use>
+                            </svg></button
+                          ><button
+                            aria-label="Copy"
+                            data-state="closed"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                          >
+                            <div class="relative flex items-center justify-center">
+                              <div
+                                class="inline-flex"
+                                style="opacity: 1; transition: opacity 150ms 150ms"
+                              >
+                                <svg
+                                  role="img"
+                                  class="inline-flex fill-current shrink-0"
+                                  width="16"
+                                  height="16"
+                                >
+                                  <use xlink:href="#pplx-icon-copy"></use>
+                                </svg>
+                              </div>
+                              <div
+                                class="absolute inset-0 flex items-center justify-center"
+                                style="opacity: 0; transition: opacity 150ms"
+                              ></div>
+                            </div></button
+                          ><button
+                            data-state="closed"
+                            aria-label="Rewrite"
+                            aria-expanded="false"
+                            aria-haspopup="menu"
+                            type="button"
+                            class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                          >
+                            <svg
+                              role="img"
+                              class="inline-flex fill-current shrink-0"
+                              width="16"
+                              height="16"
+                            >
+                              <use xlink:href="#pplx-icon-repeat"></use>
+                            </svg>
+                          </button>
+                          <div class="rounded-full">
+                            <button
+                              type="button"
+                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full hover:text-foreground hover:bg-subtle px-3 relative"
+                            >
+                              <span
+                                class="text-box-trim-both"
+                                style="opacity: 1; transition: opacity 150ms 150ms"
+                                ><div class="text-quiet font-normal gap-x-sm flex flex-row -ml-0.5">
+                                  <svg
+                                    width="14"
+                                    height="14"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="absolute opacity-0"
+                                  >
+                                    <defs>
+                                      <clipPath id="clip-path-default">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M10.0635 0.704214C9.13824 0.253115 8.09868 0 7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14C8.09868 14 9.13824 13.7469 10.0635 13.2958C8.19825 11.8312 7 9.55552 7 7C7 4.44448 8.19825 2.16882 10.0635 0.704214Z"
+                                          fill="#D9D9D9"
+                                        ></path>
+                                      </clipPath>
+                                    </defs></svg
+                                  ><svg
+                                    width="12"
+                                    height="12"
+                                    viewBox="0 0 12 12"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="absolute opacity-0"
+                                  >
+                                    <defs>
+                                      <clipPath id="clip-path-small">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M8.57242 0.57787C7.7928 0.20734 6.92062 0 6 0C2.68629 0 0 2.68629 0 6C0 9.31371 2.68629 12 6 12C6.92062 12 7.7928 11.7927 8.57242 11.4221C7.00228 10.1385 6 8.18628 6 6C6 3.81372 7.00228 1.86154 8.57242 0.57787Z"
+                                          fill="#D9D9D9"
+                                        ></path>
+                                      </clipPath>
+                                    </defs>
+                                  </svg>
+                                  <div class="gap-xs relative flex shrink-0 items-center">
+                                    <div class="ml-xs flex">
+                                      <div
+                                        class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                        style="clip-path: url('#clip-path-default')"
+                                      >
+                                        <div
+                                          class="rounded-inherit absolute inset-0 bg-white"
+                                        ></div>
+                                        <img
+                                          class="relative block"
+                                          alt="perplexity.ai favicon"
+                                          width="14"
+                                          height="14"
+                                          src="https://www.google.com/s2/favicons?sz=128&amp;domain=perplexity.ai"
+                                          style="width: 14px; height: 14px"
+                                        />
+                                        <div
+                                          class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                        ></div>
+                                      </div>
+                                      <div
+                                        class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                        style="clip-path: url('#clip-path-default')"
+                                      >
+                                        <div
+                                          class="rounded-inherit absolute inset-0 bg-white"
+                                        ></div>
+                                        <img
+                                          class="relative block"
+                                          alt="perplexity.ai favicon"
+                                          width="14"
+                                          height="14"
+                                          src="https://www.google.com/s2/favicons?sz=128&amp;domain=perplexity.ai"
+                                          style="width: 14px; height: 14px"
+                                        />
+                                        <div
+                                          class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                        ></div>
+                                      </div>
+                                      <div
+                                        class="relative shrink-0 overflow-hidden rounded-full bg-subtle relative z-0 inline-flex shrink-0 -ml-[5px]"
+                                      >
+                                        <div
+                                          class="rounded-inherit absolute inset-0 bg-white"
+                                        ></div>
+                                        <img
+                                          class="relative block"
+                                          alt="perplexity.ai favicon"
+                                          width="14"
+                                          height="14"
+                                          src="https://www.google.com/s2/favicons?sz=128&amp;domain=perplexity.ai"
+                                          style="width: 14px; height: 14px"
+                                        />
+                                        <div
+                                          class="rounded-inherit absolute inset-0 border border-[black]/10 dark:border-transparent"
+                                        ></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  18 sources
+                                </div></span
+                              >
+                              <div
+                                class="absolute inset-0 flex items-center justify-center"
+                                style="opacity: 0; transition: opacity 150ms"
+                              ></div>
+                            </button>
+                          </div>
+                        </div>
+                        <div class="gap-x-xs flex flex-shrink-0 items-center">
+                          <div>
+                            <div
+                              class="gap-xs flex items-center border-subtlest ring-subtlest divide-subtlest bg-transparent"
+                            >
+                              <button
+                                aria-label="Helpful"
+                                data-state="closed"
+                                type="button"
+                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                              >
+                                <div class="relative flex items-center justify-center">
+                                  <div
+                                    class="inline-flex"
+                                    style="opacity: 1; transition: opacity 150ms 150ms"
+                                  >
+                                    <svg
+                                      role="img"
+                                      class="inline-flex fill-current shrink-0"
+                                      width="16"
+                                      height="16"
+                                    >
+                                      <use xlink:href="#pplx-icon-thumb-up"></use>
+                                    </svg>
+                                  </div>
+                                  <div
+                                    class="absolute inset-0 flex items-center justify-center"
+                                    style="opacity: 0; transition: opacity 150ms"
+                                  ></div>
+                                </div></button
+                              ><button
+                                aria-label="Not helpful"
+                                data-state="closed"
+                                type="button"
+                                class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 aspect-[9/8] hover:text-foreground hover:bg-subtle"
+                              >
+                                <div class="relative flex items-center justify-center">
+                                  <div
+                                    class="inline-flex"
+                                    style="opacity: 1; transition: opacity 150ms 150ms"
+                                  >
+                                    <svg
+                                      role="img"
+                                      class="inline-flex fill-current shrink-0"
+                                      width="16"
+                                      height="16"
+                                    >
+                                      <use xlink:href="#pplx-icon-thumb-down"></use>
+                                    </svg>
+                                  </div>
+                                  <div
+                                    class="absolute inset-0 flex items-center justify-center"
+                                    style="opacity: 0; transition: opacity 150ms"
+                                  ></div>
+                                </div>
+                              </button>
+                            </div>
+                          </div>
+                          <div>
+                            <button
+                              data-state="closed"
+                              aria-label="More actions"
+                              aria-expanded="false"
+                              aria-haspopup="menu"
+                              type="button"
+                              class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap data-[state=open]:text-foreground data-[state=open]:bg-subtle text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex rounded-full aspect-square p-0 hover:text-foreground hover:bg-subtle"
+                            >
+                              <svg
+                                role="img"
+                                class="inline-flex fill-current shrink-0"
+                                width="16"
+                                height="16"
+                              >
+                                <use xlink:href="#pplx-icon-dots"></use>
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="gap-y-lg flex flex-col first:mt-0"></div>
+          </div>
+        </div>
+      </div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-shopping"
+        hidden=""
+        id="radix-:r29n:-content-shopping"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-hotels"
+        hidden=""
+        id="radix-:r29n:-content-hotels"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-places"
+        hidden=""
+        id="radix-:r29n:-content-places"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-jobs"
+        hidden=""
+        id="radix-:r29n:-content-jobs"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-videos"
+        hidden=""
+        id="radix-:r29n:-content-videos"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-images"
+        hidden=""
+        id="radix-:r29n:-content-images"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-sources"
+        hidden=""
+        id="radix-:r29n:-content-sources"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-assets"
+        hidden=""
+        id="radix-:r29n:-content-assets"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+      <div
+        data-state="inactive"
+        data-orientation="horizontal"
+        role="tabpanel"
+        aria-labelledby="radix-:r29n:-trigger-news"
+        hidden=""
+        id="radix-:r29n:-content-news"
+        tabindex="0"
+        class="focus:outline-none"
+      ></div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Add `PerplexityExtractor` class extending `BaseExtractor` for `www.perplexity.ai`
- Integrate into extension pipeline: manifest permissions, background ALLOWED_ORIGINS, content script routing
- Rename fixture directory `perplxity` → `perplexity`
- Add Perplexity DOM helpers, 29 unit tests, and 4 E2E tests (582 total, 0 regressions)

## Changes

| File | Action |
|---|---|
| `src/content/extractors/perplexity.ts` | **NEW** — PerplexityExtractor class |
| `src/manifest.json` | Add `host_permissions` + `content_scripts` |
| `src/background/index.ts` | Add to `ALLOWED_ORIGINS` |
| `src/content/index.ts` | Add routing + container wait selector |
| `test/fixtures/dom-helpers.ts` | Add Perplexity DOM helpers |
| `test/extractors/e2e/helpers.ts` | Add `'perplexity'` to E2E pipeline |
| `test/extractors/perplexity.test.ts` | **NEW** — 29 unit tests |
| `test/extractors/e2e/perplexity.e2e.test.ts` | **NEW** — 4 E2E tests |
| `test/fixtures/html/perplexity/` | Renamed from `perplxity/` |

## Design

- Follows `ChatGPTExtractor` pattern (no special Deep Research mode)
- Turn pairing: `span.select-text` (queries) ↔ `div[id^="markdown-content-"]` (responses) by sequential index
- Citations: `<a href>` survives DOMPurify; `data-pplx-*` stripped (acceptable)
- Strict hostname check (`www.perplexity.ai`) prevents subdomain attacks

## Test plan

- [x] `npm run format` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — TypeScript + Vite passes
- [x] `npx vitest run` — 582 tests pass, 0 failures
- [x] No regressions in existing Gemini/Claude/ChatGPT extractors
- [x] E2E snapshots generated for chat-simple and deep-research fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)