### PR TITLE
fix: skip Extended Thinking content in Claude assistant extraction

### DIFF
--- a/docs/design/DES-009-claude-extended-thinking-fix.md
+++ b/docs/design/DES-009-claude-extended-thinking-fix.md
@@ -1,0 +1,180 @@
+# DES-009: Claude Extended Thinking Extraction Fix
+
+**Issue**: #48 - Claude extractor captures Extended Thinking instead of actual response
+**Date**: 2026-02-20
+**Status**: Implemented
+**Investigation**: [docs/investigation/claude-extended-thinking-dom.md](../investigation/claude-extended-thinking-dom.md)
+
+## 1. Problem Statement
+
+When Extended Thinking is enabled on Claude AI, `extractAssistantContent()` returns the **thinking content** instead of the **actual response**. This is because `queryWithFallback(SELECTORS.markdownContent, element)` returns the first `.standard-markdown` in DOM order, which is inside the thinking section (`.row-start-1`), not the response section (`.row-start-2`).
+
+### 1.1 Scope
+
+| Extraction Path | Affected | Reason |
+|-----------------|----------|--------|
+| `extractAssistantContent()` | **YES** | First `.standard-markdown` match is thinking content |
+| `extractDeepResearchContent()` | No | Uses `#markdown-artifact .standard-markdown` (separate right panel) |
+| Artifacts | No | Same right panel as Deep Research (`#markdown-artifact`) |
+
+## 2. DOM Structure Analysis
+
+### 2.1 Extended Thinking Response (all modes: Normal, Deep Research, Artifacts)
+
+```
+.font-claude-response
+  └── div.grid (grid-rows-[0fr_1fr] | grid-rows-[1fr_1fr] | grid-rows-[auto_auto])
+      ├── .row-start-1  ← Thinking section (ALWAYS in DOM, even when collapsed)
+      │   └── div (overflow:hidden, min-h:0)
+      │       └── div.group/thinking
+      │           └── div.grid
+      │               ├── .standard-markdown (chunk 1) ← FIRST MATCH (BUG)
+      │               ├── .standard-markdown (chunk 2)
+      │               └── ...
+      │
+      └── .row-start-2  ← Actual response
+          └── div
+              └── .standard-markdown  ← CORRECT content
+```
+
+### 2.2 Non-Extended-Thinking Response (existing behavior)
+
+```
+.font-claude-response
+  └── .standard-markdown  ← Single direct child, no grid
+```
+
+### 2.3 Stable Selectors
+
+| Selector | Target | Stability | Notes |
+|----------|--------|-----------|-------|
+| `.row-start-1` | Thinking section | HIGH | Tailwind grid utility |
+| `.row-start-2` | Response section | HIGH | Tailwind grid utility |
+| `.group\/thinking` | Thinking wrapper | MEDIUM | Escaped `/` in class |
+| `.row-start-2 .standard-markdown` | Correct content | HIGH | Composite |
+
+## 3. Design
+
+### 3.1 Approach
+
+Add a scoping step to `extractAssistantContent()`: when `.row-start-2` exists within the response element, narrow the search scope to that section before applying the existing selector chain. This ensures thinking content in `.row-start-1` is excluded.
+
+When `.row-start-2` is absent (non-Extended-Thinking responses), the existing behavior is preserved.
+
+### 3.2 Why `.row-start-2` scoping (not exclusion of `.row-start-1`)
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Scope to `.row-start-2`** (chosen) | Simple, positive selection; works with existing `queryWithFallback` | Relies on `.row-start-2` being present |
+| Exclude `.row-start-1` via `:not()` | Doesn't require `.row-start-2` | Complex selector; fragile with nesting |
+| Skip first N markdown elements | No selector dependency | Brittle; count varies |
+
+### 3.3 Code Changes
+
+#### 3.3.1 `src/content/extractors/claude.ts` - `extractAssistantContent()`
+
+**Before:**
+```typescript
+private extractAssistantContent(element: Element): string {
+  const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
+  if (markdownEl) {
+    return sanitizeHtml(markdownEl.innerHTML);
+  }
+  return sanitizeHtml(element.innerHTML);
+}
+```
+
+**After:**
+```typescript
+private extractAssistantContent(element: Element): string {
+  // Extended Thinking: scope to .row-start-2 to skip thinking in .row-start-1
+  const responseSection = element.querySelector('.row-start-2');
+  if (responseSection) {
+    const markdownEl = this.queryWithFallback<HTMLElement>(
+      SELECTORS.markdownContent, responseSection
+    );
+    if (markdownEl) {
+      return sanitizeHtml(markdownEl.innerHTML);
+    }
+  }
+
+  // Non-Extended-Thinking fallback: existing behavior
+  const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
+  if (markdownEl) {
+    return sanitizeHtml(markdownEl.innerHTML);
+  }
+
+  return sanitizeHtml(element.innerHTML);
+}
+```
+
+**Line count change**: +8 lines (273-282 current → 273-290 proposed)
+
+### 3.4 No SELECTORS constant changes
+
+`.row-start-2` is used as a **structural scoping selector**, not a content selector. It does not belong in the `SELECTORS` object which holds fallback chains for content discovery.
+
+## 4. Test Plan
+
+### 4.1 DOM Helper Changes (`test/fixtures/dom-helpers.ts`)
+
+Add an optional `thinking` field to `ClaudeConversationMessage` to generate Extended Thinking DOM:
+
+```typescript
+interface ClaudeConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  thinking?: string[];  // Optional: thinking chunks for Extended Thinking
+}
+```
+
+When `thinking` is provided on an assistant message, `createClaudeConversationDOM()` will generate the grid structure with `.row-start-1` (thinking) and `.row-start-2` (response) instead of the flat `.standard-markdown`.
+
+**New helper function:**
+
+```typescript
+/**
+ * Create Extended Thinking assistant response DOM
+ */
+function createClaudeExtendedThinkingResponse(
+  content: string,
+  thinkingChunks: string[],
+  collapsed: boolean = true
+): string
+```
+
+### 4.2 New Test Cases (`test/extractors/claude.test.ts`)
+
+```
+describe('Extended Thinking')
+  ├── it('extracts response content, not thinking content (collapsed)')
+  ├── it('extracts response content, not thinking content (expanded)')
+  ├── it('handles multiple thinking chunks without capturing any')
+  ├── it('works with mixed conversation (some turns with thinking, some without)')
+  └── it('backward compatible: non-thinking responses still work')
+```
+
+**Total new tests**: 5
+
+### 4.3 Existing Tests
+
+All existing tests must continue to pass. The non-Extended-Thinking DOM structure has no `.row-start-2`, so the new code path falls through to the existing behavior.
+
+## 5. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `.row-start-2` class name changes | LOW | Response not extracted | Tailwind utility class; unlikely to change |
+| Claude removes grid layout | LOW | Falls through to existing behavior (safe) | Fallback preserves backward compatibility |
+| `.row-start-2` used elsewhere in DOM | LOW | Wrong scoping target | Scoped to `.font-claude-response` element only |
+
+## 6. Files Changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/content/extractors/claude.ts` | Modify `extractAssistantContent()` | +8 |
+| `test/fixtures/dom-helpers.ts` | Add Extended Thinking DOM helper | ~30 |
+| `test/extractors/claude.test.ts` | Add 5 Extended Thinking test cases | ~80 |
+| `docs/investigation/claude-extended-thinking-dom.md` | Update status to Complete | ~2 |
+
+**Total estimated change**: ~120 lines

--- a/docs/investigation/claude-extended-thinking-dom.md
+++ b/docs/investigation/claude-extended-thinking-dom.md
@@ -1,0 +1,166 @@
+# Claude Extended Thinking DOM Analysis
+
+**Issue**: #48 - Claude extractor captures Extended Thinking instead of actual response
+**Date**: 2026-02-20
+**Status**: Complete (fix implemented in DES-009)
+
+## Problem Summary
+
+`ClaudeExtractor.extractAssistantContent()` uses `queryWithFallback(SELECTORS.markdownContent, element)` which returns the **first** `.standard-markdown` found in DOM order. When Extended Thinking is enabled, the first `.standard-markdown` is the **thinking content**, not the actual response.
+
+### Affected Code
+
+```typescript
+// src/content/extractors/claude.ts:273-282
+private extractAssistantContent(element: Element): string {
+  const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
+  if (markdownEl) {
+    return sanitizeHtml(markdownEl.innerHTML);  // ← Returns thinking, not response!
+  }
+  return sanitizeHtml(element.innerHTML);
+}
+```
+
+### Current Selector Chain
+
+```typescript
+markdownContent: [
+  '.standard-markdown',       // Semantic (HIGH)
+  '.progressive-markdown',    // Semantic (HIGH)
+  '[class*="markdown"]',      // Partial match (MEDIUM)
+],
+```
+
+## Verified: Normal Chat + Extended Thinking
+
+### DOM Structure (Common to Collapsed & Expanded)
+
+Each assistant response (`.font-claude-response`) contains a grid layout:
+
+```
+.font-claude-response
+  └── div.grid (grid-rows-[0fr_1fr] or grid-rows-[1fr_1fr])
+      ├── .row-start-1  ← Thinking section (ALWAYS in DOM)
+      │   └── div (overflow:hidden, min-h:0)
+      │       └── div.group/thinking (border, rounded)
+      │           └── div
+      │               ├── button "Claude's Thoughts" (toggle)
+      │               └── div
+      │                   └── div
+      │                       └── div.grid
+      │                           ├── .standard-markdown (thinking chunk 1) ← ⚠️ FIRST MATCH
+      │                           ├── .standard-markdown (thinking chunk 2)
+      │                           └── ... (multiple chunks)
+      │
+      └── .row-start-2  ← Actual response section
+          └── div
+              └── .standard-markdown  ← THIS is the correct content
+```
+
+### Key Findings
+
+1. **Bug confirmed**: `.standard-markdown` in `.row-start-1` (thinking) appears first in DOM order
+2. **Thinking is ALWAYS in DOM**: Even when collapsed, elements exist (CSS `grid-template-rows: 0fr` + `overflow:hidden` hides them)
+3. **Multiple thinking chunks**: Thinking section contains multiple `.standard-markdown` elements
+4. **Response is single**: `.row-start-2` contains exactly one `.standard-markdown`
+
+### Collapsed vs Expanded Differences
+
+| Aspect | Collapsed | Expanded |
+|--------|-----------|----------|
+| Container grid | `grid-rows-[0fr_1fr]` | `grid-rows-[1fr_1fr]` |
+| Thinking visible | No (overflow:hidden + 0fr) | Yes |
+| Thinking in DOM | **Yes** (always present) | Yes |
+| Bug triggered | **Yes** | **Yes** |
+
+### Stable Selectors Identified
+
+| Selector | Target | Stability |
+|----------|--------|-----------|
+| `.row-start-1` | Thinking section | HIGH (Tailwind grid utility) |
+| `.row-start-2` | Actual response section | HIGH (Tailwind grid utility) |
+| `.group\/thinking` | Thinking wrapper (escaped `/`) | MEDIUM |
+| `.row-start-2 .standard-markdown` | Correct response content | HIGH |
+
+## Verified: Artifacts + Extended Thinking
+
+Artifact (通常の code/document 生成) は Deep Research と同一の右パネルに配置されることを確認。
+
+### Container Selector (共通)
+
+```
+#main-content > div > div.max-md\:absolute.top-0.right-0.bottom-0.left-0.z-20
+  .md\:flex-grow-0.md\:flex-shrink-0.md\:basis-0.overflow-hidden.h-full.max-md\:flex-1
+```
+
+Both normal Artifacts and Deep Research Artifacts share this identical container, which is completely separate from the conversation panel (`.font-claude-response`).
+
+### Key Findings
+
+1. **Same right panel as Deep Research**: `#markdown-artifact` is in the same DOM location regardless of Artifact type
+2. **Extended Thinking does NOT affect Artifact extraction**: Artifact container is outside the conversation panel's `.row-start-1`/`.row-start-2` grid
+3. **`isDeepResearchVisible()` covers both cases**: Detection via `#markdown-artifact` presence works for both Deep Research and normal Artifacts
+
+## Verified: Deep Research + Extended Thinking
+
+### DOM Structure
+
+Deep Research with Extended Thinking follows the same `.row-start-1` / `.row-start-2` grid pattern in the conversation panel, but the actual report content is in a separate right panel:
+
+```
+Left panel (conversation)
+  .font-claude-response
+    └── div.grid.grid-rows-[auto_auto]
+        ├── .row-start-1  ← Thinking section
+        │   └── button (toggle) + thinking steps + .standard-markdown (thinking chunks)
+        └── .row-start-2  ← Actual response
+            └── .standard-markdown (response content)
+
+Right panel (artifact, completely separate)
+  div.max-md:absolute...overflow-hidden
+    └── div#markdown-artifact
+        └── div.standard-markdown  ← Deep Research report body
+```
+
+### Key Findings
+
+1. **`.row-start-1` / `.row-start-2` pattern is consistent**: Same grid structure as Normal Chat
+2. **Grid uses `grid-rows-[auto_auto]`**: Different from Normal Chat (`0fr_1fr`/`1fr_1fr`) but `.row-start-1` / `.row-start-2` selectors are unaffected
+3. **`#markdown-artifact` is in a separate panel**: Completely outside the conversation `.font-claude-response` elements
+4. **Deep Research extraction is NOT affected by the Extended Thinking bug**: `extractDeepResearchContent()` uses `#markdown-artifact .standard-markdown` which targets the right panel, not the conversation panel's thinking content
+5. **Normal chat extraction bug still applies**: `extractAssistantContent()` for conversation messages in the left panel would still hit thinking `.standard-markdown` first
+
+## Proposed Fix Approach
+
+All modes verified. The fix scope is limited to `extractAssistantContent()` only:
+
+1. Check `.row-start-2 .standard-markdown` first (Extended Thinking response)
+2. Fall back to existing selector chain for non-thinking responses
+3. Ensure backward compatibility with conversations without Extended Thinking
+
+### Draft Fix (pending validation)
+
+```typescript
+private extractAssistantContent(element: Element): string {
+  // Extended Thinking: response is in .row-start-2, thinking is in .row-start-1
+  const responseSection = element.querySelector('.row-start-2');
+  if (responseSection) {
+    const markdownEl = this.queryWithFallback<HTMLElement>(
+      SELECTORS.markdownContent, responseSection
+    );
+    if (markdownEl) {
+      return sanitizeHtml(markdownEl.innerHTML);
+    }
+  }
+
+  // Non-thinking fallback: existing logic
+  const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
+  if (markdownEl) {
+    return sanitizeHtml(markdownEl.innerHTML);
+  }
+
+  return sanitizeHtml(element.innerHTML);
+}
+```
+
+**Impact scope**: `extractAssistantContent()` only. Deep Research and Artifacts are unaffected (both use `#markdown-artifact` in a separate right panel).

--- a/docs/workflow/workflow-DES-009-extended-thinking-fix.md
+++ b/docs/workflow/workflow-DES-009-extended-thinking-fix.md
@@ -1,0 +1,204 @@
+# Workflow: DES-009 Claude Extended Thinking Fix
+
+**Design**: [DES-009-claude-extended-thinking-fix.md](../design/DES-009-claude-extended-thinking-fix.md)
+**Issue**: #48
+**Branch**: `fix/claude-extended-thinking-extraction`
+
+## Phase Overview
+
+```
+Phase 1: Branch Setup
+  │
+Phase 2: DOM Helper (test infrastructure)
+  │
+Phase 3: Test Cases (red → failing tests first)
+  │
+Phase 4: Implementation (green → make tests pass)
+  │
+Phase 5: Verification (lint, typecheck, full test suite)
+  │
+Phase 6: Documentation Update
+```
+
+---
+
+## Phase 1: Branch Setup
+
+**Goal**: Create feature branch from main
+
+### Step 1.1: Create branch
+```bash
+git checkout -b fix/claude-extended-thinking-extraction
+```
+
+**Checkpoint**: `git branch --show-current` shows `fix/claude-extended-thinking-extraction`
+
+---
+
+## Phase 2: DOM Helper
+
+**Goal**: Add Extended Thinking DOM generation to test fixtures
+**File**: `test/fixtures/dom-helpers.ts`
+
+### Step 2.1: Update `ClaudeConversationMessage` interface
+
+Add optional `thinking` field:
+
+```typescript
+interface ClaudeConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  thinking?: string[];  // Extended Thinking chunks
+}
+```
+
+### Step 2.2: Create `createClaudeExtendedThinkingResponse()` helper
+
+New private function to generate the grid layout with `.row-start-1` (thinking) and `.row-start-2` (response):
+
+```typescript
+function createClaudeExtendedThinkingResponse(
+  content: string,
+  thinkingChunks: string[],
+  collapsed: boolean = true
+): string
+```
+
+Must generate:
+- Outer `div.grid` with appropriate `grid-rows-[...]` class
+- `.row-start-1` containing thinking chunks as individual `.standard-markdown` elements
+- `.row-start-2` containing the actual response as `.standard-markdown`
+- `button` with "Claude's Thoughts" text (for realism)
+
+### Step 2.3: Modify `createClaudeConversationDOM()` branching
+
+When `msg.thinking` is provided on an assistant message, call `createClaudeExtendedThinkingResponse()` instead of the flat `.standard-markdown` structure.
+
+**Checkpoint**: `npm run lint` and `npx tsc --noEmit` pass
+
+---
+
+## Phase 3: Test Cases
+
+**Goal**: Write 5 new test cases (expected to fail before implementation)
+**File**: `test/extractors/claude.test.ts`
+
+### Step 3.1: Add `describe('Extended Thinking')` block
+
+Location: After the existing "Message Extraction" describe block (after line ~267).
+
+### Step 3.2: Test case list
+
+| # | Test Name | DOM Setup | Assertion |
+|---|-----------|-----------|-----------|
+| 1 | extracts response content, not thinking content (collapsed) | Single turn, `thinking: ['chunk1']`, collapsed grid | Content matches response, not thinking |
+| 2 | extracts response content, not thinking content (expanded) | Same but with expanded grid class | Same assertion |
+| 3 | handles multiple thinking chunks without capturing any | `thinking: ['chunk1', 'chunk2', 'chunk3']` | Content is response only |
+| 4 | works with mixed conversation | Turn 1: no thinking; Turn 2: with thinking | Both turns extract correct content |
+| 5 | backward compatible: non-thinking responses still work | Standard DOM (no thinking) | Existing behavior preserved |
+
+Each test uses `createClaudePage()` with the extended message format.
+
+**Checkpoint**: `npx vitest run test/extractors/claude.test.ts` shows 5 new **failing** tests (red phase)
+
+---
+
+## Phase 4: Implementation
+
+**Goal**: Fix `extractAssistantContent()` to skip Extended Thinking content
+**File**: `src/content/extractors/claude.ts`
+
+### Step 4.1: Modify `extractAssistantContent()` (lines 273-282)
+
+Apply the `.row-start-2` scoping logic from DES-009 Section 3.3.1:
+
+1. First, check `element.querySelector('.row-start-2')`
+2. If found, scope `queryWithFallback` to that section
+3. If not found, fall through to existing behavior
+
+**Checkpoint**: `npx vitest run test/extractors/claude.test.ts` shows all tests **passing** (green phase)
+
+---
+
+## Phase 5: Verification
+
+**Goal**: Ensure no regressions across the entire project
+
+### Step 5.1: Full test suite
+```bash
+npx vitest run
+```
+**Expect**: All tests pass (existing + 5 new)
+
+### Step 5.2: TypeScript strict check
+```bash
+npx tsc --noEmit
+```
+**Expect**: 0 errors
+
+### Step 5.3: ESLint
+```bash
+npm run lint
+```
+**Expect**: 0 errors, 0 warnings
+
+### Step 5.4: Prettier
+```bash
+npm run format
+```
+
+### Step 5.5: Build
+```bash
+npm run build
+```
+**Expect**: Clean build
+
+**Checkpoint**: All 5 verification steps pass
+
+---
+
+## Phase 6: Documentation Update
+
+**Goal**: Finalize investigation document status
+
+### Step 6.1: Update investigation document
+
+**File**: `docs/investigation/claude-extended-thinking-dom.md`
+
+- Change Status to: `Complete (fix implemented in DES-009)`
+- Update Proposed Fix section to reference the actual implementation
+
+### Step 6.2: Update design document status
+
+**File**: `docs/design/DES-009-claude-extended-thinking-fix.md`
+
+- Change Status from `Draft` to `Implemented`
+
+**Checkpoint**: All doc updates committed
+
+---
+
+## Dependency Map
+
+```
+Phase 1 (branch)
+    └──→ Phase 2 (DOM helper)
+              └──→ Phase 3 (tests - red)
+                        └──→ Phase 4 (implementation - green)
+                                  └──→ Phase 5 (verification)
+                                            └──→ Phase 6 (docs)
+```
+
+All phases are sequential. No parallelism possible due to dependencies.
+
+---
+
+## Exit Criteria
+
+- [ ] 5 new Extended Thinking tests pass
+- [ ] All existing tests pass (no regressions)
+- [ ] `npm run build` succeeds
+- [ ] `npm run lint` clean
+- [ ] `npx tsc --noEmit` clean
+- [ ] Investigation doc status updated
+- [ ] Design doc status updated

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -271,7 +271,19 @@ export class ClaudeExtractor extends BaseExtractor {
    * @see NFR-001-2 in design document
    */
   private extractAssistantContent(element: Element): string {
-    // Try to find markdown content inside the response
+    // Extended Thinking: scope to .row-start-2 to skip thinking in .row-start-1
+    const responseSection = element.querySelector('.row-start-2');
+    if (responseSection) {
+      const markdownEl = this.queryWithFallback<HTMLElement>(
+        SELECTORS.markdownContent,
+        responseSection
+      );
+      if (markdownEl) {
+        return sanitizeHtml(markdownEl.innerHTML);
+      }
+    }
+
+    // Non-Extended-Thinking fallback: existing behavior
     const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
     if (markdownEl) {
       return sanitizeHtml(markdownEl.innerHTML);


### PR DESCRIPTION
## Summary

- Fix #48: `extractAssistantContent()` now scopes to `.row-start-2` when Extended Thinking is enabled, skipping thinking chunks in `.row-start-1`
- Falls through to existing behavior for non-Extended-Thinking responses (backward compatible)
- Add Extended Thinking DOM helper (`createClaudeExtendedThinkingResponse()`) to test fixtures
- Add 5 new test cases: collapsed, expanded, multiple chunks, mixed conversation, backward compatibility
- Add design doc (DES-009) and investigation doc with verified DOM analysis for Normal Chat, Deep Research, and Artifacts

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (588 tests, including 5 new Extended Thinking tests)
- [x] `npx tsc --noEmit` passes
- [x] Manual verification: extract Claude conversation with Extended Thinking enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)