### PR TITLE
fix: release-please versioning and add Perplexity docs

### DIFF
--- a/docs/design/DES-004-perplexity-extractor.md
+++ b/docs/design/DES-004-perplexity-extractor.md
@@ -1,0 +1,431 @@
+# DES-004: Perplexity Extractor Design
+
+**Status**: Draft
+**Requirements**: `docs/requirements/REQ-perplexity-extractor.md`
+**Precedent**: `src/content/extractors/chatgpt.ts` (closest pattern match)
+
+---
+
+## 1. Overview
+
+This document specifies the design for `PerplexityExtractor`, a new extractor class supporting `www.perplexity.ai`. The design follows the established `BaseExtractor` pattern and mirrors the `ChatGPTExtractor` approach (no special Deep Research mode).
+
+## 2. Design Decisions Summary
+
+| Decision | Choice | Evidence |
+|---|---|---|
+| Hostname | `www.perplexity.ai` | All observed URLs use `www` subdomain |
+| Conversation ID | Full slug from `/search/{slug}` | REQ Q2 |
+| Citations | Preserve in HTML; `<a href>` survives DOMPurify | REQ Q3; `data-pplx-*` stripped by sanitize.ts, but `href` persists |
+| Deep Research | Treat as `type: 'conversation'` | REQ Q5; no structural difference in DOM |
+| Fixture directory | Rename `perplxity` → `perplexity` | REQ Q4 |
+
+---
+
+## 3. Architecture
+
+### 3.1 Class Diagram
+
+```
+IConversationExtractor (interface)
+        │
+  BaseExtractor (abstract)
+   ├── GeminiExtractor
+   ├── ClaudeExtractor
+   ├── ChatGPTExtractor
+   └── PerplexityExtractor  ← NEW
+```
+
+### 3.2 File Map
+
+| File | Action | Description |
+|---|---|---|
+| `src/content/extractors/perplexity.ts` | **CREATE** | PerplexityExtractor class |
+| `src/content/index.ts` | MODIFY | Add routing + container selector |
+| `src/background/index.ts` | MODIFY | Add to ALLOWED_ORIGINS |
+| `src/manifest.json` | MODIFY | Add host_permissions + content_scripts |
+| `src/lib/types.ts` | NO CHANGE | `'perplexity'` already in unions |
+| `src/lib/sanitize.ts` | NO CHANGE | `<a href>` survives; `data-pplx-*` not needed |
+| `src/content/markdown.ts` | NO CHANGE | `getAssistantLabel('perplexity')` already returns `'Perplexity'` |
+| `test/fixtures/html/perplxity/` | RENAME | → `test/fixtures/html/perplexity/` |
+| `test/fixtures/dom-helpers.ts` | MODIFY | Add Perplexity DOM helpers |
+| `test/extractors/e2e/helpers.ts` | MODIFY | Add Perplexity to pipeline |
+| `test/extractors/perplexity.test.ts` | **CREATE** | Unit tests |
+| `test/extractors/e2e/perplexity.e2e.test.ts` | **CREATE** | E2E tests |
+
+---
+
+## 4. PerplexityExtractor Design
+
+### 4.1 SELECTORS Constant
+
+```typescript
+const SELECTORS = {
+  // User query text
+  userQuery: [
+    'span.select-text',                          // Semantic (HIGH)
+    'div.bg-offset.rounded-2xl span.select-text', // Style (MEDIUM)
+  ],
+
+  // Assistant response content container
+  markdownContent: [
+    'div[id^="markdown-content-"]',               // ID pattern (HIGH)
+    '.prose.dark\\:prose-invert',                  // Style (MEDIUM)
+  ],
+
+  // Prose content within response
+  proseContent: [
+    '.prose.dark\\:prose-invert',                  // Standard (HIGH)
+    '.prose',                                      // Fallback (LOW)
+  ],
+
+  // Conversation container (for waitForConversationContainer)
+  conversationContainer: [
+    'div.max-w-threadContentWidth',                // Layout (HIGH)
+    'div[class*="threadContentWidth"]',            // Partial match (MEDIUM)
+  ],
+};
+```
+
+**Evidence from HTML fixtures:**
+
+| Selector | Found at (chat-simple.html) | Stability |
+|---|---|---|
+| `span.select-text` | Lines 447, 1096 | HIGH - semantic class for user query text |
+| `div[id^="markdown-content-"]` | Line 516 (`id="markdown-content-0"`), Line 1165 (`id="markdown-content-1"`) | HIGH - sequential ID pattern |
+| `.prose.dark\\:prose-invert` | Lines 524, 1173 | HIGH - Tailwind typography plugin class |
+| `div.max-w-threadContentWidth` | Lines 339, 355, 988 | HIGH - layout class for thread content |
+
+### 4.2 Turn Discovery Strategy
+
+**Problem**: Unlike ChatGPT (which uses `article[data-turn-id]`), Perplexity has no explicit turn delimiter element. Turns are identified by the co-occurrence of a query (`span.select-text`) and a response (`div[id^="markdown-content-"]`).
+
+**Strategy**: Collect all user queries and all assistant responses independently, then pair them by DOM order using sequential index correlation.
+
+**Evidence from DOM structure** (chat-simple.html):
+
+Turn 0:
+- Query at line 447: `span.select-text` → "perplexityのhtml構造をテストするための質問です。「はい」とだけ答えて。"
+- Response at line 516: `id="markdown-content-0"` → "はい。"
+
+Turn 1:
+- Query at line 1096: `span.select-text` → "次は「いいえ」だけ答えて"
+- Response at line 1165: `id="markdown-content-1"` → "いいえ。"
+
+The `markdown-content-{N}` IDs are 0-indexed and sequential, matching query order. This provides a reliable pairing mechanism.
+
+### 4.3 Method Specifications
+
+#### `canExtract(): boolean`
+
+```typescript
+canExtract(): boolean {
+  return window.location.hostname === 'www.perplexity.ai';
+}
+```
+
+**Security**: Strict `===` comparison prevents subdomain attacks (e.g., `evil-www.perplexity.ai.attacker.com`).
+
+#### `getConversationId(): string | null`
+
+```typescript
+getConversationId(): string | null {
+  const match = window.location.pathname.match(/\/search\/(.+)$/);
+  return match ? match[1] : null;
+}
+```
+
+**Evidence from URLs:**
+- `/search/perplexitynohtmlgou-zao-wotesu-Y8vT04G0SKap6aQTA8L6hg` → full slug
+- `/search/da-shou-ting-toraba-CG5SwgBvRti46_Hs1jFYAw` → full slug
+
+The regex `\/search\/(.+)$` captures everything after `/search/`.
+
+#### `getTitle(): string`
+
+Priority:
+1. First `span.select-text` text content, sanitized, truncated to `MAX_CONVERSATION_TITLE_LENGTH` (100 chars)
+2. Fallback: `'Untitled Perplexity Conversation'`
+
+#### `extractMessages(): ConversationMessage[]`
+
+Algorithm:
+1. Collect all `span.select-text` elements → user queries (ordered by DOM position)
+2. Collect all `div[id^="markdown-content-"]` elements → assistant responses (ordered by ID index)
+3. Pair queries and responses by sequential index (query[0] ↔ response[0], query[1] ↔ response[1], ...)
+4. For each pair:
+   - User: extract `textContent` from `span.select-text`, sanitize
+   - Assistant: extract `innerHTML` from the `.prose` child inside the `markdown-content-*` div, sanitize via DOMPurify
+
+**Edge cases:**
+- More queries than responses (user asked but response pending): include query-only messages
+- More responses than queries (system-generated content): skip orphan responses
+- Empty content: skip and log warning
+
+#### `extract(): Promise<ExtractionResult>`
+
+Standard flow matching ChatGPTExtractor pattern:
+1. `canExtract()` guard
+2. `extractMessages()`
+3. Validate message count
+4. Build `ConversationData` with `source: 'perplexity'`
+5. Return `ExtractionResult`
+
+### 4.4 Citation Handling in DOMPurify
+
+**Key insight**: Perplexity citations use this structure:
+
+```html
+<span class="citation inline"
+      data-pplx-citation=""
+      data-pplx-citation-url="https://example.com">
+  <a href="https://example.com">
+    <span>example</span>
+  </a>
+</span>
+```
+
+After DOMPurify processing (current `sanitize.ts`):
+- `data-pplx-citation` → **STRIPPED** (blocked by `data-*` filter in hook)
+- `data-pplx-citation-url` → **STRIPPED** (blocked by `data-*` filter in hook)
+- `<a href="https://example.com">` → **PRESERVED** (standard HTML)
+- `<span>example</span>` → **PRESERVED** (standard HTML)
+
+**Result**: The `<a href>` tag survives sanitization. Turndown will convert `<a href="url">text</a>` to `[text](url)` in Markdown. No changes to `sanitize.ts` needed.
+
+The `<span class="citation-nbsp">` (empty separator span) will be stripped by DOMPurify or ignored by Turndown, which is acceptable behavior.
+
+---
+
+## 5. Integration Changes
+
+### 5.1 `src/content/index.ts` — Routing
+
+Add import and routing for Perplexity:
+
+```typescript
+import { PerplexityExtractor } from './extractors/perplexity';
+
+// In getExtractor():
+if (hostname === 'www.perplexity.ai') {
+  return new PerplexityExtractor();
+}
+```
+
+### 5.2 `src/content/index.ts` — Container Wait Selector
+
+Add Perplexity-specific selector to `waitForConversationContainer()`:
+
+```
+Current:  '.conversation-container, [class*="conversation"], article[data-turn-id]'
+Updated:  '.conversation-container, [class*="conversation"], article[data-turn-id], div[class*="threadContentWidth"]'
+```
+
+The selector `div[class*="threadContentWidth"]` matches `div.max-w-threadContentWidth`, which is the main content container on Perplexity pages.
+
+### 5.3 `src/background/index.ts` — ALLOWED_ORIGINS
+
+```typescript
+const ALLOWED_ORIGINS = [
+  'https://gemini.google.com',
+  'https://claude.ai',
+  'https://chatgpt.com',
+  'https://www.perplexity.ai',  // NEW
+] as const;
+```
+
+**Note**: No changes to `validateNoteData()` needed. The frontmatter source validation at `background/index.ts:140` already includes `'perplexity'` in the allowed list.
+
+### 5.4 `src/manifest.json`
+
+Add to `host_permissions`:
+```json
+"https://www.perplexity.ai/*"
+```
+
+Add to `content_scripts[0].matches`:
+```json
+"https://www.perplexity.ai/*"
+```
+
+---
+
+## 6. Test Design
+
+### 6.1 Fixture Rename
+
+```
+test/fixtures/html/perplxity/ → test/fixtures/html/perplexity/
+```
+
+Files retained:
+- `chat-simple.html` (2-turn conversation)
+- `deep-research.html` (single-turn Deep Research report)
+
+### 6.2 DOM Helpers (`test/fixtures/dom-helpers.ts`)
+
+New functions following existing ChatGPT helper pattern:
+
+#### `setPerplexityLocation(slug: string): void`
+
+```typescript
+export function setPerplexityLocation(slug: string): void {
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: 'www.perplexity.ai',
+      pathname: `/search/${slug}`,
+      href: `https://www.perplexity.ai/search/${slug}`,
+      origin: 'https://www.perplexity.ai',
+      protocol: 'https:',
+      host: 'www.perplexity.ai',
+      search: '',
+      hash: '',
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+```
+
+#### `setNonPerplexityLocation(hostname: string, pathname?: string): void`
+
+For security tests (subdomain attack prevention).
+
+#### `createPerplexityConversationDOM(messages: PerplexityConversationMessage[]): string`
+
+Creates minimal DOM matching the observed Perplexity structure:
+- User queries wrapped in `div[class*="group/query"] > div.bg-offset > span.select-text`
+- Assistant responses in `div[id="markdown-content-{N}"] > div.prose`
+
+#### `createPerplexityPage(slug: string, messages: PerplexityConversationMessage[]): void`
+
+Combines `setPerplexityLocation` + `loadFixture`.
+
+#### `createPerplexityInlineCitation(url: string, displayText: string): string`
+
+Creates Perplexity-style citation HTML with `data-pplx-citation-url`.
+
+### 6.3 E2E Helper Updates (`test/extractors/e2e/helpers.ts`)
+
+Add `'perplexity'` to:
+- `loadFixtureFile()` platform parameter type
+- `setLocationForPlatform()` switch
+- `createExtractor()` switch
+- `runE2EPipeline()` platform parameter type
+- `assertSourcePlatform()` expected parameter type
+- `assertCalloutFormat()` platform parameter type
+
+### 6.4 Unit Tests (`test/extractors/perplexity.test.ts`)
+
+Test categories (following `claude.test.ts` pattern):
+
+**Platform Detection:**
+- `canExtract()` returns true on `www.perplexity.ai`
+- `canExtract()` returns false on `perplexity.ai` (without www)
+- `canExtract()` returns false on subdomain attacks (`evil.www.perplexity.ai.attacker.com`)
+
+**URL Extraction:**
+- `getConversationId()` extracts full slug from `/search/{slug}` URLs
+- `getConversationId()` returns null for non-search paths (e.g., `/`, `/hub`, `/pro`)
+
+**Title Extraction:**
+- `getTitle()` returns first user query text
+- `getTitle()` truncates to `MAX_CONVERSATION_TITLE_LENGTH`
+- `getTitle()` returns default when no queries found
+
+**Message Extraction:**
+- `extractMessages()` extracts paired user/assistant messages
+- `extractMessages()` handles multi-turn conversations
+- `extractMessages()` returns empty array when no content found
+- `extractMessages()` preserves HTML content for assistant messages
+- Citations in assistant HTML have `<a href>` preserved after sanitization
+
+**Full Extraction:**
+- `extract()` returns success with valid conversation data
+- `extract()` returns `source: 'perplexity'`
+- `extract()` returns failure when not on Perplexity page
+
+### 6.5 E2E Tests (`test/extractors/e2e/perplexity.e2e.test.ts`)
+
+**Chat - Simple Conversation:**
+- Loads `chat-simple.html` fixture
+- Validates extraction success, source platform, message structure
+- Validates frontmatter fields
+- Validates callout format (`> [!QUESTION]`, `> [!NOTE]`)
+- Snapshot test for full Markdown output
+
+**Deep Research:**
+- Loads `deep-research.html` fixture
+- Validates extraction as normal conversation (not `type: 'deep-research'`)
+- Validates content includes headings, tables, citation links
+- Snapshot test for full Markdown output
+
+---
+
+## 7. Sequence Diagram
+
+```
+User clicks Sync button
+        │
+        ▼
+  handleSync()
+        │
+        ▼
+  getExtractor()
+   hostname === 'www.perplexity.ai'
+        │
+        ▼
+  PerplexityExtractor.extract()
+        │
+        ├─→ canExtract()     → true
+        ├─→ extractMessages()
+        │     ├─→ queryAllWithFallback(SELECTORS.userQuery)
+        │     │     → [span.select-text, span.select-text, ...]
+        │     ├─→ querySelectorAll('div[id^="markdown-content-"]')
+        │     │     → [div#markdown-content-0, div#markdown-content-1, ...]
+        │     ├─→ pair by index → [{user, assistant}, ...]
+        │     └─→ sanitizeHtml(response.innerHTML) for each assistant
+        ├─→ getConversationId()
+        │     → pathname.match(/\/search\/(.+)$/) → full slug
+        ├─→ getTitle()
+        │     → first span.select-text textContent
+        └─→ return ExtractionResult { source: 'perplexity' }
+        │
+        ▼
+  conversationToNote()
+        │ getAssistantLabel('perplexity') → 'Perplexity'
+        │ htmlToMarkdown() via Turndown
+        │   └─→ <a href="url">text</a> → [text](url)
+        ▼
+  saveToOutputs()
+```
+
+---
+
+## 8. Risk Analysis
+
+| Risk | Mitigation |
+|---|---|
+| Perplexity DOM changes | Multiple fallback selectors; HIGH/MEDIUM stability ranking |
+| `span.select-text` is too generic | Scoped within query container context, not document-wide |
+| `markdown-content-{N}` ID pattern changes | Fallback to `.prose` selector |
+| Hostname redirect (`perplexity.ai` → `www.perplexity.ai`) | Content script only runs on `www.perplexity.ai`; Chrome handles redirect before content script injection |
+| DOMPurify strips citation context | `<a href>` survives; display text preserved; only `data-*` attrs stripped (acceptable) |
+| Large Deep Research reports exceed MAX_CONTENT_SIZE | Existing 1MB limit applies; Perplexity reports observed to be well under this |
+
+---
+
+## 9. Implementation Steps
+
+Ordered by dependency:
+
+1. **Rename fixture directory**: `test/fixtures/html/perplxity/` → `test/fixtures/html/perplexity/`
+2. **Create `src/content/extractors/perplexity.ts`**: PerplexityExtractor class
+3. **Modify `src/content/index.ts`**: Add import, routing, container selector
+4. **Modify `src/background/index.ts`**: Add to ALLOWED_ORIGINS
+5. **Modify `src/manifest.json`**: Add host_permissions + content_scripts
+6. **Modify `test/fixtures/dom-helpers.ts`**: Add Perplexity DOM helpers
+7. **Modify `test/extractors/e2e/helpers.ts`**: Add Perplexity to pipeline
+8. **Create `test/extractors/perplexity.test.ts`**: Unit tests
+9. **Create `test/extractors/e2e/perplexity.e2e.test.ts`**: E2E tests
+10. **Run tests**: `npm run lint && npm run build && npx vitest run`

--- a/docs/requirements/REQ-perplexity-extractor.md
+++ b/docs/requirements/REQ-perplexity-extractor.md
@@ -1,0 +1,241 @@
+# REQ: Perplexity Extractor - Requirements Specification
+
+## 1. Background & Goal
+
+The gemini2obsidian Chrome Extension currently supports Gemini, Claude, and ChatGPT. The user wants to add **Perplexity** (`www.perplexity.ai`) as a fourth supported platform.
+
+Perplexity has two content types:
+- **Simple Chat**: Multi-turn Q&A conversations (similar to other platforms)
+- **Deep Research**: A comprehensive report generated in response to a single query (embedded as part of the chat structure, similar to ChatGPT's approach)
+
+## 2. Scope
+
+This document covers requirements discovery only. Architecture and implementation details are deferred to `/sc:design` and `/sc:implement`.
+
+---
+
+## 3. DOM Structure Analysis (from HTML fixtures)
+
+### 3.1 Perplexity Page Structure
+
+Perplexity uses a **React + Radix UI** component architecture. The conversation is structured as a sequence of **query-response pairs** (turns), where each turn is a nested set of divs rather than article/turn elements.
+
+### 3.2 User Message (Query)
+
+**Key selector path:**
+```
+div.group/query > div.bg-offset > span.select-text
+```
+
+- User queries are wrapped in `<h1>` (first turn) or `<div>` elements with class `group/query`
+- The actual text is inside `<span class="select-text">`
+- The query bubble has class `bg-offset text-foreground rounded-2xl p-3`
+- User queries are right-aligned (wrapped in `flex justify-end`)
+- Edit/Copy Query buttons appear alongside (aria-label="Edit Query", "Copy Query")
+
+**Selectors (stability HIGH → LOW):**
+1. `span.select-text` inside `div[class*="group/query"]` (HIGH - semantic)
+2. `div.bg-offset.rounded-2xl span.select-text` (MEDIUM - style-based)
+
+### 3.3 Assistant Response (Answer)
+
+**Key selector path:**
+```
+div[id^="markdown-content-"] > div.has-inline-images > div.prose
+```
+
+- Each response has a unique `id="markdown-content-{N}"` (0-indexed)
+- Content is inside `div.prose.dark\\:prose-invert`
+- Contains headings (`<h2>`), paragraphs (`<p>`), tables (`<table>`), etc.
+- Inline citations use `<span class="citation inline" data-pplx-citation-url="...">`
+- The `data-pplx-citation-url` attribute holds the source URL
+- Citation display text is inside nested `<span>` within the citation element
+- A `<span class="citation-nbsp">` appears before each citation (separator)
+
+**Selectors (stability HIGH → LOW):**
+1. `div[id^="markdown-content-"]` (HIGH - unique ID pattern)
+2. `div.prose.dark\\:prose-invert` within answer area (MEDIUM)
+
+### 3.4 Turn Structure
+
+Each Q&A turn follows this nesting pattern:
+```
+div.flex.flex-col.gap-y-lg          ← Turn container
+  ├── div.bg-base                   ← Query block
+  │   └── div.group/query
+  │       └── div.bg-offset > span.select-text  ← User query text
+  └── div.gap-y-lg.flex.flex-col    ← Response block
+      └── div[role="tabpanel"]
+          └── div[id^="markdown-content-"]       ← Assistant response
+              └── div.prose                       ← Markdown content
+```
+
+Follow-up turns are nested inside a wrapper with class `min-h-[var(--page-content-height)]` and repeat the same structure.
+
+### 3.5 Citations (Inline)
+
+Perplexity uses the `data-pplx-citation` attribute system:
+```html
+<span class="citation inline"
+      data-pplx-citation=""
+      data-pplx-citation-url="https://example.com/article">
+  <a href="https://example.com/article">
+    <span>example</span>
+  </a>
+</span>
+```
+
+- The `data-pplx-citation-url` attribute contains the source URL
+- The `aria-label` on the parent `<span class="inline-flex">` contains the title
+- Citations appear inline in text, preceded by `<span class="citation-nbsp">`
+
+### 3.6 Source List
+
+- A button showing "Reviewed N sources" or "N steps completed" appears in the response metadata area
+- Individual source favicons are displayed (not directly linkable from this button)
+- Full source details are available on the "Links" tab but may not be accessible from the Answer tab DOM
+
+### 3.7 Deep Research Detection
+
+Deep Research responses are distinguished by:
+- The presence of `"N steps completed"` text (vs "Reviewed N sources" for normal search)
+- More extensive content with structured headings, tables, etc.
+- Single query with a comprehensive report response
+- **No separate Deep Research panel** (unlike Gemini's `deep-research-immersive-panel` or Claude's `#markdown-artifact`)
+
+Since Deep Research is structurally identical to a normal conversation (just longer), the ChatGPT approach applies: **treat Deep Research as a normal conversation** without special extraction logic.
+
+---
+
+## 4. URL Structure
+
+Pattern: `https://www.perplexity.ai/search/{slug}-{hash}`
+
+Examples:
+- `https://www.perplexity.ai/search/perplexitynohtmlgou-zao-wotesu-Y8vT04G0SKap6aQTA8L6hg`
+- `https://www.perplexity.ai/search/da-shou-ting-toraba-CG5SwgBvRti46_Hs1jFYAw`
+- `https://www.perplexity.ai/search/xian-zai-qnap-ts-433-4g-nas-wo-MPL6rxO2R5C96UJ1M1Uzeg`
+
+**Conversation ID extraction:**
+- Path format: `/search/{title-slug}-{base64-like-hash}`
+- The hash portion at the end appears to be the unique identifier
+- Regex: `/\/search\/(.+)$/i` → full slug, or extract just the trailing hash
+
+**Hostname:** `www.perplexity.ai` (note: includes `www` subdomain)
+
+---
+
+## 5. Functional Requirements
+
+### FR-001: Platform Detection
+- Detect Perplexity pages via `window.location.hostname === 'www.perplexity.ai'`
+- Note: Must use `www.perplexity.ai`, not `perplexity.ai`
+
+### FR-002: Conversation ID Extraction
+- Extract from URL path `/search/{slug}`
+- Use the full slug as ID, or extract the trailing hash portion
+- Fallback to `perplexity-{timestamp}` if no match
+
+### FR-003: Title Extraction
+- Use the first user query text as the title
+- Truncate to `MAX_CONVERSATION_TITLE_LENGTH`
+- Default: "Untitled Perplexity Conversation"
+
+### FR-004: User Message Extraction
+- Extract text from `span.select-text` within query containers
+- Preserve multi-line content
+- Sanitize whitespace
+
+### FR-005: Assistant Response Extraction
+- Extract HTML content from `div[id^="markdown-content-"]` elements
+- Sanitize via DOMPurify
+- Preserve headings, paragraphs, tables, lists, code blocks
+
+### FR-006: Citation Handling
+- Extract inline citations from `span.citation[data-pplx-citation-url]`
+- Preserve citation URLs in the HTML for Markdown conversion
+- Optionally extract citation sources as `DeepResearchLinks` for frontmatter
+
+### FR-007: Multi-turn Conversation
+- Handle multiple Q&A turns in sequence
+- Correctly pair user queries with their corresponding responses
+- Maintain message order
+
+### FR-008: Deep Research Support
+- Treat Deep Research same as normal conversation (ChatGPT pattern)
+- No special extraction mode needed
+- The conversation type can remain `'conversation'` (no need for `'deep-research'` type)
+
+---
+
+## 6. Non-Functional Requirements
+
+### NFR-001: Security
+- Strict hostname comparison (`===`) to prevent subdomain attacks
+- Origin validation in background worker: add `'https://www.perplexity.ai'` to `ALLOWED_ORIGINS`
+- HTML sanitization via DOMPurify for all assistant content
+
+### NFR-002: Resilience
+- Multiple fallback selectors per element (HIGH → LOW stability)
+- Graceful degradation when selectors fail
+- Warnings for partial extraction
+
+### NFR-003: Consistency
+- Follow existing extractor patterns (extend `BaseExtractor`)
+- Use same output format (Obsidian callouts with YAML frontmatter)
+- Same message structure (`ConversationMessage`)
+
+---
+
+## 7. Integration Points (Checklist)
+
+Based on CLAUDE.md "Adding New Platforms" guide:
+
+1. [ ] `src/lib/types.ts` — `'perplexity'` already exists in source/platform unions
+2. [ ] `src/content/extractors/base.ts` — May need updates if platform-specific logic exists
+3. [ ] `src/content/extractors/perplexity.ts` — **NEW FILE**: Create extractor class
+4. [ ] `src/content/index.ts` — Add routing for `www.perplexity.ai`
+5. [ ] `src/content/index.ts` — Update `waitForConversationContainer()` selectors
+6. [ ] `src/background/index.ts` — Add `'https://www.perplexity.ai'` to `ALLOWED_ORIGINS`
+7. [ ] `src/manifest.json` — Add to `host_permissions`
+8. [ ] `src/manifest.json` — Add to `content_scripts.matches`
+9. [ ] `test/extractors/perplexity.test.ts` — **NEW FILE**: Unit tests
+10. [ ] `test/extractors/e2e/perplexity.e2e.test.ts` — **NEW FILE**: E2E tests
+11. [ ] `test/fixtures/html/perplexity/` — Rename from `perplxity` (typo in current directory name)
+12. [ ] `test/fixtures/dom-helpers.ts` — Add Perplexity DOM helpers
+
+---
+
+## 8. Design Decisions (Resolved)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| Q1 | Hostname | `www.perplexity.ai` only | Matches observed URLs. Users always land on `www`. |
+| Q2 | Conversation ID | Full slug from `/search/{slug}` | Simple, unique, preserves URL semantics. |
+| Q3 | Citations | Preserve in HTML only | Simpler approach (like ChatGPT). Turndown handles link conversion. |
+| Q4 | Fixture directory | Rename `perplxity` → `perplexity` | Fix typo for consistency. |
+| Q5 | Deep Research | Treat all as `type: 'conversation'` | Structurally identical to normal chat. No special detection needed. |
+
+---
+
+## 9. Acceptance Criteria
+
+- [ ] Extension activates on `www.perplexity.ai` pages
+- [ ] Sync button appears on Perplexity conversation pages
+- [ ] Simple chat: All user queries and assistant responses extracted correctly
+- [ ] Deep Research: Full report content extracted correctly
+- [ ] Inline citations preserved in Markdown output
+- [ ] YAML frontmatter includes `source: perplexity`
+- [ ] Output matches Obsidian callout format of other platforms
+- [ ] Unit tests pass for platform detection, URL extraction, message extraction
+- [ ] E2E tests pass with provided HTML fixtures
+- [ ] No regressions in existing Gemini/Claude/ChatGPT extractors
+
+---
+
+## 10. Next Steps
+
+After requirements approval:
+1. **`/sc:design`** — Architecture design for PerplexityExtractor
+2. **`/sc:implement`** — Implementation
+3. **`/sc:test`** — Test execution and validation

--- a/docs/workflow/WF-006-perplexity-extractor-implementation.md
+++ b/docs/workflow/WF-006-perplexity-extractor-implementation.md
@@ -1,0 +1,537 @@
+# WF-006: Perplexity Extractor Implementation Workflow
+
+**Status**: Pending
+**Requirements**: `docs/requirements/REQ-perplexity-extractor.md`
+**Design**: `docs/design/DES-004-perplexity-extractor.md`
+**Precedent Workflow**: `docs/workflow/WF-003-chatgpt-extractor-implementation.md`
+
+---
+
+## Workflow Summary
+
+| Property | Value |
+|---|---|
+| Total Phases | 4 |
+| Total Steps | 10 |
+| New Files | 3 (`perplexity.ts`, `perplexity.test.ts`, `perplexity.e2e.test.ts`) |
+| Modified Files | 5 (`content/index.ts`, `background/index.ts`, `manifest.json`, `dom-helpers.ts`, `e2e/helpers.ts`) |
+| Renamed Dirs | 1 (`test/fixtures/html/perplxity/` → `test/fixtures/html/perplexity/`) |
+| Files Unchanged | 3 (`types.ts`, `sanitize.ts`, `markdown.ts`) — verified no changes needed |
+
+---
+
+## Phase 1: Foundation (Steps 1–2)
+
+> Prepare the file system and test infrastructure before writing any extractor code.
+
+### Step 1: Rename Fixture Directory
+
+**Action**: Rename `test/fixtures/html/perplxity/` → `test/fixtures/html/perplexity/`
+
+**Files**:
+- `test/fixtures/html/perplxity/` → `test/fixtures/html/perplexity/`
+
+**Command**:
+```bash
+git mv test/fixtures/html/perplxity test/fixtures/html/perplexity
+```
+
+**Validation**:
+- [ ] Directory `test/fixtures/html/perplexity/` exists
+- [ ] Files `chat-simple.html` and `deep-research.html` present
+- [ ] No remaining `perplxity` references in codebase (`grep -r perplxity .`)
+
+**Depends on**: Nothing
+**Blocks**: Steps 7, 8, 9
+
+---
+
+### Step 2: Add Perplexity DOM Helpers
+
+**Action**: Append Perplexity helper functions to `test/fixtures/dom-helpers.ts`
+
+**File**: `test/fixtures/dom-helpers.ts`
+
+**Functions to add** (following ChatGPT helper pattern at lines 575–742):
+
+1. **`PerplexityConversationMessage` interface**
+   - `role: 'user' | 'assistant'`
+   - `content: string`
+
+2. **`createPerplexityConversationDOM(messages): string`**
+   - Creates minimal DOM matching observed Perplexity structure
+   - User queries: `div[class*="group/query"] > div.bg-offset.rounded-2xl > span.select-text`
+   - Assistant responses: `div[id="markdown-content-{N}"] > div.prose.dark:prose-invert`
+   - Index `N` is 0-based, sequential
+
+3. **`setPerplexityLocation(slug: string): void`**
+   - Sets `window.location` for Perplexity URL
+   - `hostname: 'www.perplexity.ai'`
+   - `pathname: /search/${slug}`
+   - `origin: 'https://www.perplexity.ai'`
+
+4. **`setNonPerplexityLocation(hostname: string, pathname?: string): void`**
+   - For security testing (subdomain attack prevention)
+
+5. **`createPerplexityInlineCitation(url: string, displayText: string): string`**
+   - Creates `<span class="citation inline" data-pplx-citation-url="..."><a href="...">...</a></span>`
+
+6. **`createPerplexityPage(slug: string, messages): void`**
+   - Combines `setPerplexityLocation` + `loadFixture`
+
+**Reference pattern**: `createChatGPTConversationDOM` at `dom-helpers.ts:592`
+**Reference pattern**: `setChatGPTLocation` at `dom-helpers.ts:650`
+
+**Validation**:
+- [ ] TypeScript compiles without errors
+- [ ] Functions exported and accessible from test files
+
+**Depends on**: Nothing
+**Blocks**: Steps 8, 9
+
+---
+
+## Phase 2: Core Implementation (Steps 3–5)
+
+> Create the extractor and integrate it into the extension pipeline.
+
+### Step 3: Create PerplexityExtractor
+
+**Action**: Create new file `src/content/extractors/perplexity.ts`
+
+**Design reference**: `DES-004 Section 4`
+
+**Structure** (following `chatgpt.ts` at 299 lines):
+
+```
+src/content/extractors/perplexity.ts
+├── Imports: BaseExtractor, extractErrorMessage, sanitizeHtml, types, constants
+├── SELECTORS constant (DES-004 Section 4.1)
+│   ├── userQuery: ['span.select-text', 'div.bg-offset.rounded-2xl span.select-text']
+│   ├── markdownContent: ['div[id^="markdown-content-"]', '.prose.dark\\:prose-invert']
+│   └── proseContent: ['.prose.dark\\:prose-invert', '.prose']
+├── class PerplexityExtractor extends BaseExtractor
+│   ├── readonly platform = 'perplexity' as const
+│   ├── canExtract(): boolean
+│   │   └── window.location.hostname === 'www.perplexity.ai'
+│   ├── getConversationId(): string | null
+│   │   └── pathname.match(/\/search\/(.+)$/) → full slug
+│   ├── getTitle(): string
+│   │   └── First span.select-text → sanitize → truncate(100)
+│   │   └── Fallback: 'Untitled Perplexity Conversation'
+│   ├── extractMessages(): ConversationMessage[]
+│   │   ├── Collect all span.select-text → user queries
+│   │   ├── Collect all div[id^="markdown-content-"] → responses
+│   │   ├── Pair by sequential index
+│   │   ├── User: textContent → sanitizeText()
+│   │   └── Assistant: .prose innerHTML → sanitizeHtml()
+│   ├── private extractUserContent(queryElement): string
+│   ├── private extractAssistantContent(contentElement): string
+│   └── async extract(): Promise<ExtractionResult>
+│       ├── canExtract() guard
+│       ├── extractMessages()
+│       ├── Validate counts, build warnings
+│       ├── getConversationId() || `perplexity-${Date.now()}`
+│       ├── getTitle()
+│       └── Return ExtractionResult { source: 'perplexity' }
+```
+
+**Key implementation details**:
+
+- **Turn pairing**: `span.select-text` elements are collected document-wide. `div[id^="markdown-content-"]` elements provide 0-indexed IDs. Pair `queries[i]` with `responses[i]`.
+- **Assistant content extraction**: For each `div[id^="markdown-content-"]`, find the `.prose` child element and extract its `innerHTML`. Pass through `sanitizeHtml()`.
+- **Citation handling**: No special processing. `<a href>` tags inside citation spans survive DOMPurify and get converted to Markdown links by Turndown.
+
+**Validation**:
+- [ ] `npm run build` succeeds (TypeScript compiles)
+- [ ] Class extends `BaseExtractor` correctly
+- [ ] All abstract methods implemented
+
+**Depends on**: Nothing (standalone file)
+**Blocks**: Step 6
+
+---
+
+### Step 4: Update Manifest
+
+**Action**: Modify `src/manifest.json`
+
+**Changes**:
+
+1. Add to `host_permissions` array (after `"https://chatgpt.com/*"`):
+   ```json
+   "https://www.perplexity.ai/*"
+   ```
+
+2. Add to `content_scripts[0].matches` array (after `"https://chatgpt.com/*"`):
+   ```json
+   "https://www.perplexity.ai/*"
+   ```
+
+**Reference**: Current `manifest.json` lines 21–25 (host_permissions), lines 36–39 (content_scripts.matches)
+
+**Validation**:
+- [ ] JSON syntax valid
+- [ ] `npm run build` succeeds
+- [ ] 4 entries in host_permissions (excluding localhost)
+- [ ] 4 entries in content_scripts.matches
+
+**Depends on**: Nothing
+**Blocks**: Nothing (but required for runtime)
+
+---
+
+### Step 5: Update Background Worker
+
+**Action**: Modify `src/background/index.ts`
+
+**Change**: Add `'https://www.perplexity.ai'` to `ALLOWED_ORIGINS` (line 35–39):
+
+```typescript
+const ALLOWED_ORIGINS = [
+  'https://gemini.google.com',
+  'https://claude.ai',
+  'https://chatgpt.com',
+  'https://www.perplexity.ai',
+] as const;
+```
+
+**Verified NO CHANGE needed**:
+- `validateNoteData()` at line 140: already includes `'perplexity'` in source validation list
+
+**Validation**:
+- [ ] `npm run build` succeeds
+- [ ] Array has 4 entries
+- [ ] Origin matches `www.perplexity.ai` (with `www`)
+
+**Depends on**: Nothing
+**Blocks**: Nothing (but required for runtime)
+
+---
+
+## Phase 3: Routing Integration (Step 6)
+
+> Wire the extractor into the content script pipeline.
+
+### Step 6: Update Content Script Router
+
+**Action**: Modify `src/content/index.ts`
+
+**Changes**:
+
+1. **Add import** (after line 8):
+   ```typescript
+   import { PerplexityExtractor } from './extractors/perplexity';
+   ```
+
+2. **Add routing** in `getExtractor()` (after line 133, before `return null`):
+   ```typescript
+   if (hostname === 'www.perplexity.ai') {
+     return new PerplexityExtractor();
+   }
+   ```
+
+3. **Update container wait selectors** in `waitForConversationContainer()` (lines 65–66, 78–79):
+   - Current: `'.conversation-container, [class*="conversation"], article[data-turn-id]'`
+   - Updated: `'.conversation-container, [class*="conversation"], article[data-turn-id], div[class*="threadContentWidth"]'`
+   - Apply to both `document.querySelector` calls (lines 65 and 78)
+
+**Reference**: `getExtractor()` at `content/index.ts:122–137`
+**Reference**: `waitForConversationContainer()` at `content/index.ts:61–114`
+
+**Validation**:
+- [ ] `npm run build` succeeds
+- [ ] `npm run lint` passes
+- [ ] Import resolves correctly
+
+**Depends on**: Step 3 (perplexity.ts must exist)
+**Blocks**: Steps 8, 9
+
+---
+
+## Phase 4: Testing (Steps 7–10)
+
+> Create tests and validate the full pipeline.
+
+### Step 7: Update E2E Helper
+
+**Action**: Modify `test/extractors/e2e/helpers.ts`
+
+**Changes** (6 locations):
+
+1. **Add import** (line 18):
+   ```typescript
+   import { setPerplexityLocation } from '../../fixtures/dom-helpers';
+   ```
+   ```typescript
+   import { PerplexityExtractor } from '../../../src/content/extractors/perplexity';
+   ```
+
+2. **Update `loadFixtureFile()` platform type** (line 119):
+   ```typescript
+   platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity',
+   ```
+
+3. **Update `setLocationForPlatform()` switch** (lines 142–157):
+   Add case:
+   ```typescript
+   case 'perplexity':
+     setPerplexityLocation(conversationId);
+     break;
+   ```
+
+4. **Update `createExtractor()` switch** (lines 162–171):
+   Add case:
+   ```typescript
+   case 'perplexity':
+     return new PerplexityExtractor();
+   ```
+
+5. **Update `runE2EPipeline()` platform type** (line 185):
+   ```typescript
+   platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity',
+   ```
+
+6. **Update `assertSourcePlatform()` expected type** (line 263):
+   ```typescript
+   expected: 'gemini' | 'claude' | 'chatgpt' | 'perplexity'
+   ```
+
+7. **Update `assertCalloutFormat()` platform type** (line 343):
+   ```typescript
+   _platform: 'gemini' | 'claude' | 'chatgpt' | 'perplexity'
+   ```
+
+**Validation**:
+- [ ] TypeScript compiles
+- [ ] Existing E2E tests still pass: `npx vitest run test/extractors/e2e/`
+
+**Depends on**: Steps 1, 3 (fixture renamed, extractor exists)
+**Blocks**: Step 9
+
+---
+
+### Step 8: Create Unit Tests
+
+**Action**: Create new file `test/extractors/perplexity.test.ts`
+
+**Test structure** (following `claude.test.ts` pattern):
+
+```
+test/extractors/perplexity.test.ts
+├── describe('PerplexityExtractor')
+│   ├── describe('Platform Detection')
+│   │   ├── it('canExtract() returns true on www.perplexity.ai')
+│   │   ├── it('canExtract() returns false on perplexity.ai (no www)')
+│   │   ├── it('canExtract() returns false on evil.www.perplexity.ai.attacker.com')
+│   │   └── it('canExtract() returns false on other domains')
+│   │
+│   ├── describe('URL Extraction')
+│   │   ├── it('getConversationId() extracts slug from /search/{slug}')
+│   │   ├── it('getConversationId() handles URL-encoded characters')
+│   │   ├── it('getConversationId() returns null for non-search paths')
+│   │   └── it('getConversationId() returns null for root path')
+│   │
+│   ├── describe('Title Extraction')
+│   │   ├── it('getTitle() returns first user query text')
+│   │   ├── it('getTitle() truncates long titles')
+│   │   └── it('getTitle() returns default when no queries found')
+│   │
+│   ├── describe('Message Extraction')
+│   │   ├── it('extractMessages() extracts paired user/assistant messages')
+│   │   ├── it('extractMessages() handles multi-turn conversations')
+│   │   ├── it('extractMessages() returns empty array when no content')
+│   │   ├── it('extractMessages() preserves HTML for assistant messages')
+│   │   └── it('extractMessages() handles query without response (pending)')
+│   │
+│   └── describe('Full Extraction')
+│       ├── it('extract() returns success with valid data')
+│       ├── it('extract() sets source to perplexity')
+│       ├── it('extract() returns failure when not on Perplexity page')
+│       └── it('extract() handles empty conversation')
+```
+
+**Test helpers used**:
+- `setPerplexityLocation()` from `dom-helpers.ts`
+- `setNonPerplexityLocation()` from `dom-helpers.ts`
+- `createPerplexityConversationDOM()` from `dom-helpers.ts`
+- `createPerplexityPage()` from `dom-helpers.ts`
+- `loadFixture()`, `clearFixture()`, `resetLocation()` from `dom-helpers.ts`
+
+**Validation**:
+- [ ] `npx vitest run test/extractors/perplexity.test.ts` — all tests pass
+- [ ] Minimum 14 test cases
+
+**Depends on**: Steps 2, 3 (DOM helpers + extractor)
+**Blocks**: Step 10
+
+---
+
+### Step 9: Create E2E Tests
+
+**Action**: Create new file `test/extractors/e2e/perplexity.e2e.test.ts`
+
+**Test structure** (following `chatgpt.e2e.test.ts` pattern):
+
+```
+test/extractors/e2e/perplexity.e2e.test.ts
+├── describe('Perplexity E2E Extraction')
+│   ├── beforeEach: clearFixture()
+│   ├── afterEach: clearFixture() + resetLocation()
+│   │
+│   ├── describe('Chat - Simple Conversation')
+│   │   ├── FIXTURE = 'chat-simple'
+│   │   ├── CONVERSATION_ID = 'e2e-perplexity-chat-001'
+│   │   ├── it('should extract conversation with valid structure')
+│   │   │   ├── assertExtractionSuccess
+│   │   │   ├── assertSourcePlatform(data, 'perplexity')
+│   │   │   ├── assertMessageStructure(data, { minCount: 2 })
+│   │   │   ├── assertFrontmatterFields(note)
+│   │   │   └── assertCalloutFormat(markdown, 'perplexity')
+│   │   └── it('should generate correct markdown output')
+│   │       └── expect(result.finalMarkdown).toMatchSnapshot()
+│   │
+│   └── describe('Deep Research')
+│       ├── FIXTURE = 'deep-research'
+│       ├── CONVERSATION_ID = 'e2e-perplexity-dr-001'
+│       ├── it('should extract deep research as normal conversation')
+│       │   ├── assertExtractionSuccess
+│       │   ├── assertSourcePlatform(data, 'perplexity')
+│       │   ├── expect(data.type).not.toBe('deep-research')
+│       │   └── assertMessageStructure(data, { minCount: 1 })
+│       └── it('should generate correct markdown output')
+│           └── expect(result.finalMarkdown).toMatchSnapshot()
+```
+
+**Note on E2E helper `setLocationForPlatform`**: The Perplexity slug-based ID format differs from UUID-based IDs of other platforms. The `conversationId` parameter will be used as-is for the URL slug in `setPerplexityLocation()`.
+
+**Validation**:
+- [ ] `npx vitest run test/extractors/e2e/perplexity.e2e.test.ts` — all tests pass
+- [ ] Snapshots generated and reviewed
+- [ ] Minimum 4 test cases
+
+**Depends on**: Steps 1, 2, 3, 7 (fixture renamed, DOM helpers, extractor, E2E helper updated)
+**Blocks**: Step 10
+
+---
+
+### Step 10: Final Validation
+
+**Action**: Run full test suite and build validation
+
+**Commands** (sequential):
+
+```bash
+# 1. Format
+npm run format
+
+# 2. Lint
+npm run lint
+
+# 3. TypeScript check + production build
+npm run build
+
+# 4. Full test suite (includes existing + new tests)
+npx vitest run
+
+# 5. Verify no regressions in existing extractors
+npx vitest run test/extractors/e2e/gemini.e2e.test.ts
+npx vitest run test/extractors/e2e/claude.e2e.test.ts
+npx vitest run test/extractors/e2e/chatgpt.e2e.test.ts
+
+# 6. Verify new tests pass
+npx vitest run test/extractors/perplexity.test.ts
+npx vitest run test/extractors/e2e/perplexity.e2e.test.ts
+
+# 7. Verify no perplxity typo remains
+grep -r "perplxity" . --include="*.ts" --include="*.json" --include="*.md"
+```
+
+**Acceptance criteria checklist** (from REQ Section 9):
+- [ ] Extension activates on `www.perplexity.ai` pages (verified by unit test)
+- [ ] Simple chat: All user queries and assistant responses extracted (verified by E2E)
+- [ ] Deep Research: Full report content extracted (verified by E2E)
+- [ ] Inline citations preserved in Markdown output (verified by snapshot)
+- [ ] YAML frontmatter includes `source: perplexity` (verified by E2E)
+- [ ] Output matches Obsidian callout format (verified by E2E)
+- [ ] Unit tests pass (verified by vitest)
+- [ ] E2E tests pass (verified by vitest)
+- [ ] No regressions in existing extractors (verified by existing E2E tests)
+- [ ] `npm run lint` passes
+- [ ] `npm run build` succeeds
+
+**Depends on**: Steps 1–9 (all)
+**Blocks**: Nothing (final step)
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: Foundation
+  Step 1 (rename fixture) ─────────────────────┐
+  Step 2 (DOM helpers)    ──────────────────┐   │
+                                            │   │
+Phase 2: Core Implementation                │   │
+  Step 3 (perplexity.ts)  ──────────┐      │   │
+  Step 4 (manifest.json)  ──[independent]   │   │
+  Step 5 (background.ts)  ──[independent]   │   │
+                                    │      │   │
+Phase 3: Routing                    │      │   │
+  Step 6 (content/index.ts) ◄───────┘      │   │
+                                    │      │   │
+Phase 4: Testing                    │      │   │
+  Step 7 (e2e/helpers.ts)  ◄────────┼──────┼───┘
+  Step 8 (unit tests)      ◄────────┼──────┘
+  Step 9 (e2e tests)       ◄────────┴──────────┐
+                                               │
+  Step 10 (final validation) ◄─────────────────┘
+```
+
+**Parallelizable groups**:
+- Steps 1 + 2 (can run in parallel)
+- Steps 3 + 4 + 5 (can run in parallel)
+- Steps 7 + 8 (can run in parallel after dependencies met)
+
+---
+
+## Execution Checkpoints
+
+| After Phase | Checkpoint | Command |
+|---|---|---|
+| Phase 1 | Fixtures renamed, DOM helpers compile | `npm run build` |
+| Phase 2 | Extractor + manifest + background all compile | `npm run build` |
+| Phase 3 | Full pipeline compiles, format + lint clean | `npm run format && npm run lint && npm run build` |
+| Phase 4 | All tests pass, no regressions | `npm run format && npm run lint && npm run build && npx vitest run` |
+
+---
+
+## Files Changed Summary
+
+### New Files (3)
+| File | Phase | Step |
+|---|---|---|
+| `src/content/extractors/perplexity.ts` | 2 | 3 |
+| `test/extractors/perplexity.test.ts` | 4 | 8 |
+| `test/extractors/e2e/perplexity.e2e.test.ts` | 4 | 9 |
+
+### Modified Files (5)
+| File | Phase | Step | Lines Changed (est.) |
+|---|---|---|---|
+| `src/manifest.json` | 2 | 4 | +2 |
+| `src/background/index.ts` | 2 | 5 | +1 |
+| `src/content/index.ts` | 3 | 6 | +5 |
+| `test/fixtures/dom-helpers.ts` | 1 | 2 | +120 |
+| `test/extractors/e2e/helpers.ts` | 4 | 7 | +15 |
+
+### Renamed (1)
+| From | To | Step |
+|---|---|---|
+| `test/fixtures/html/perplxity/` | `test/fixtures/html/perplexity/` | 1 |
+
+### Verified Unchanged (3)
+| File | Reason |
+|---|---|
+| `src/lib/types.ts` | `'perplexity'` already in unions (line 30, 256) |
+| `src/lib/sanitize.ts` | `<a href>` survives DOMPurify; `data-pplx-*` not needed |
+| `src/content/markdown.ts` | `getAssistantLabel('perplexity')` already returns `'Perplexity'` (line 327) |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,5 +24,5 @@
   "pull-request-title-pattern": "chore(main): release ${version}",
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true
+  "bump-patch-for-minor-pre-major": false
 }


### PR DESCRIPTION
## Summary

- Disable `bump-patch-for-minor-pre-major` so `feat:` commits produce minor version bumps (e.g. 0.6.10 → 0.7.0) instead of patch bumps
- Add Perplexity extractor design, requirements, and workflow documentation

## Manual follow-up

To fix duplicate CHANGELOG entries, update GitHub repo settings:

- **Settings → General → Pull Requests** → Enable "Allow squash merging" with default "Pull request title"
- Optionally disable "Allow merge commits"

## Test plan

- [ ] Verify `release-please-config.json` is valid JSON
- [ ] Next `feat:` PR merge should produce a minor version bump
- [ ] Squash merge this PR to verify single CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)