### PR TITLE
refactor: fix selector priority in queryWithFallback and harden URL sanitization

### DIFF
--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -159,9 +159,14 @@ export abstract class BaseExtractor implements IConversationExtractor {
   }
 
   /**
-   * Try multiple selectors and return first successful result
+   * Try multiple selectors in priority order and return first successful result
    *
-   * @param selectors - Array of CSS selectors to try in order
+   * Selectors are tried sequentially (not combined) to preserve priority ordering.
+   * Extractors list selectors from HIGH → LOW stability, and this method must
+   * respect that order. A comma-joined querySelector would return the first
+   * match in DOM order instead, breaking the priority contract.
+   *
+   * @param selectors - Array of CSS selectors to try in priority order
    * @param parent - Parent element to search within (defaults to document)
    * @returns First matching element or null if none found or selectors empty
    */
@@ -182,11 +187,14 @@ export abstract class BaseExtractor implements IConversationExtractor {
   }
 
   /**
-   * Try multiple selectors and return all results
+   * Try multiple selectors in priority order and return all results from the first match
    *
-   * @param selectors - Array of CSS selectors to try in order
+   * Returns results from the FIRST selector that matches (not a union of all).
+   * Like queryWithFallback, preserves HIGH → LOW priority ordering.
+   *
+   * @param selectors - Array of CSS selectors to try in priority order
    * @param parent - Parent element to search within (defaults to document)
-   * @returns All matching elements or empty array if none found or selectors empty
+   * @returns All matching elements from first successful selector, or empty array
    */
   protected queryAllWithFallback<T extends Element>(
     selectors: string[],

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -23,7 +23,7 @@ import { MAX_FILENAME_BASE_LENGTH, FILENAME_ID_SUFFIX_LENGTH } from '../lib/cons
  * Sanitize URL to remove dangerous schemes
  */
 export function sanitizeUrl(url: string): string {
-  const dangerousSchemes = ['javascript:', 'data:', 'vbscript:'];
+  const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'blob:'];
   const lowerUrl = url.toLowerCase().trim();
 
   for (const scheme of dangerousSchemes) {


### PR DESCRIPTION
## Summary

- Restore loop-based `queryWithFallback()` to preserve HIGH→LOW selector priority ordering (comma-joined `querySelector` returned DOM-order matches instead)
- Improve JSDoc on both `queryWithFallback()` and `queryAllWithFallback()` to document the priority contract
- Refactor `PLATFORM_ROOT_SELECTORS` from comma-separated strings to `string[]` arrays, eliminating fragile `.split(', ')` parsing
- Add `blob:` to dangerous URL schemes in `sanitizeUrl()` (blob URLs are session-specific and unresolvable in Obsidian)

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npx vitest run` passes (570/570 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)