### PR TITLE
feat: add platform lint script and update docs for Perplexity support

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,175 @@
+---
+description: "Commit, push, and create PR following release-please conventions"
+---
+
+Release workflow for current changes. User description: $ARGUMENTS
+
+Execute the following steps **in order**. Stop and report if any step fails.
+
+---
+
+## Step 1: Verify preconditions
+
+1. Run `git status` (never use `-uall`) and `git diff --stat` to see all changes (staged + unstaged + untracked).
+2. If there are **no changes** (no untracked files, no modifications, no staged changes), stop and report: "Nothing to release — no changes detected."
+3. Scan for sensitive files in the changes. NEVER stage any of these:
+   - `.env`, `.env.local`, `.mcp.json`
+   - Files matching `*credential*`, `*secret*`, `*token*`, `*.key`, `*.pem`
+   - `node_modules/`, `dist/`, `coverage/`
+   - `.DS_Store`, `Thumbs.db`
+4. If sensitive files are found in the diff, warn the user and ask for confirmation before proceeding. Exclude them from staging regardless.
+
+---
+
+## Step 2: Detect commit type
+
+First, check if `$ARGUMENTS` explicitly starts with a recognized conventional commit type followed by a colon (e.g., `fix: correct null pointer`). If so, use that type and description directly. Skip auto-detection.
+
+Recognized types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `revert`, `build`, `ci`, `security`, `ui`, `release`.
+
+If `$ARGUMENTS` does NOT start with a `type:` prefix (or is empty), auto-detect the **dominant** type by analyzing the changed file paths:
+
+| Changed File Patterns | Detected Type |
+|----------------------|---------------|
+| `src/` with **new files** or substantial new functionality | `feat` |
+| `src/` with bug fix modifications (small targeted changes) | `fix` |
+| `src/` with structural changes, no new features | `refactor` |
+| Only `docs/`, `README*`, `CLAUDE.md`, `*.html` doc files | `docs` |
+| Only test files (`*.test.ts`, `*.spec.ts`, fixtures) | `test` |
+| Only config files (`package.json` scripts, `eslint*`, `vite.config*`, `tsconfig*`) | `chore` |
+| Only `.github/workflows/` | `ci` |
+| Only CSS / formatting-only changes | `style` |
+| Performance-focused changes | `perf` |
+| Security-related changes | `security` |
+| UI-only changes (popup, CSS) | `ui` |
+| Mixed categories | Use the type covering the most impactful files; default to `feat` if new functionality exists, otherwise `chore` |
+
+---
+
+## Step 3: Generate commit message
+
+Format: `{type}: {description}`
+
+Rules:
+- Total header length MUST be **under 100 characters** (commitlint rule)
+- Description starts **lowercase**
+- No period at the end
+- No emoji in the header
+- If `$ARGUMENTS` is provided and does not start with a `type:` prefix, use it as the description verbatim
+- If `$ARGUMENTS` starts with `type: description`, use both parts directly
+- If `$ARGUMENTS` is empty, generate a concise description from the diff analysis
+
+---
+
+## Step 4: Create branch if needed
+
+Check the current branch with `git branch --show-current`.
+
+**If on `main`**:
+1. Slugify the description: lowercase, replace non-alphanumeric characters (except hyphens) with `-`, collapse consecutive hyphens, trim hyphens from start/end, truncate to 50 characters
+2. Run: `git checkout -b {type}/{slug}`
+
+**If already on a non-main branch**: stay on it, do not create a new branch.
+
+---
+
+## Step 5: Stage and commit
+
+### Staging
+
+Stage files selectively using `git add` with **explicit file paths**. Group related files together.
+
+NEVER use `git add -A` or `git add .`.
+
+Skip these patterns entirely:
+- `.env`, `.env.local`, `.mcp.json`
+- `node_modules/`, `dist/`, `coverage/`
+- `.DS_Store`, `Thumbs.db`
+- Files matching `*credential*`, `*secret*`, `*token*`, `*.key`, `*.pem`
+
+### Committing
+
+Commit using a heredoc to ensure proper multi-line formatting:
+
+```bash
+git commit -m "$(cat <<'EOF'
+{type}: {description}
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**If the commit fails** (e.g., commitlint hook rejects the message):
+1. Analyze the error message
+2. Fix the message format
+3. Create a **NEW** commit — NEVER use `--amend` or `--no-verify`
+
+---
+
+## Step 6: Push
+
+Run:
+```bash
+git push -u origin HEAD
+```
+
+**If the push fails** because the remote branch already exists with divergent history:
+- Stop and report the issue to the user
+- NEVER force push (`--force` or `--force-with-lease`)
+
+---
+
+## Step 7: Create PR
+
+First check if a PR already exists for this branch:
+```bash
+gh pr view --json url 2>/dev/null
+```
+
+If a PR already exists, report the existing PR URL and **skip PR creation**.
+
+If no PR exists, create one:
+
+```bash
+gh pr create --title "{type}: {description}" --body "$(cat <<'EOF'
+## Summary
+- {bullet points summarizing the actual changes from the diff}
+
+## Test plan
+- [ ] `npm run build` succeeds
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+- [ ] {additional relevant checks based on what changed}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Rules:
+- The PR **title MUST exactly match** the commit message header
+- Customize the Summary bullets based on what actually changed — not a generic template
+- Customize the Test plan based on which checks are relevant (e.g., for docs-only changes, skip test/build checks)
+
+---
+
+## Step 8: Report result
+
+Output a summary:
+- **Branch**: the branch name
+- **Commit**: the full commit message header
+- **Files**: number of files changed
+- **PR**: the PR URL (clickable)
+
+---
+
+## Safety Rules (ABSOLUTE — never override)
+
+- NEVER run `git push --force` or `git push --force-with-lease`
+- NEVER use `--no-verify` on any git command
+- NEVER use `--amend` on any commit
+- NEVER use `git add -A` or `git add .`
+- NEVER commit `.env`, `.mcp.json`, credential files, or secret files
+- NEVER force push to `main`
+- If push fails due to divergence, STOP and report — do not attempt to resolve automatically

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .mcp.json
 data/
 .serena/
-.claude/
+.claude/settings.local.json
 
 # Dependencies
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Chrome Extension that extracts AI conversations from Google Gemini and Claude AI and saves them to Obsidian via the Local REST API. Built with CRXJS + Vite + TypeScript.
+Chrome Extension that extracts AI conversations from Google Gemini, Claude AI, ChatGPT, and Perplexity and saves them to Obsidian via the Local REST API. Built with CRXJS + Vite + TypeScript.
 
 ## ⚠️ Absolute Rules
 
@@ -73,7 +73,7 @@ Load the extension in Chrome: `chrome://extensions` → Load unpacked → select
 ## Architecture
 
 ```
-Content Script (gemini.google.com, claude.ai)
+Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
     ↓ extracts conversation / Deep Research / Artifacts
 Background Service Worker
     ↓ sends to Obsidian
@@ -142,6 +142,7 @@ source: gemini
 - **Gemini** (`gemini.google.com`): Conversations and Deep Research reports
 - **Claude** (`claude.ai`): Conversations, Extended Thinking, and Artifacts with inline citations
 - **ChatGPT** (`chatgpt.com`): Conversations (including custom GPTs via `/g/` URLs)
+- **Perplexity** (`www.perplexity.ai`): Conversations
 
 ## Adding New Platforms
 
@@ -160,4 +161,4 @@ When adding a new platform extractor:
 
 ## Future Platforms
 
-Types support `perplexity` source. Add new extractors by extending `BaseExtractor` and implementing `IConversationExtractor`.
+Add new extractors by extending `BaseExtractor` and implementing `IConversationExtractor`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Google Gemini、Claude AI、ChatGPT の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
+Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
 
 [English version](README.md)
 
@@ -9,7 +9,7 @@ Google Gemini、Claude AI、ChatGPT の会話を Obsidian に保存する Chrome
 
 ## 機能
 
-- **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT からエクスポート
+- **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity からエクスポート
 - **ワンクリック保存**: 対応 AI ページに表示される「Sync」ボタンで即座に保存
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
 - **Deep Research 対応**: Gemini Deep Research と Claude Extended Thinking レポートを保存
@@ -87,6 +87,12 @@ Google Gemini、Claude AI、ChatGPT の会話を Obsidian に保存する Chrome
 ### ChatGPT
 
 1. [chatgpt.com](https://chatgpt.com) で会話を開く
+2. 右下に表示される紫色の「Sync」ボタンをクリック
+3. Gemini と同じ出力オプションで会話がエクスポートされます
+
+### Perplexity
+
+1. [www.perplexity.ai](https://www.perplexity.ai) で会話を開く
 2. 右下に表示される紫色の「Sync」ボタンをクリック
 3. Gemini と同じ出力オプションで会話がエクスポートされます
 
@@ -185,7 +191,7 @@ npm run test:coverage
 ## アーキテクチャ
 
 ```
-Content Script (gemini.google.com, claude.ai, chatgpt.com)
+Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
     ↓ 会話 / Deep Research / Artifacts を抽出
 Background Service Worker
     ↓ Obsidian に送信
@@ -200,6 +206,7 @@ Obsidian Local REST API (127.0.0.1:27123)
 | `src/content/extractors/gemini.ts` | Gemini 会話 & Deep Research 抽出 |
 | `src/content/extractors/claude.ts` | Claude 会話 & Artifact 抽出 |
 | `src/content/extractors/chatgpt.ts` | ChatGPT 会話抽出 |
+| `src/content/extractors/perplexity.ts` | Perplexity 会話抽出 |
 | `src/background/` | API 通信用のサービスワーカー |
 | `src/popup/` | 設定 UI |
 | `src/lib/` | 共有ユーティリティと型定義 |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Chrome Extension that exports AI conversations from Google Gemini, Claude AI, and ChatGPT to Obsidian via the Local REST API.
+Chrome Extension that exports AI conversations from Google Gemini, Claude AI, ChatGPT, and Perplexity to Obsidian via the Local REST API.
 
 [日本語版はこちら](README.ja.md)
 
@@ -9,7 +9,7 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, an
 
 ## Features
 
-- **Multi-platform support**: Export from Google Gemini, Claude AI, and ChatGPT
+- **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, and Perplexity
 - **One-click export**: Floating "Sync" button on supported AI pages
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
 - **Deep Research support**: Export Gemini Deep Research and Claude Extended Thinking reports
@@ -87,6 +87,12 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, an
 ### ChatGPT
 
 1. Open a conversation on [chatgpt.com](https://chatgpt.com)
+2. Click the purple "Sync" button in the bottom-right corner
+3. The conversation will be exported with the same output options as Gemini
+
+### Perplexity
+
+1. Open a conversation on [www.perplexity.ai](https://www.perplexity.ai)
 2. Click the purple "Sync" button in the bottom-right corner
 3. The conversation will be exported with the same output options as Gemini
 
@@ -185,7 +191,7 @@ npm run test:coverage
 ## Architecture
 
 ```
-Content Script (gemini.google.com, claude.ai, chatgpt.com)
+Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
     ↓ extracts conversation / Deep Research / Artifacts
 Background Service Worker
     ↓ sends to Obsidian
@@ -200,6 +206,7 @@ Obsidian Local REST API (127.0.0.1:27123)
 | `src/content/extractors/gemini.ts` | Gemini conversation & Deep Research extractor |
 | `src/content/extractors/claude.ts` | Claude conversation & Artifact extractor |
 | `src/content/extractors/chatgpt.ts` | ChatGPT conversation extractor |
+| `src/content/extractors/perplexity.ts` | Perplexity conversation extractor |
 | `src/background/` | Service worker for API communication |
 | `src/popup/` | Settings UI |
 | `src/lib/` | Shared utilities and types |

--- a/docs/design/DES-007-platform-lint-and-perplexity-docs.md
+++ b/docs/design/DES-007-platform-lint-and-perplexity-docs.md
@@ -1,0 +1,342 @@
+# DES-007: Platform Lint Script and Perplexity Documentation Update
+
+> **Revision History**
+> | Rev | Date | Changes |
+> |-----|------|---------|
+> | 1 | 2026-02-02 | Initial design |
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This document specifies:
+
+1. A lint script (`scripts/lint-platforms.mjs`) that validates platform references across documentation and configuration files against the single source of truth (SSOT)
+2. The required edits to 7 files to add Perplexity AI as a documented platform
+
+### 1.2 Problem Statement
+
+When a new platform is added to `src/manifest.json` `content_scripts[0].matches`, there is no automated mechanism to detect that documentation files (`README.md`, `privacy.html`, etc.) are missing the new platform. This has resulted in Perplexity being present in the manifest but absent from 7 other files.
+
+### 1.3 SSOT Definition
+
+**Single Source of Truth**: `src/manifest.json` → `content_scripts[0].matches`
+
+Current value:
+```json
+[
+  "https://gemini.google.com/*",
+  "https://claude.ai/*",
+  "https://chatgpt.com/*",
+  "https://www.perplexity.ai/*"
+]
+```
+
+The `host_permissions` array also contains `http://127.0.0.1:27123/*`, which is infrastructure (Obsidian Local REST API), not a platform. The lint script explicitly excludes `127.0.0.1` from platform checks.
+
+### 1.4 References
+
+- `src/manifest.json`: Chrome Extension manifest (Manifest V3)
+- Node.js `fs` module: https://nodejs.org/api/fs.html
+- ESM modules in Node.js: https://nodejs.org/api/esm.html
+
+---
+
+## 2. Design: lint-platforms Script
+
+### 2.1 File Location
+
+`scripts/lint-platforms.mjs`
+
+ESM module (`.mjs`) to match the project's `"type": "module"` in `package.json`. No external dependencies — uses only Node.js built-in modules (`fs`, `path`, `url`).
+
+### 2.2 Host-to-DisplayName Mapping
+
+The script extracts hostnames from `content_scripts[0].matches` patterns by stripping the `https://` prefix and `/*` suffix. It then maps hostnames to display names using the following table:
+
+| Hostname | Display Name | Derivation |
+|----------|-------------|------------|
+| `gemini.google.com` | `Gemini` | Subdomain first segment, capitalized |
+| `claude.ai` | `Claude` | Domain first segment, capitalized |
+| `chatgpt.com` | `ChatGPT` | Domain first segment, cased as brand |
+| `www.perplexity.ai` | `Perplexity` | Second segment (skip `www`), capitalized |
+
+This mapping is hardcoded in the script because:
+- Brand capitalization is not derivable from hostnames (e.g., `ChatGPT`, not `Chatgpt`)
+- The number of platforms is small (4) and grows infrequently
+- A new platform addition requires updating this map, which the script itself will catch on the next run after `manifest.json` is updated (the script will fail with "unknown hostname" if a match entry has no mapping)
+
+### 2.3 Check Targets
+
+| File | Check Type | What is Checked |
+|------|-----------|-----------------|
+| `docs/privacy.html` | hostname | Each platform hostname appears in the file body |
+| `README.md` | hostname | Each platform hostname appears in the file body |
+| `README.ja.md` | hostname | Each platform hostname appears in the file body |
+| `CLAUDE.md` | hostname | Each platform hostname appears in the file body |
+| `package.json` | display name | `description` field contains each platform display name (case-insensitive) |
+| `src/_locales/en/messages.json` | display name | `extDescription.message` contains each platform display name (case-insensitive) |
+| `src/_locales/ja/messages.json` | display name | `extDescription.message` contains each platform display name (case-insensitive) |
+
+**Rationale for two check types:**
+
+- **hostname check**: Documentation files like `README.md` and `privacy.html` reference platforms by their URLs (e.g., `gemini.google.com`), so checking for the hostname is appropriate
+- **display name check**: `package.json` description and locale messages use human-readable names (e.g., "Gemini, Claude, and ChatGPT"), so checking for the display name is appropriate
+
+### 2.4 Algorithm
+
+```
+1. Read src/manifest.json
+2. Extract content_scripts[0].matches array
+3. For each match pattern:
+   a. Strip "https://" prefix and "/*" suffix → hostname
+   b. Skip if hostname starts with "127." (infrastructure, not platform)
+   c. Look up display name in hardcoded map
+   d. If hostname not in map → error: "Unknown platform hostname: {hostname}. Add it to HOST_DISPLAY_NAMES in scripts/lint-platforms.mjs"
+4. For each check target:
+   a. Read file content
+   b. For JSON files (package.json, messages.json): parse and extract specific field
+   c. Check that required string (hostname or display name) is present
+   d. Collect all missing entries
+5. If any missing entries found:
+   a. Print each as: "ERROR: {file} is missing platform: {name}"
+   b. Exit with code 1
+6. If all checks pass:
+   a. Print "All platform references are consistent with manifest.json"
+   b. Exit with code 0
+```
+
+### 2.5 package.json Integration
+
+Current `lint` script:
+```json
+"lint": "eslint src/"
+```
+
+Updated scripts:
+```json
+"lint": "eslint src/ && node scripts/lint-platforms.mjs",
+"lint:platforms": "node scripts/lint-platforms.mjs"
+```
+
+This ensures:
+- `npm run lint` runs both ESLint and platform checks (CI integration)
+- `npm run lint:platforms` is available for standalone use
+
+### 2.6 Error Output Format
+
+```
+Platform lint check
+===================
+Source: src/manifest.json content_scripts[0].matches
+Platforms: Gemini (gemini.google.com), Claude (claude.ai), ChatGPT (chatgpt.com), Perplexity (www.perplexity.ai)
+
+ERROR: docs/privacy.html is missing platform hostname: www.perplexity.ai
+ERROR: README.md is missing platform hostname: www.perplexity.ai
+
+2 error(s) found. Update the files above to include all platforms.
+```
+
+Success output:
+```
+Platform lint check
+===================
+Source: src/manifest.json content_scripts[0].matches
+Platforms: Gemini (gemini.google.com), Claude (claude.ai), ChatGPT (chatgpt.com), Perplexity (www.perplexity.ai)
+
+All 7 files are consistent with manifest.json. ✓
+```
+
+---
+
+## 3. Design: 7-File Perplexity Documentation Update
+
+### 3.1 `docs/privacy.html`
+
+**Change 1: Data Transmission section (after line 53)**
+
+Add:
+```html
+<li><strong>www.perplexity.ai</strong>: To extract Perplexity conversation content (read-only)</li>
+```
+
+**Change 2: Permissions Explained table (after line 77)**
+
+Add:
+```html
+<tr><td>Host: www.perplexity.ai</td><td>Inject the sync button on Perplexity pages</td></tr>
+```
+
+### 3.2 `README.md`
+
+**Change 1: Line 3 — opening description**
+
+```
+- Before: Chrome Extension that exports AI conversations from Google Gemini, Claude AI, and ChatGPT to Obsidian via the Local REST API.
++ After:  Chrome Extension that exports AI conversations from Google Gemini, Claude AI, ChatGPT, and Perplexity to Obsidian via the Local REST API.
+```
+
+**Change 2: Line 12 — Features list**
+
+```
+- Before: - **Multi-platform support**: Export from Google Gemini, Claude AI, and ChatGPT
++ After:  - **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, and Perplexity
+```
+
+**Change 3: Lines 87-91 — Add Perplexity usage section (after ChatGPT section)**
+
+Add:
+```markdown
+### Perplexity
+
+1. Open a conversation on [www.perplexity.ai](https://www.perplexity.ai)
+2. Click the purple "Sync" button in the bottom-right corner
+3. The conversation will be exported with the same output options as Gemini
+```
+
+**Change 4: Line 188 — Architecture diagram**
+
+```
+- Before: Content Script (gemini.google.com, claude.ai, chatgpt.com)
++ After:  Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
+```
+
+**Change 5: Lines 200-202 — Key Components table**
+
+Add row:
+```markdown
+| `src/content/extractors/perplexity.ts` | Perplexity conversation extractor |
+```
+
+### 3.3 `README.ja.md`
+
+**Change 1: Line 3 — opening description**
+
+```
+- Before: Google Gemini、Claude AI、ChatGPT の会話を Obsidian に保存する Chrome 拡張機能です。
++ After:  Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存する Chrome 拡張機能です。
+```
+
+**Change 2: Line 12 — 機能 list**
+
+```
+- Before: - **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT からエクスポート
++ After:  - **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity からエクスポート
+```
+
+**Change 3: Lines 87-91 — Add Perplexity usage section (after ChatGPT section)**
+
+Add:
+```markdown
+### Perplexity
+
+1. [www.perplexity.ai](https://www.perplexity.ai) で会話を開く
+2. 右下に表示される紫色の「Sync」ボタンをクリック
+3. Gemini と同じ出力オプションで会話がエクスポートされます
+```
+
+**Change 4: Line 188 — Architecture diagram**
+
+```
+- Before: Content Script (gemini.google.com, claude.ai, chatgpt.com)
++ After:  Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
+```
+
+**Change 5: Lines 200-202 — Key Components table**
+
+Add row:
+```markdown
+| `src/content/extractors/perplexity.ts` | Perplexity 会話抽出 |
+```
+
+### 3.4 `CLAUDE.md`
+
+**Change 1: Line 7 — Project Overview**
+
+```
+- Before: Chrome Extension that extracts AI conversations from Google Gemini and Claude AI and saves them to Obsidian
++ After:  Chrome Extension that extracts AI conversations from Google Gemini, Claude AI, ChatGPT, and Perplexity and saves them to Obsidian
+```
+
+**Change 2: Line 76 — Architecture diagram**
+
+```
+- Before: Content Script (gemini.google.com, claude.ai)
++ After:  Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)
+```
+
+**Change 3: Lines 140-144 — Supported Platforms section**
+
+Add:
+```markdown
+- **Perplexity** (`www.perplexity.ai`): Conversations
+```
+
+**Change 4: Lines 161-163 — Future Platforms section**
+
+Remove or update this section since Perplexity is now implemented:
+```
+- Before: Types support `perplexity` source. Add new extractors by extending `BaseExtractor` and implementing `IConversationExtractor`.
++ After:  Add new extractors by extending `BaseExtractor` and implementing `IConversationExtractor`.
+```
+
+### 3.5 `package.json`
+
+**Change: Line 4 — description**
+
+```
+- Before: "description": "Chrome Extension to export AI conversations from Gemini, Claude, and ChatGPT to Obsidian, file download, or clipboard"
++ After:  "description": "Chrome Extension to export AI conversations from Gemini, Claude, ChatGPT, and Perplexity to Obsidian, file download, or clipboard"
+```
+
+### 3.6 `src/_locales/en/messages.json`
+
+**Change: Line 7 — extDescription.message**
+
+```
+- Before: "Export AI conversations from Gemini, Claude, and ChatGPT to Obsidian via Local REST API"
++ After:  "Export AI conversations from Gemini, Claude, ChatGPT, and Perplexity to Obsidian via Local REST API"
+```
+
+### 3.7 `src/_locales/ja/messages.json`
+
+**Change: Line 6 — extDescription.message**
+
+```
+- Before: "Gemini、Claude、ChatGPT の AI 会話を Obsidian へエクスポート（Local REST API 経由）"
++ After:  "Gemini、Claude、ChatGPT、Perplexity の AI 会話を Obsidian へエクスポート（Local REST API 経由）"
+```
+
+---
+
+## 4. Verification Plan
+
+### 4.1 lint-platforms Script Verification
+
+1. Run `node scripts/lint-platforms.mjs` **before** updating 7 files → expect errors listing all missing Perplexity references
+2. Update all 7 files
+3. Run `node scripts/lint-platforms.mjs` **after** updates → expect success
+4. Run `npm run lint` → expect both ESLint and platform lint to pass
+
+### 4.2 Documentation Verification
+
+1. Confirm all 7 files contain `perplexity` or `Perplexity` as appropriate
+2. Confirm `privacy.html` is valid HTML (no broken tags)
+3. Confirm JSON files are valid (`package.json`, both `messages.json`)
+
+---
+
+## 5. Files Modified
+
+| File | Type | Change |
+|------|------|--------|
+| `scripts/lint-platforms.mjs` | **New** | Platform lint script |
+| `package.json` | Modified | Add `lint:platforms` script, update `lint` script, update `description` |
+| `docs/privacy.html` | Modified | Add Perplexity to Data Transmission and Permissions |
+| `README.md` | Modified | Add Perplexity to description, features, usage, architecture, components |
+| `README.ja.md` | Modified | Same as README.md (Japanese) |
+| `CLAUDE.md` | Modified | Add Perplexity to overview, architecture, supported platforms |
+| `src/_locales/en/messages.json` | Modified | Add Perplexity to extension description |
+| `src/_locales/ja/messages.json` | Modified | Add Perplexity to extension description |
+
+**Total: 8 files (1 new, 7 modified)**

--- a/docs/design/DES-008-release-command.md
+++ b/docs/design/DES-008-release-command.md
@@ -1,0 +1,284 @@
+# DES-008: `/release` Custom Slash Command
+
+> **Revision History**
+> | Rev | Date | Changes |
+> |-----|------|---------|
+> | 1 | 2026-02-03 | Initial design |
+
+## 1. Overview
+
+### 1.1 Purpose
+
+A Claude Code custom slash command (`/release`) that automates the full release-please-compatible workflow: **analyze changes -> create branch -> stage -> commit -> push -> create PR**.
+
+### 1.2 Problem Statement
+
+The current release workflow requires developers to manually:
+1. Create a properly named branch
+2. Stage files carefully (avoiding secrets)
+3. Write a conventional commit message that passes commitlint
+4. Push with upstream tracking
+5. Create a PR with a structured body via `gh`
+
+Each step has format requirements (commitlint types, header max-length, PR body structure, branch naming) that are easy to get wrong. A single command should encapsulate all conventions.
+
+### 1.3 References
+
+- Conventional Commits: https://www.conventionalcommits.org/
+- release-please: `release-please-config.json` in repo root
+- commitlint: `commitlint.config.js` in repo root
+- Claude Code custom commands: `.claude/commands/*.md`
+
+---
+
+## 2. Design
+
+### 2.1 File Location
+
+`.claude/commands/release.md`
+
+This is a Claude Code custom slash command file. It consists of YAML frontmatter (metadata) and a Markdown prompt body (instructions for Claude). It is NOT executable code — Claude interprets the prompt and uses its tools (Bash, etc.) to carry out the workflow.
+
+### 2.2 `.gitignore` Change
+
+Currently `.claude/` is gitignored. To track the command file while keeping `settings.local.json` ignored:
+
+```gitignore
+.claude/
+!.claude/commands/
+```
+
+The negation rule `!.claude/commands/` allows the `commands/` subdirectory to be tracked by git. All other `.claude/` contents (e.g., `settings.local.json` with local MCP permissions) remain ignored.
+
+### 2.3 Invocation
+
+```
+/release                              # Auto-detect type, auto-generate description
+/release "add platform lint script"   # Auto-detect type, use provided description
+/release "fix: handle null extractor" # Use explicit type and description
+```
+
+The argument text is available as `$ARGUMENTS` in the command template.
+
+### 2.4 Workflow Steps
+
+```
+Step 1: Verify preconditions
+    ├─ git status + git diff --stat
+    ├─ Abort if no changes
+    └─ Warn on sensitive files
+
+Step 2: Detect commit type
+    ├─ Parse $ARGUMENTS for explicit "type: ..." prefix
+    └─ OR analyze changed file paths for dominant type
+
+Step 3: Generate commit message
+    ├─ Format: "{type}: {description}"
+    ├─ Header < 100 chars (commitlint rule)
+    └─ Use $ARGUMENTS as description, or auto-generate
+
+Step 4: Create branch (if on main)
+    ├─ Slugify description → branch name
+    └─ git checkout -b {type}/{slug}
+
+Step 5: Stage and commit
+    ├─ git add (explicit file paths, never -A)
+    ├─ Skip sensitive files
+    └─ Commit with Co-Authored-By trailer
+
+Step 6: Push
+    └─ git push -u origin HEAD
+
+Step 7: Create PR
+    ├─ Check for existing PR on branch
+    ├─ gh pr create --title --body
+    └─ Body: ## Summary + ## Test plan
+
+Step 8: Report
+    └─ Output: branch, commit message, PR URL
+```
+
+### 2.5 Commit Type Auto-Detection
+
+When `$ARGUMENTS` does not start with a recognized `type:` prefix, the command analyzes the changed file paths to determine the dominant type:
+
+| Changed File Patterns | Detected Type |
+|----------------------|---------------|
+| `src/` with new files or substantial new functionality | `feat` |
+| `src/` with bug fix modifications | `fix` |
+| `src/` with structural changes, no new features | `refactor` |
+| Only `docs/`, `README*`, `CLAUDE.md`, `*.html` (doc files) | `docs` |
+| Only test files (`*.test.ts`, `*.spec.ts`, `test/`) | `test` |
+| Only config files (`package.json` scripts, eslint, vite, tsconfig) | `chore` |
+| Only `.github/workflows/` | `ci` |
+| Only CSS/formatting changes | `style` |
+| Performance-focused changes | `perf` |
+| Security-related changes | `security` |
+| UI-only changes (popup, CSS) | `ui` |
+| `scripts/` new tooling + docs updates | Dominant by proportion |
+
+When changes span multiple categories, the type covering the most impactful changes wins. For truly mixed changes, `feat` is used if new functionality is present, otherwise `chore`.
+
+### 2.6 Allowed Commit Types
+
+From `commitlint.config.js`:
+
+```
+feat, fix, docs, style, refactor, perf, test, chore, revert, build, ci, security, ui, release
+```
+
+Header max-length: **100 characters** (commitlint rule).
+
+### 2.7 Branch Naming
+
+| Property | Rule |
+|----------|------|
+| Pattern | `{type}/{slug}` |
+| Slug derivation | Lowercase description, non-alphanumeric chars replaced with `-`, consecutive hyphens collapsed, leading/trailing hyphens trimmed |
+| Max slug length | 50 characters |
+| Trigger | Only when current branch is `main` |
+
+Examples:
+- `feat: add platform lint script` -> `feat/add-platform-lint-script`
+- `docs: update README with Perplexity` -> `docs/update-readme-with-perplexity`
+- `fix: handle null pointer in gemini extractor` -> `fix/handle-null-pointer-in-gemini-extractor`
+
+Branch prefix mapping uses `{type}/` directly (e.g., `feat/`, `fix/`, `docs/`).
+
+### 2.8 Commit Message Format
+
+```
+{type}: {description}
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+Rules:
+- Description starts lowercase
+- No trailing period
+- No emoji in the header
+- Total header line under 100 characters
+- Blank line between header and trailer
+- Co-Authored-By trailer always present
+
+Implementation uses a heredoc to ensure correct multi-line formatting:
+
+```bash
+git commit -m "$(cat <<'EOF'
+{type}: {description}
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 2.9 File Staging Rules
+
+**Stage**: All changed/new files relevant to the work, added by explicit path.
+
+**Never stage**:
+- `.env`, `.env.local`, `.mcp.json`
+- `node_modules/`, `dist/`, `coverage/`
+- `.DS_Store`, `Thumbs.db`
+- Files matching `*credential*`, `*secret*`, `*token*`, `*.key`, `*.pem`
+
+**Warn and ask user**: Any file not in the skip list but matching a suspicious pattern (e.g., contains "password", "api_key" in filename).
+
+NEVER use `git add -A` or `git add .`.
+
+### 2.10 PR Creation
+
+**Check first**: `gh pr view --json url 2>/dev/null` — if a PR already exists for the branch, report the existing URL and skip creation.
+
+**Title**: Exactly matches the commit header (e.g., `feat: add platform lint script`).
+
+**Body structure**:
+
+```markdown
+## Summary
+- {bullet points summarizing changes, derived from the diff}
+
+## Test plan
+- [ ] `npm run build` succeeds
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+- [ ] {additional checks relevant to the change}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+The summary and test plan are customized based on the actual changes — not a static template.
+
+### 2.11 Safety Rules
+
+| Rule | Rationale |
+|------|-----------|
+| NEVER `git push --force` | Prevents history destruction |
+| NEVER `--no-verify` on commit | Commitlint hook provides safety net |
+| NEVER `--amend` | Prevents modifying previous commits |
+| NEVER `git add -A` or `git add .` | Prevents staging secrets |
+| Abort on divergent remote | Prevents silent overwrites |
+| Check for existing PR before creating | Prevents duplicates |
+
+### 2.12 Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No changes detected | Abort with "Nothing to release — no changes detected." |
+| Already on non-main branch | Use current branch, skip branch creation |
+| Remote branch exists with divergent history | Abort and report, never force push |
+| PR already exists for branch | Report existing PR URL, skip PR creation |
+| Commit fails (commitlint rejects message) | Fix message format and create NEW commit |
+| `gh` CLI not authenticated | Report error and suggest `gh auth login` |
+| Push fails (no remote access) | Report error with the push failure message |
+
+---
+
+## 3. YAML Frontmatter Specification
+
+```yaml
+---
+description: "Commit, push, and create PR following release-please conventions"
+---
+```
+
+Only the `description` field is needed. The command is user-invocable by default. No tool restrictions are specified — Claude needs access to Bash (for git/gh), Read (for diff analysis), and other standard tools.
+
+---
+
+## 4. Files Modified
+
+| File | Type | Change |
+|------|------|--------|
+| `.claude/commands/release.md` | **New** | Custom slash command |
+| `.gitignore` | Modified | Add `!.claude/commands/` negation rule |
+
+**Total: 2 files (1 new, 1 modified)**
+
+---
+
+## 5. Verification Plan
+
+### 5.1 File Tracking Verification
+
+```bash
+# Confirm release.md is NOT ignored by git
+git check-ignore .claude/commands/release.md
+# Expected: no output (file is tracked)
+
+# Confirm settings.local.json IS still ignored
+git check-ignore .claude/settings.local.json
+# Expected: .claude/settings.local.json
+```
+
+### 5.2 Functional Verification
+
+1. Open a new Claude Code session in the project
+2. Type `/release` — confirm the command appears in autocomplete
+3. Make a trivial change (e.g., add a comment to a test file)
+4. Run `/release "test the release command"` — confirm the full workflow executes:
+   - Branch created: `test/test-the-release-command` (or similar)
+   - Commit: `test: test the release command`
+   - Push succeeds
+   - PR created with structured body
+5. Delete the test PR and branch after verification

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -51,6 +51,7 @@
     <li><strong>gemini.google.com</strong>: To extract Gemini conversation content (read-only)</li>
     <li><strong>claude.ai</strong>: To extract Claude conversation content (read-only)</li>
     <li><strong>chatgpt.com</strong>: To extract ChatGPT conversation content (read-only)</li>
+    <li><strong>www.perplexity.ai</strong>: To extract Perplexity conversation content (read-only)</li>
     <li><strong>127.0.0.1 (localhost)</strong>: To save files to your local Obsidian vault (when Obsidian output is enabled)</li>
   </ul>
   <p>No data is ever sent to external servers or third parties.</p>
@@ -74,6 +75,7 @@
     <tr><td>Host: gemini.google.com</td><td>Inject the sync button on Gemini pages</td></tr>
     <tr><td>Host: claude.ai</td><td>Inject the sync button on Claude pages</td></tr>
     <tr><td>Host: chatgpt.com</td><td>Inject the sync button on ChatGPT pages</td></tr>
+    <tr><td>Host: www.perplexity.ai</td><td>Inject the sync button on Perplexity pages</td></tr>
     <tr><td>Host: 127.0.0.1</td><td>Communicate with Obsidian's local API</td></tr>
   </table>
 

--- a/docs/workflow/WF-007-platform-lint-and-perplexity-docs.md
+++ b/docs/workflow/WF-007-platform-lint-and-perplexity-docs.md
@@ -1,0 +1,254 @@
+# WF-007: Platform Lint Script and Perplexity Documentation Update
+
+**Status**: Pending
+**Design**: `docs/design/DES-007-platform-lint-and-perplexity-docs.md`
+**Precedent Workflow**: `docs/workflow/WF-006-perplexity-extractor-implementation.md`
+
+---
+
+## Workflow Summary
+
+| Property | Value |
+|---|---|
+| Total Phases | 3 |
+| Total Steps | 6 |
+| New Files | 1 (`scripts/lint-platforms.mjs`) |
+| Modified Files | 7 (`package.json`, `docs/privacy.html`, `README.md`, `README.ja.md`, `CLAUDE.md`, `src/_locales/en/messages.json`, `src/_locales/ja/messages.json`) |
+
+---
+
+## Phase 1: Lint Script (Steps 1–2)
+
+> Create the lint script and integrate into npm scripts.
+
+### Step 1: Create `scripts/lint-platforms.mjs`
+
+**Action**: Create the platform lint script per DES-007 §2.
+
+**File**: `scripts/lint-platforms.mjs` (new)
+
+**Specification**:
+- Read `src/manifest.json` → `content_scripts[0].matches`
+- Extract hostnames by stripping `https://` prefix and `/*` suffix
+- Skip hostnames starting with `127.` (infrastructure, not platform)
+- Hardcoded hostname → display name map (DES-007 §2.2):
+  - `gemini.google.com` → `Gemini`
+  - `claude.ai` → `Claude`
+  - `chatgpt.com` → `ChatGPT`
+  - `www.perplexity.ai` → `Perplexity`
+- Error on unknown hostname (not in map)
+- Check 7 target files with two check types (DES-007 §2.3):
+  - **hostname check** (`docs/privacy.html`, `README.md`, `README.ja.md`, `CLAUDE.md`): hostname string present in file body
+  - **display name check** (`package.json` → `description`, `src/_locales/en/messages.json` → `extDescription.message`, `src/_locales/ja/messages.json` → `extDescription.message`): display name present (case-insensitive)
+- Output format per DES-007 §2.6
+- Exit 1 on missing references, exit 0 on success
+- No external dependencies (Node.js `fs`, `path`, `url` only)
+
+**Validation**:
+- [ ] `node scripts/lint-platforms.mjs` runs without syntax errors
+- [ ] Reports errors for files missing Perplexity (expected at this step — 7 errors)
+- [ ] Exit code is 1
+
+**Depends on**: Nothing
+**Blocks**: Step 2, Step 5
+
+---
+
+### Step 2: Update `package.json` Scripts
+
+**Action**: Add `lint:platforms` script and chain into existing `lint` script.
+
+**File**: `package.json`
+
+**Changes**:
+```
+- Before: "lint": "eslint src/"
++ After:  "lint": "eslint src/ && node scripts/lint-platforms.mjs"
+```
+
+Add new script:
+```json
+"lint:platforms": "node scripts/lint-platforms.mjs"
+```
+
+**Validation**:
+- [ ] `npm run lint:platforms` executes and reports errors (Perplexity missing from docs)
+- [ ] `npm run lint` runs ESLint then platform lint sequentially
+- [ ] `package.json` is valid JSON
+
+**Depends on**: Step 1
+**Blocks**: Step 5
+
+---
+
+## Phase 2: Documentation Update (Steps 3–4)
+
+> Update all 7 files to include Perplexity references.
+
+### Step 3: Update Documentation Files (4 files)
+
+**Action**: Apply hostname-checked file changes from DES-007 §3.1–§3.4.
+
+**File 1: `docs/privacy.html`** (DES-007 §3.1)
+- Add `<li><strong>www.perplexity.ai</strong>: To extract Perplexity conversation content (read-only)</li>` to Data Transmission list (after line 53, before localhost entry)
+- Add `<tr><td>Host: www.perplexity.ai</td><td>Inject the sync button on Perplexity pages</td></tr>` to Permissions table (after line 77, before localhost entry)
+
+**File 2: `README.md`** (DES-007 §3.2)
+- Line 3: `"from Google Gemini, Claude AI, and ChatGPT"` → `"from Google Gemini, Claude AI, ChatGPT, and Perplexity"`
+- Line 12: `"Export from Google Gemini, Claude AI, and ChatGPT"` → `"Export from Google Gemini, Claude AI, ChatGPT, and Perplexity"`
+- After line 91 (ChatGPT section): Add Perplexity usage section
+- Line 188: `"Content Script (gemini.google.com, claude.ai, chatgpt.com)"` → `"Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)"`
+- After line 202 (chatgpt.ts row): Add `| src/content/extractors/perplexity.ts | Perplexity conversation extractor |`
+
+**File 3: `README.ja.md`** (DES-007 §3.3)
+- Line 3: `"Google Gemini、Claude AI、ChatGPT の会話"` → `"Google Gemini、Claude AI、ChatGPT、Perplexity の会話"`
+- Line 12: `"Google Gemini、Claude AI、ChatGPT からエクスポート"` → `"Google Gemini、Claude AI、ChatGPT、Perplexity からエクスポート"`
+- After line 91 (ChatGPT section): Add Perplexity usage section (Japanese)
+- Line 188: Same architecture diagram change as README.md
+- After line 202: Add `| src/content/extractors/perplexity.ts | Perplexity 会話抽出 |`
+
+**File 4: `CLAUDE.md`** (DES-007 §3.4)
+- Line 7: `"from Google Gemini and Claude AI"` → `"from Google Gemini, Claude AI, ChatGPT, and Perplexity"`
+- Line 76: `"Content Script (gemini.google.com, claude.ai)"` → `"Content Script (gemini.google.com, claude.ai, chatgpt.com, www.perplexity.ai)"`
+- After line 144 (ChatGPT entry): Add `- **Perplexity** (www.perplexity.ai): Conversations`
+- Lines 161–163: Remove `perplexity` from "Future Platforms" text → `"Add new extractors by extending BaseExtractor and implementing IConversationExtractor."`
+
+**Validation**:
+- [ ] Each file contains `www.perplexity.ai` (hostname check target)
+- [ ] `docs/privacy.html` has no broken HTML tags
+- [ ] README Perplexity usage sections follow existing ChatGPT section format
+
+**Depends on**: Nothing (can run in parallel with Phase 1)
+**Blocks**: Step 5
+
+---
+
+### Step 4: Update Description Files (3 files)
+
+**Action**: Apply display-name-checked file changes from DES-007 §3.5–§3.7.
+
+**File 1: `package.json`** (DES-007 §3.5)
+- `"description"`: `"from Gemini, Claude, and ChatGPT"` → `"from Gemini, Claude, ChatGPT, and Perplexity"`
+
+**File 2: `src/_locales/en/messages.json`** (DES-007 §3.6)
+- `"extDescription.message"`: `"from Gemini, Claude, and ChatGPT"` → `"from Gemini, Claude, ChatGPT, and Perplexity"`
+
+**File 3: `src/_locales/ja/messages.json`** (DES-007 §3.7)
+- `"extDescription.message"`: `"Gemini、Claude、ChatGPT の"` → `"Gemini、Claude、ChatGPT、Perplexity の"`
+
+**Validation**:
+- [ ] `package.json` is valid JSON
+- [ ] `src/_locales/en/messages.json` is valid JSON
+- [ ] `src/_locales/ja/messages.json` is valid JSON
+- [ ] Each file contains `Perplexity` (display name check target)
+
+**Depends on**: Nothing (can run in parallel with Phase 1)
+**Blocks**: Step 5
+
+---
+
+## Phase 3: Verification (Steps 5–6)
+
+> Verify all changes are consistent and no regressions.
+
+### Step 5: Run Platform Lint
+
+**Action**: Run the lint script to confirm all platform references are consistent.
+
+**Command**:
+```bash
+node scripts/lint-platforms.mjs
+```
+
+**Expected output** (DES-007 §2.6):
+```
+Platform lint check
+===================
+Source: src/manifest.json content_scripts[0].matches
+Platforms: Gemini (gemini.google.com), Claude (claude.ai), ChatGPT (chatgpt.com), Perplexity (www.perplexity.ai)
+
+All 7 files are consistent with manifest.json. ✓
+```
+
+**Validation**:
+- [ ] Exit code is 0
+- [ ] All 7 files pass
+- [ ] No missing platform errors
+
+**Depends on**: Steps 1, 2, 3, 4
+**Blocks**: Step 6
+
+---
+
+### Step 6: Run Full Lint and Build
+
+**Action**: Run existing CI checks to confirm no regressions.
+
+**Commands** (sequential):
+```bash
+npm run lint
+npm run build
+```
+
+**Validation**:
+- [ ] `npm run lint` passes (ESLint + platform lint)
+- [ ] `npm run build` passes (TypeScript + Vite)
+- [ ] No new warnings introduced
+
+**Depends on**: Step 5
+**Blocks**: Nothing (final step)
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: Lint Script
+  Step 1 (lint-platforms.mjs) ──→ Step 2 (package.json scripts) ──┐
+                                                                   │
+Phase 2: Documentation Update                                      │
+  Step 3 (4 doc files)  ──────────────────────────────────────────┤
+  Step 4 (3 description files) ───────────────────────────────────┤
+                                                                   ↓
+Phase 3: Verification                                              │
+  Step 5 (platform lint) ◄────────────────────────────────────────┘
+       │
+       ↓
+  Step 6 (full lint + build)
+```
+
+**Parallelizable groups**:
+- Phase 1 (Steps 1–2) and Phase 2 (Steps 3–4) can run in parallel
+- Steps 3 and 4 can run in parallel within Phase 2
+
+---
+
+## Execution Checkpoints
+
+| After Phase | Checkpoint | Command |
+|---|---|---|
+| Phase 1 | Lint script runs, reports errors for missing Perplexity | `node scripts/lint-platforms.mjs` (expect exit 1) |
+| Phase 2 | All 7 files updated with Perplexity references | Manual review: `grep -l -i perplexity docs/privacy.html README.md README.ja.md CLAUDE.md package.json src/_locales/en/messages.json src/_locales/ja/messages.json` |
+| Phase 3 | All checks pass, no regressions | `npm run lint && npm run build` |
+
+---
+
+## Files Changed Summary
+
+### New Files (1)
+| File | Phase | Step |
+|---|---|---|
+| `scripts/lint-platforms.mjs` | 1 | 1 |
+
+### Modified Files (7)
+| File | Phase | Step | Changes |
+|---|---|---|---|
+| `package.json` | 1+2 | 2, 4 | Add `lint:platforms` script, update `lint` script, update `description` |
+| `docs/privacy.html` | 2 | 3 | Add Perplexity to Data Transmission list (+1 line) and Permissions table (+1 line) |
+| `README.md` | 2 | 3 | Update description, features, add usage section, update architecture, add component row |
+| `README.ja.md` | 2 | 3 | Same as README.md (Japanese) |
+| `CLAUDE.md` | 2 | 3 | Update overview, architecture, add to Supported Platforms, update Future Platforms |
+| `src/_locales/en/messages.json` | 2 | 4 | Update `extDescription.message` |
+| `src/_locales/ja/messages.json` | 2 | 4 | Update `extDescription.message` |
+
+**Total: 8 files (1 new, 7 modified)**

--- a/docs/workflow/WF-008-release-command.md
+++ b/docs/workflow/WF-008-release-command.md
@@ -1,0 +1,232 @@
+# WF-008: `/release` Custom Slash Command Implementation
+
+**Status**: Pending
+**Design**: `docs/design/DES-008-release-command.md`
+**Precedent Workflow**: `docs/workflow/WF-007-platform-lint-and-perplexity-docs.md`
+
+---
+
+## Workflow Summary
+
+| Property | Value |
+|---|---|
+| Total Phases | 3 |
+| Total Steps | 5 |
+| New Files | 1 (`.claude/commands/release.md`) |
+| Modified Files | 1 (`.gitignore`) |
+
+---
+
+## Phase 1: Prepare Directory and Git Tracking (Steps 1-2)
+
+> Make `.claude/commands/` trackable and create the directory.
+
+### Step 1: Update `.gitignore`
+
+**Action**: Add negation rule so `.claude/commands/` is tracked by git while `.claude/settings.local.json` remains ignored.
+
+**File**: `.gitignore`
+
+**Change**:
+```
+- Before: .claude/
++ After:  .claude/
++         !.claude/commands/
+```
+
+Add the `!.claude/commands/` line immediately after the `.claude/` line.
+
+**Validation**:
+- [ ] `.gitignore` is syntactically correct
+- [ ] `git check-ignore .claude/settings.local.json` returns the path (still ignored)
+
+**Depends on**: Nothing
+**Blocks**: Step 3, Step 4
+
+---
+
+### Step 2: Create `.claude/commands/` directory
+
+**Action**: Create the commands directory if it does not exist.
+
+**Command**:
+```bash
+mkdir -p .claude/commands
+```
+
+**Validation**:
+- [ ] Directory `.claude/commands/` exists
+
+**Depends on**: Nothing
+**Blocks**: Step 3
+
+---
+
+## Phase 2: Create Command File (Step 3)
+
+> Write the `/release` command prompt file per DES-008.
+
+### Step 3: Create `.claude/commands/release.md`
+
+**Action**: Create the custom slash command file with YAML frontmatter and prompt body per DES-008 §2-§3.
+
+**File**: `.claude/commands/release.md` (new)
+
+**Specification**:
+
+The file contains:
+
+1. **YAML frontmatter** with `description` field only
+2. **Prompt body** instructing Claude to execute the 8-step workflow:
+   - Step 1: Verify preconditions (`git status`, `git diff --stat`, sensitive file check)
+   - Step 2: Detect commit type (parse `$ARGUMENTS` for explicit `type:` prefix, or auto-detect from file paths per DES-008 §2.5)
+   - Step 3: Generate commit message (`{type}: {description}`, header < 100 chars, lowercase start, no period, no emoji)
+   - Step 4: Create branch if on `main` (`{type}/{slug}`, slug max 50 chars per DES-008 §2.7)
+   - Step 5: Stage and commit (explicit file paths, never `git add -A`, skip sensitive files per DES-008 §2.9, heredoc commit with Co-Authored-By trailer)
+   - Step 6: Push (`git push -u origin HEAD`, never force push)
+   - Step 7: Create PR (check for existing PR first, `gh pr create` with title matching commit header, body with Summary + Test plan per DES-008 §2.10)
+   - Step 8: Report (branch name, commit message, PR URL)
+
+3. **Safety rules** embedded in the prompt (DES-008 §2.11):
+   - Never `--force`, `--no-verify`, `--amend`
+   - Never `git add -A` or `git add .`
+   - Abort on divergent remote
+   - Check for existing PR before creating
+
+4. **Edge case handling** (DES-008 §2.12):
+   - No changes -> abort
+   - Already on feature branch -> use it
+   - PR exists -> report URL, skip creation
+   - Commit rejected by hook -> fix and create NEW commit
+
+5. **Type detection table** (DES-008 §2.5):
+   - `src/` new files -> `feat`
+   - `src/` bug fixes -> `fix`
+   - `src/` structural -> `refactor`
+   - `docs/` only -> `docs`
+   - Test files only -> `test`
+   - Config only -> `chore`
+   - `.github/workflows/` only -> `ci`
+   - Formatting only -> `style`
+
+**Validation**:
+- [ ] File exists at `.claude/commands/release.md`
+- [ ] YAML frontmatter is valid (has `description` field)
+- [ ] Prompt contains all 8 workflow steps
+- [ ] Prompt includes safety rules (no force push, no --amend, no --no-verify)
+- [ ] Prompt includes type detection heuristics
+- [ ] Prompt includes branch naming rules
+- [ ] Prompt includes Co-Authored-By trailer instruction
+
+**Depends on**: Steps 1, 2
+**Blocks**: Step 4
+
+---
+
+## Phase 3: Verification (Steps 4-5)
+
+> Verify git tracking and command availability.
+
+### Step 4: Verify Git Tracking
+
+**Action**: Confirm the `.gitignore` negation rule works correctly.
+
+**Commands**:
+```bash
+# release.md should NOT be ignored
+git check-ignore .claude/commands/release.md
+# Expected: no output (exit code 1 = not ignored)
+
+# settings.local.json should still be ignored
+git check-ignore .claude/settings.local.json
+# Expected: .claude/settings.local.json (exit code 0 = ignored)
+```
+
+**Validation**:
+- [ ] `.claude/commands/release.md` is NOT ignored by git
+- [ ] `.claude/settings.local.json` IS still ignored by git
+- [ ] `git status` shows `.claude/commands/release.md` as untracked (ready to commit)
+
+**Depends on**: Steps 1, 3
+**Blocks**: Step 5
+
+---
+
+### Step 5: Verify Command Content
+
+**Action**: Read the created file and confirm structural completeness.
+
+**Checks**:
+```bash
+# File exists and has content
+wc -l .claude/commands/release.md
+# Expected: non-zero line count
+
+# YAML frontmatter is present
+head -5 .claude/commands/release.md
+# Expected: starts with ---
+
+# Key workflow elements present
+grep -c "git status" .claude/commands/release.md    # precondition check
+grep -c "git diff" .claude/commands/release.md      # diff analysis
+grep -c "git checkout -b" .claude/commands/release.md  # branch creation
+grep -c "git commit" .claude/commands/release.md    # commit
+grep -c "git push" .claude/commands/release.md      # push
+grep -c "gh pr create" .claude/commands/release.md  # PR creation
+grep -c "Co-Authored-By" .claude/commands/release.md # co-author trailer
+grep -c "NEVER" .claude/commands/release.md         # safety rules
+```
+
+**Validation**:
+- [ ] All grep checks return non-zero counts
+- [ ] File has valid YAML frontmatter
+- [ ] All 8 workflow steps are represented
+
+**Depends on**: Step 4
+**Blocks**: Nothing (final step)
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: Prepare
+  Step 1 (.gitignore) ─────────────────────────────────┐
+  Step 2 (mkdir commands/) ─────────────────────────────┤
+                                                        ↓
+Phase 2: Create                                         │
+  Step 3 (release.md) ◄────────────────────────────────┘
+       │
+       ↓
+Phase 3: Verification
+  Step 4 (git tracking check) ──→ Step 5 (content check)
+```
+
+**Parallelizable groups**:
+- Steps 1 and 2 can run in parallel
+
+---
+
+## Execution Checkpoints
+
+| After Phase | Checkpoint | Command |
+|---|---|---|
+| Phase 1 | `.claude/commands/` dir exists, `.gitignore` updated | `ls -d .claude/commands/ && grep '!.claude/commands/' .gitignore` |
+| Phase 2 | Command file created with complete content | `wc -l .claude/commands/release.md` |
+| Phase 3 | Git tracking correct, all content checks pass | `git check-ignore .claude/commands/release.md; echo "exit: $?"` |
+
+---
+
+## Files Changed Summary
+
+### New Files (1)
+| File | Phase | Step |
+|---|---|---|
+| `.claude/commands/release.md` | 2 | 3 |
+
+### Modified Files (1)
+| File | Phase | Step | Changes |
+|---|---|---|---|
+| `.gitignore` | 1 | 1 | Add `!.claude/commands/` negation rule |
+
+**Total: 2 files (1 new, 1 modified)**

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "obsidian-ai-exporter",
   "version": "0.6.11",
-  "description": "Chrome Extension to export AI conversations from Gemini, Claude, and ChatGPT to Obsidian, file download, or clipboard",
+  "description": "Chrome Extension to export AI conversations from Gemini, Claude, ChatGPT, and Perplexity to Obsidian, file download, or clipboard",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "build:zip": "npm run build && cd dist && zip -r ../gemini2obsidian-$(node -p \"require('../package.json').version\").zip . -x '*.DS_Store' -x '.vite/*' && cd ..",
-    "lint": "eslint src/",
+    "lint": "eslint src/ && node scripts/lint-platforms.mjs",
+    "lint:platforms": "node scripts/lint-platforms.mjs",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,html}\"",
     "preview": "vite preview",

--- a/scripts/lint-platforms.mjs
+++ b/scripts/lint-platforms.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * Platform lint script — validates that all platforms in manifest.json
+ * content_scripts[0].matches are referenced in documentation and config files.
+ *
+ * SSOT: src/manifest.json → content_scripts[0].matches
+ *
+ * Usage: node scripts/lint-platforms.mjs
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// Hardcoded hostname → display name map.
+// Brand capitalization is not derivable from hostnames (e.g., ChatGPT, not Chatgpt).
+// When a new platform is added to manifest.json, add it here — the script will
+// fail with "Unknown platform hostname" if a match entry has no mapping.
+const HOST_DISPLAY_NAMES = {
+  'gemini.google.com': 'Gemini',
+  'claude.ai': 'Claude',
+  'chatgpt.com': 'ChatGPT',
+  'www.perplexity.ai': 'Perplexity',
+};
+
+// Check targets: each entry defines a file and what to look for.
+// "hostname" checks look for the raw hostname string in the file body.
+// "displayName" checks parse a specific JSON field and look for the display name (case-insensitive).
+const CHECK_TARGETS = [
+  { file: 'docs/privacy.html', type: 'hostname' },
+  { file: 'README.md', type: 'hostname' },
+  { file: 'README.ja.md', type: 'hostname' },
+  { file: 'CLAUDE.md', type: 'hostname' },
+  { file: 'package.json', type: 'displayName', jsonField: 'description' },
+  {
+    file: 'src/_locales/en/messages.json',
+    type: 'displayName',
+    jsonField: 'extDescription.message',
+  },
+  {
+    file: 'src/_locales/ja/messages.json',
+    type: 'displayName',
+    jsonField: 'extDescription.message',
+  },
+];
+
+// --- Main ---
+
+const manifest = JSON.parse(
+  readFileSync(resolve(ROOT, 'src/manifest.json'), 'utf-8'),
+);
+const matches = manifest.content_scripts[0].matches;
+
+// Extract platforms (skip infrastructure hosts like 127.0.0.1)
+const platforms = [];
+for (const pattern of matches) {
+  const hostname = pattern.replace('https://', '').replace('/*', '');
+  if (hostname.startsWith('127.')) continue;
+
+  const displayName = HOST_DISPLAY_NAMES[hostname];
+  if (!displayName) {
+    console.error(
+      `ERROR: Unknown platform hostname: ${hostname}. Add it to HOST_DISPLAY_NAMES in scripts/lint-platforms.mjs`,
+    );
+    process.exit(1);
+  }
+  platforms.push({ hostname, displayName });
+}
+
+// Header
+console.log('Platform lint check');
+console.log('===================');
+console.log(
+  `Source: src/manifest.json content_scripts[0].matches`,
+);
+console.log(
+  `Platforms: ${platforms.map((p) => `${p.displayName} (${p.hostname})`).join(', ')}`,
+);
+console.log();
+
+// Run checks
+const errors = [];
+
+for (const target of CHECK_TARGETS) {
+  const filePath = resolve(ROOT, target.file);
+  const raw = readFileSync(filePath, 'utf-8');
+
+  for (const platform of platforms) {
+    if (target.type === 'hostname') {
+      if (!raw.includes(platform.hostname)) {
+        errors.push(
+          `ERROR: ${target.file} is missing platform hostname: ${platform.hostname}`,
+        );
+      }
+    } else if (target.type === 'displayName') {
+      let searchText = raw;
+      if (target.jsonField) {
+        const json = JSON.parse(raw);
+        // Support dotted paths like "extDescription.message"
+        const parts = target.jsonField.split('.');
+        let value = json;
+        for (const part of parts) {
+          value = value?.[part];
+        }
+        searchText = typeof value === 'string' ? value : '';
+      }
+      if (!searchText.toLowerCase().includes(platform.displayName.toLowerCase())) {
+        errors.push(
+          `ERROR: ${target.file} is missing platform display name: ${platform.displayName}`,
+        );
+      }
+    }
+  }
+}
+
+// Report
+if (errors.length > 0) {
+  for (const err of errors) {
+    console.log(err);
+  }
+  console.log();
+  console.log(
+    `${errors.length} error(s) found. Update the files above to include all platforms.`,
+  );
+  process.exit(1);
+} else {
+  console.log(
+    `All ${CHECK_TARGETS.length} files are consistent with manifest.json. \u2713`,
+  );
+  process.exit(0);
+}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name shown in browser"
   },
   "extDescription": {
-    "message": "Export AI conversations from Gemini, Claude, and ChatGPT to Obsidian via Local REST API",
+    "message": "Export AI conversations from Gemini, Claude, ChatGPT, and Perplexity to Obsidian via Local REST API",
     "description": "Extension description shown in browser and store"
   },
 

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -3,7 +3,7 @@
     "message": "Obsidian AI Exporter"
   },
   "extDescription": {
-    "message": "Gemini、Claude、ChatGPT の AI 会話を Obsidian へエクスポート（Local REST API 経由）"
+    "message": "Gemini、Claude、ChatGPT、Perplexity の AI 会話を Obsidian へエクスポート（Local REST API 経由）"
   },
 
   "ui_syncButton": {


### PR DESCRIPTION
## Summary

- Add `scripts/lint-platforms.mjs` that validates all manifest.json platforms are referenced in docs, locales, and config files
- Integrate platform lint into `npm run lint` and add standalone `npm run lint:platforms` script
- Update all documentation (README.md, README.ja.md, CLAUDE.md, privacy.html) to include Perplexity as a supported platform
- Update locale descriptions (en, ja) to mention Perplexity
- Refine `.gitignore` to track `.claude/commands/` while still ignoring `.claude/settings.local.json`
- Add `.claude/commands/release.md` for automated release workflow
- Add design docs (DES-007, DES-008) and workflow docs (WF-007, WF-008)

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes (includes new platform lint)
- [ ] `npm run lint:platforms` passes standalone
- [ ] Extension loads in Chrome with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)