### PR TITLE
feat: add auto-scroll for Gemini long conversations with settings toggle

### DIFF
--- a/docs/adr/002-gemini-auto-scroll.md
+++ b/docs/adr/002-gemini-auto-scroll.md
@@ -1,0 +1,61 @@
+# ADR-002: Auto-Scroll for Gemini Long Conversation Extraction
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ADR-002 |
+| **Date** | 2026-02-20 |
+| **Status** | Accepted |
+| **Branch** | `feature/gemini-auto-scroll` |
+| **Issue** | [#49](https://github.com/sho7650/obsidian-AI-exporter/issues/49) |
+| **Related** | [#44](https://github.com/sho7650/obsidian-AI-exporter/issues/44), PR #45 (closed) |
+| **Design Spec** | [DES-002](../design/002-gemini-auto-scroll.md) |
+
+---
+
+## Context
+
+Gemini uses backward infinite scrolling for long conversations. Only recent messages are in the DOM; older ones load from the server when the user scrolls upward. The current `GeminiExtractor.extractMessages()` reads only DOM-present elements, silently truncating long conversations.
+
+Investigation confirmed Gemini uses **append-only lazy loading** (NOT true virtual scroll). Once messages load into the DOM, they persist. `scrollTo({ top: 0 })` triggers server-side backfill.
+
+---
+
+## Decision
+
+**Scroll-to-top with DOM stabilization** inside `GeminiExtractor`.
+
+- Detect partial load via `scrollTop > 0` on `#chat-history`
+- Programmatically `scrollTo({ top: 0 })` repeatedly (1s interval)
+- Count `.conversation-container` elements; 3 consecutive unchanged readings = done
+- Timeout at 30s; extract available messages + warning
+- Short conversations (`scrollTop === 0`): bypass entirely, zero overhead
+
+Implementation is confined to `GeminiExtractor` (private methods). No changes to `BaseExtractor`, `IConversationExtractor`, or `buildConversationResult()`.
+
+---
+
+## Alternatives Rejected
+
+| Alternative | Reason |
+|-------------|--------|
+| **MutationObserver** | Harder to test in jsdom, still needs timeout, no clear benefit over 1s polling |
+| **Incremental scrollBy()** | Unnecessary — single `scrollTo(0)` triggers full backfill |
+| **Network interception (batchexecute API)** | Fragile auth tokens, API instability, excessive complexity |
+| **User notification only** | Pushes work to user; auto-scroll is automatic with graceful fallback |
+| **Modify buildConversationResult()** | Shared interface change for Gemini-specific concern; warning can be appended after return |
+
+---
+
+## Consequences
+
+**Positive**: Long conversations fully extracted; zero overhead for short ones; graceful timeout with warning.
+
+**Risks**: Scroll briefly visible to user; selector change degrades to pre-fix behavior (not a regression); 30s cap may not load extremely long conversations.
+
+---
+
+## References
+
+- Design specification: [DES-002](../design/002-gemini-auto-scroll.md)
+- [gemini-chat-exporter](https://github.com/Louisjo/gemini-chat-exporter) — scroll-to-top approach reference
+- Gemini scroll bug reports: [thread 1](https://support.google.com/gemini/thread/388320766), [thread 2](https://support.google.com/gemini/thread/349679299)

--- a/docs/design/002-gemini-auto-scroll.md
+++ b/docs/design/002-gemini-auto-scroll.md
@@ -1,0 +1,613 @@
+# DES-002: Gemini Auto-Scroll Design Specification
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | DES-002 |
+| **Date** | 2026-02-20 |
+| **Status** | Final |
+| **Issue** | [#49](https://github.com/sho7650/obsidian-AI-exporter/issues/49) |
+| **ADR** | [ADR-002](../adr/002-gemini-auto-scroll.md) |
+
+---
+
+## 1. Purpose
+
+Gemini の長い会話で、遅延読み込み（backward infinite scroll）により DOM に存在しないメッセージが抽出されない問題を解決する。
+
+**現状**: `extractMessages()` は DOM に存在する `.conversation-container` のみを読む。長い会話では最新のメッセージしか DOM にないため、サイレントに不完全な抽出となる。
+
+**目標**: 抽出前に自動スクロールで全メッセージを DOM にロードし、完全な会話を取得する。
+
+---
+
+## 2. Scope
+
+### In Scope
+
+- `GeminiExtractor` への自動スクロール機構の追加
+- タイムアウト時の部分抽出と警告表示
+- ユニットテスト
+
+### Out of Scope
+
+- 他プラットフォーム (Claude / ChatGPT / Perplexity) のスクロール対応
+- Gemini API 直接呼び出しによるメッセージ取得
+- Settings UI でのスクロール設定
+- `BaseExtractor` / `IConversationExtractor` インターフェースの変更
+
+---
+
+## 3. Background: Gemini DOM Structure
+
+### 3.1 Scroll Container Hierarchy
+
+```
+<div id="chat-history" class="chat-history-scroll-container">   ← scrollable
+  <infinite-scroller class="chat-history">                      ← Angular component
+    <div class="conversation-container">                        ← turn 1 (oldest)
+      <user-query>...</user-query>
+      <model-response>...</model-response>
+    </div>
+    <div class="conversation-container">                        ← turn 2
+      ...
+    </div>
+    ...
+    <div class="conversation-container">                        ← turn N (newest)
+      ...
+    </div>
+  </infinite-scroller>
+</div>
+```
+
+### 3.2 Lazy Loading Behavior
+
+| 特性 | 値 |
+|------|-----|
+| 方式 | Append-only lazy loading |
+| トリガー | `#chat-history` の `scrollTop` が上端に近づいた時 |
+| ロード単位 | サーバーから会話ターン (`.conversation-container`) のバッチ |
+| ノード削除 | **なし** (true virtual scroll ではない) |
+| API | `/_/BardChatUi/data/batchexecute` / GRPC `hNvQHb` (READ_CHAT) |
+
+**重要**: 一度 DOM にロードされたノードは消えない。全メッセージがロードされれば、既存の `extractMessages()` がそのまま動作する。
+
+---
+
+## 4. Interface Specification
+
+### 4.1 ScrollResult (module-private)
+
+```typescript
+/**
+ * Result of the auto-scroll process
+ * Internal to gemini.ts — not exported
+ */
+interface ScrollResult {
+  /** Whether all messages loaded before timeout */
+  fullyLoaded: boolean;
+  /** Number of .conversation-container elements found after scrolling */
+  elementCount: number;
+  /** Total scroll-poll iterations performed */
+  scrollIterations: number;
+  /** Whether scrolling was unnecessary (already at top or no container) */
+  skipped: boolean;
+}
+```
+
+### 4.2 Constants
+
+File: `src/lib/constants.ts`
+
+```typescript
+// ============================================================
+// Auto-Scroll Configuration (Gemini)
+// ============================================================
+
+/** Interval between scroll-to-top attempts (milliseconds) */
+export const SCROLL_POLL_INTERVAL = 1000;
+
+/** Maximum time to wait for all messages to load (milliseconds) */
+export const SCROLL_TIMEOUT = 30000;
+
+/** Number of consecutive unchanged element counts to consider loading complete */
+export const SCROLL_STABILITY_THRESHOLD = 3;
+```
+
+### 4.3 Selectors
+
+File: `src/content/extractors/gemini.ts` — existing `SELECTORS` object に追加
+
+```typescript
+const SELECTORS = {
+  // ... existing entries ...
+
+  // Scroll container for lazy-load detection
+  scrollContainer: [
+    '#chat-history',
+    '.chat-history-scroll-container',
+    'infinite-scroller',
+  ],
+};
+```
+
+---
+
+## 5. Method Specification
+
+### 5.1 `ensureAllMessagesLoaded()`
+
+| Item | Value |
+|------|-------|
+| Visibility | `private` |
+| Signature | `async ensureAllMessagesLoaded(): Promise<ScrollResult>` |
+| Location | `GeminiExtractor` class, `gemini.ts` |
+
+#### Preconditions
+
+- `canExtract()` returns `true`
+- Deep Research panel is NOT visible (caller checks this before calling)
+
+#### Algorithm
+
+```
+function ensureAllMessagesLoaded():
+    container = queryWithFallback(SELECTORS.scrollContainer)
+
+    if container is null:
+        log "[G2O] No scroll container found, skipping auto-scroll"
+        return { fullyLoaded: true, elementCount: 0, scrollIterations: 0, skipped: true }
+
+    if container.scrollTop === 0:
+        count = countConversationElements()
+        log "[G2O] Conversation already at top, no scroll needed"
+        return { fullyLoaded: true, elementCount: count, scrollIterations: 0, skipped: true }
+
+    log "[G2O] Partial load detected, auto-scrolling to load all messages"
+
+    previousCount = 0
+    stableCount = 0
+    iterations = 0
+    startTime = Date.now()
+
+    while (Date.now() - startTime < SCROLL_TIMEOUT):
+        container.scrollTo({ top: 0 })
+        await delay(SCROLL_POLL_INTERVAL)
+
+        currentCount = countConversationElements()
+        iterations++
+
+        if currentCount === previousCount:
+            stableCount++
+            if stableCount >= SCROLL_STABILITY_THRESHOLD:
+                log "[G2O] DOM stabilized after {iterations} iterations with {currentCount} elements"
+                return { fullyLoaded: true, elementCount: currentCount, scrollIterations: iterations, skipped: false }
+        else:
+            log debug "[G2O] Element count changed: {previousCount} -> {currentCount}"
+            stableCount = 0
+            previousCount = currentCount
+
+    finalCount = countConversationElements()
+    log warn "[G2O] Auto-scroll timed out after {SCROLL_TIMEOUT}ms with {finalCount} elements"
+    return { fullyLoaded: false, elementCount: finalCount, scrollIterations: iterations, skipped: false }
+```
+
+#### Postconditions
+
+- `fullyLoaded === true`: 全メッセージが DOM に存在する
+- `fullyLoaded === false`: タイムアウト。DOM にある分だけ存在する
+- `skipped === true`: スクロール不要だった (短い会話 or コンテナなし)
+
+### 5.2 `countConversationElements()`
+
+| Item | Value |
+|------|-------|
+| Visibility | `private` |
+| Signature | `countConversationElements(): number` |
+
+```typescript
+private countConversationElements(): number {
+  return document.querySelectorAll(
+    SELECTORS.conversationTurn.join(',')
+  ).length;
+}
+```
+
+**Note**: `SELECTORS.conversationTurn` を comma-join して使う。`queryAllWithFallback` は優先順位付きだが、ここでは「合計数」が欲しいので全セレクタを結合する。
+
+### 5.3 `delay()`
+
+| Item | Value |
+|------|-------|
+| Visibility | `private` |
+| Signature | `delay(ms: number): Promise<void>` |
+
+```typescript
+private delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+```
+
+---
+
+## 6. Sequence Diagram
+
+### 6.1 Normal Flow (Long Conversation)
+
+```
+User          Content Script         GeminiExtractor        DOM / Gemini Server
+ |                |                       |                        |
+ |--click Sync--->|                       |                        |
+ |                |---extract()---------->|                        |
+ |                |                       |--canExtract()          |
+ |                |                       |--isDeepResearchVisible()|
+ |                |                       |                        |
+ |                |                       |--ensureAllMessagesLoaded()
+ |                |                       |   |                    |
+ |                |                       |   |--queryWithFallback(scrollContainer)
+ |                |                       |   |   return #chat-history
+ |                |                       |   |                    |
+ |                |                       |   |--check scrollTop   |
+ |                |                       |   |   scrollTop = 1500 (> 0)
+ |                |                       |   |                    |
+ |                |                       |   |===[scroll loop]====|
+ |                |                       |   |                    |
+ |                |                       |   |--scrollTo({top:0})--->  (triggers fetch)
+ |                |                       |   |--delay(1000ms)     |
+ |                |                       |   |                    |<--server responds
+ |                |                       |   |                    |   DOM += N turns
+ |                |                       |   |--countElements()   |
+ |                |                       |   |   count: 5→12 (changed, reset stable)
+ |                |                       |   |                    |
+ |                |                       |   |--scrollTo({top:0})--->
+ |                |                       |   |--delay(1000ms)     |
+ |                |                       |   |--countElements()   |
+ |                |                       |   |   count: 12→20 (changed)
+ |                |                       |   |                    |
+ |                |                       |   |--scrollTo({top:0})--->
+ |                |                       |   |--delay(1000ms)     |
+ |                |                       |   |--countElements()   |
+ |                |                       |   |   count: 20→20 (stable 1/3)
+ |                |                       |   |                    |
+ |                |                       |   |  ... 2 more stable polls ...
+ |                |                       |   |   count: 20→20 (stable 3/3)
+ |                |                       |   |                    |
+ |                |                       |   |===[loop end]=======|
+ |                |                       |   return { fullyLoaded: true, elementCount: 20 }
+ |                |                       |                        |
+ |                |                       |--extractMessages()     |
+ |                |                       |   (reads all 20 turns from DOM)
+ |                |                       |                        |
+ |                |                       |--buildConversationResult()
+ |                |<---ExtractionResult---|                        |
+ |                |   (40 messages, no warnings)                   |
+ |<--toast--------|                       |                        |
+```
+
+### 6.2 Timeout Flow
+
+```
+GeminiExtractor
+ |
+ |--ensureAllMessagesLoaded()
+ |   |
+ |   |===[scroll loop]==========
+ |   |  scrollTo → delay → count
+ |   |  (elements keep growing each iteration)
+ |   |  ...
+ |   |  Date.now() - startTime >= 30000ms
+ |   |==============================
+ |   return { fullyLoaded: false, elementCount: 85 }
+ |
+ |--extractMessages()
+ |   (reads 85 turns available in DOM)
+ |
+ |--buildConversationResult()
+ |   result.warnings = ['No user messages found']  (example)
+ |
+ |--append timeout warning
+ |   result.warnings.push('Auto-scroll timed out after 30s. ...')
+ |
+ return ExtractionResult
+   { success: true, warnings: ['No user messages found', 'Auto-scroll timed out...'] }
+```
+
+### 6.3 Skip Flow (Short Conversation)
+
+```
+GeminiExtractor
+ |
+ |--ensureAllMessagesLoaded()
+ |   |--queryWithFallback(scrollContainer) → #chat-history
+ |   |--scrollTop === 0
+ |   return { skipped: true }       ← no delay, no scroll
+ |
+ |--extractMessages()               ← immediate, same as current behavior
+ |--buildConversationResult()
+ return ExtractionResult
+```
+
+---
+
+## 7. State Transition
+
+```
+                  ┌─────────────────────┐
+                  │       INIT          │
+                  │ (extract() called)  │
+                  └──────────┬──────────┘
+                             │
+                    canExtract()?
+                    ┌────no──┴──yes────┐
+                    ▼                  ▼
+               Return error    Deep Research?
+                              ┌──yes──┴──no──┐
+                              ▼              ▼
+                     extractDeepResearch   ┌────────────────┐
+                                          │ DETECT_SCROLL  │
+                                          │ find container │
+                                          └───────┬────────┘
+                                                  │
+                                    ┌─no container─┼─has container─┐
+                                    ▼              │               ▼
+                               SKIP (a)      scrollTop === 0?  scrollTop > 0
+                                              ▼                    ▼
+                                          SKIP (b)          ┌──────────┐
+                                                            │ SCROLLING│◄────────┐
+                                                            │scrollTo(0)│         │
+                                                            │delay(1s) │         │
+                                                            │count()   │         │
+                                                            └────┬─────┘         │
+                                                                 │               │
+                                                     count changed?              │
+                                                    ┌──yes──┴──no──┐             │
+                                                    │              ▼             │
+                                                    │       stable++            │
+                                                    │    stable >= 3?           │
+                                                    │   ┌──no──┴──yes──┐        │
+                                                    │   │              ▼        │
+                                                    │   │          COMPLETE     │
+                                                    │   │     fullyLoaded=true  │
+                                                    ▼   ▼                       │
+                                              timed out?                        │
+                                             ┌─yes─┴──no──┐                    │
+                                             ▼             └────────────────────┘
+                                          TIMEOUT
+                                     fullyLoaded=false
+                                     + warning appended
+
+
+                SKIP / COMPLETE / TIMEOUT
+                         │
+                         ▼
+                  ┌──────────────┐
+                  │   EXTRACT    │
+                  │extractMessages│
+                  │buildResult   │
+                  └──────────────┘
+```
+
+---
+
+## 8. Error Handling
+
+| Condition | Handling | User Impact |
+|-----------|----------|-------------|
+| Scroll container not found | Skip scroll, proceed with extraction | 現在と同じ動作 (部分抽出の可能性) |
+| `scrollTop === 0` | Skip scroll | 遅延なしで抽出 |
+| Scroll timed out (30s) | 現在の DOM で抽出 + warning | Toast で警告表示 |
+| `scrollTo()` が例外を投げる | `extract()` の既存 try-catch でキャッチ | エラートースト |
+| ネットワーク障害で新メッセージがロードされない | 要素数が増えず安定化判定で完了 | 部分抽出 (warning なし — スクロール自体は成功) |
+| Gemini のスクロールバグ (途中停止) | 毎回 `scrollTo({top:0})` を再送 | バグが持続する場合はタイムアウトへ |
+
+### Warning メッセージフォーマット
+
+```
+Auto-scroll timed out after 30s. Some earlier messages may be missing ({N} turns loaded).
+```
+
+`{N}` = タイムアウト時の `.conversation-container` 数。
+
+### Warning の伝播パス
+
+```
+ensureAllMessagesLoaded()
+  → fullyLoaded: false を返す
+    → extract() が result.warnings に追加
+      → content/index.ts handleSync() が displaySaveResults() を呼ぶ
+        → displaySaveResults() が showWarningToast() を呼ぶ
+```
+
+既存の `ExtractionResult.warnings?: string[]` と `displaySaveResults()` をそのまま利用。新規 UI コンポーネントは不要。
+
+---
+
+## 9. extract() Modified Flow
+
+### Before (現行)
+
+```typescript
+async extract(): Promise<ExtractionResult> {
+  try {
+    if (!this.canExtract()) { return error; }
+    if (this.isDeepResearchVisible()) { return this.extractDeepResearch(); }
+
+    const messages = this.extractMessages();                      // ← DOM にあるものだけ
+    const conversationId = this.getConversationId() || `gemini-${Date.now()}`;
+    const title = this.getTitle();
+    return this.buildConversationResult(messages, conversationId, title, 'gemini');
+  } catch (error) { ... }
+}
+```
+
+### After (変更後)
+
+```typescript
+async extract(): Promise<ExtractionResult> {
+  try {
+    if (!this.canExtract()) { return error; }
+    if (this.isDeepResearchVisible()) { return this.extractDeepResearch(); }
+
+    const scrollResult = await this.ensureAllMessagesLoaded();    // ← NEW
+
+    const messages = this.extractMessages();
+    const conversationId = this.getConversationId() || `gemini-${Date.now()}`;
+    const title = this.getTitle();
+    const result = this.buildConversationResult(messages, conversationId, title, 'gemini');
+
+    // Append timeout warning                                     // ← NEW
+    if (!scrollResult.fullyLoaded && !scrollResult.skipped) {
+      const warning =
+        `Auto-scroll timed out after ${SCROLL_TIMEOUT / 1000}s. ` +
+        `Some earlier messages may be missing (${scrollResult.elementCount} turns loaded).`;
+      if (result.warnings) {
+        result.warnings.push(warning);
+      } else {
+        result.warnings = [warning];
+      }
+    }
+
+    return result;
+  } catch (error) { ... }
+}
+```
+
+**変更点**:
+1. `ensureAllMessagesLoaded()` の呼び出しを追加 (1行)
+2. `buildConversationResult()` の戻り値を変数に受ける
+3. タイムアウト時の warning 追加ロジック (7行)
+
+`buildConversationResult()` のシグネチャは変更しない。
+
+---
+
+## 10. Files Modified
+
+| File | Change | Lines (est.) |
+|------|--------|-------------|
+| `src/lib/constants.ts` | 定数 3 件追加 | +10 |
+| `src/content/extractors/gemini.ts` | `ScrollResult`, 3 private methods, `extract()` 修正 | +70 |
+| `test/fixtures/dom-helpers.ts` | テストヘルパー 2 件追加 | +30 |
+| `test/extractors/gemini.test.ts` | テストケース 7 件追加 | +150 |
+| `docs/adr/002-gemini-auto-scroll.md` | ADR (決定記録) | rewrite |
+| `docs/design/002-gemini-auto-scroll.md` | 本文書 | new |
+
+### Unchanged
+
+- `src/content/extractors/base.ts`
+- `src/lib/types.ts`
+- `src/content/index.ts`
+- 他の extractor (claude, chatgpt, perplexity)
+
+---
+
+## 11. Test Specification
+
+### 11.1 Test Environment
+
+- vitest + jsdom
+- jsdom は `scrollTop` / `scrollTo` を実装しない → `Object.defineProperty` でモック
+- 非同期ループのテストは `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync()` を使用
+
+### 11.2 Test Helpers (新規)
+
+File: `test/fixtures/dom-helpers.ts`
+
+#### `createGeminiScrollableDOM(conversationHTML: string): string`
+
+```typescript
+/**
+ * Wrap conversation HTML in Gemini's scroll container structure
+ */
+export function createGeminiScrollableDOM(conversationHTML: string): string {
+  return `
+    <div id="chat-history" class="chat-history-scroll-container">
+      <infinite-scroller class="chat-history">
+        ${conversationHTML}
+      </infinite-scroller>
+    </div>
+  `;
+}
+```
+
+#### `mockScrollContainer(scrollTop: number, onScrollTo?: () => void): void`
+
+```typescript
+/**
+ * Mock scrollTop and scrollTo on #chat-history for jsdom tests
+ * Must be called AFTER loadFixture()
+ *
+ * @param scrollTop - Initial scrollTop value (> 0 simulates partial load)
+ * @param onScrollTo - Callback fired on scrollTo (use to inject new DOM elements)
+ */
+export function mockScrollContainer(
+  scrollTop: number,
+  onScrollTo?: () => void
+): void {
+  const container = document.getElementById('chat-history');
+  if (!container) return;
+
+  let currentScrollTop = scrollTop;
+
+  Object.defineProperty(container, 'scrollTop', {
+    get: () => currentScrollTop,
+    set: (value: number) => { currentScrollTop = value; },
+    configurable: true,
+  });
+
+  container.scrollTo = (options?: ScrollToOptions) => {
+    currentScrollTop = options?.top ?? 0;
+    if (onScrollTo) onScrollTo();
+  };
+}
+```
+
+### 11.3 Test Cases
+
+| # | Name | Scenario | Assert |
+|---|------|----------|--------|
+| 1 | skip: scrollTop === 0 | Short conversation, scrollTop is 0 | No delay added. `extract()` returns same result as current. `scrollIterations === 0` |
+| 2 | skip: no scroll container | DOM has no `#chat-history` | Extraction proceeds. `skipped === true` |
+| 3 | stabilization | scrollTop=1000, `onScrollTo` adds 3 turns first 2 calls, then stops | `fullyLoaded === true`, all messages in result |
+| 4 | timeout | scrollTop=1000, `onScrollTo` adds 1 turn every call (never stabilizes) | `fullyLoaded === false`, result has timeout warning string |
+| 5 | Deep Research bypass | Deep Research panel + scrollTop > 0 | `extractDeepResearch()` called, no scroll |
+| 6 | full integration | scrollTop=500, 2 initial turns, `onScrollTo` adds 3 more turns | `result.data.messages.length === 10` (5 turns x 2) |
+| 7 | warning merge | Timeout + `buildConversationResult` generates its own warning | `result.warnings.length >= 2` |
+
+### 11.4 Timer Strategy
+
+```typescript
+describe('ensureAllMessagesLoaded', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stabilization', async () => {
+    // setup DOM with mockScrollContainer(...)
+    const extractPromise = extractor.extract();
+
+    // Advance through scroll iterations
+    await vi.advanceTimersByTimeAsync(SCROLL_POLL_INTERVAL * 5);
+
+    const result = await extractPromise;
+    expect(result.success).toBe(true);
+    // ...
+  });
+});
+```
+
+---
+
+## 12. Performance Impact
+
+| Scenario | 現行 | 変更後 |
+|----------|------|--------|
+| 短い会話 (scrollTop === 0) | ~0ms | ~0ms (scrollTop チェックのみ) |
+| 20 ターンの会話 | ~0ms (部分抽出) | ~5s (5 iterations × 1s) |
+| 100 ターンの会話 | ~0ms (部分抽出) | ~10-15s |
+| 500+ ターンの会話 | ~0ms (部分抽出) | 30s (timeout) + 部分抽出 |
+
+**短い会話への影響はゼロ。** `scrollTop === 0` のチェックは同期的で、コストは DOM 要素1個の property 読み取りのみ。

--- a/docs/workflow/002-gemini-auto-scroll.md
+++ b/docs/workflow/002-gemini-auto-scroll.md
@@ -1,0 +1,275 @@
+# WF-002: Gemini Auto-Scroll Implementation Workflow
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | WF-002 |
+| **Date** | 2026-02-20 |
+| **Issue** | [#49](https://github.com/sho7650/obsidian-AI-exporter/issues/49) |
+| **ADR** | [ADR-002](../adr/002-gemini-auto-scroll.md) |
+| **Design Spec** | [DES-002](../design/002-gemini-auto-scroll.md) |
+
+---
+
+## Dependency Graph
+
+```
+Phase 0: Branch
+    │
+    ▼
+Phase 1: Constants ─────────────────────┐
+    │                                    │
+    ▼                                    ▼
+Phase 2: GeminiExtractor          Phase 3: Test Helpers
+    │                                    │
+    └──────────┬─────────────────────────┘
+               ▼
+         Phase 4: Tests
+               │
+               ▼
+         Phase 5: Verification
+               │
+               ▼
+         Phase 6: Documentation
+```
+
+Phase 1 と Phase 3 は互いに依存しないため並行実行可能。
+Phase 4 は Phase 2 と Phase 3 の両方に依存する。
+
+---
+
+## Phase 0: Branch Creation
+
+| Step | Action | Validation |
+|------|--------|------------|
+| 0.1 | `git checkout -b feature/gemini-auto-scroll` | `git branch --show-current` → `feature/gemini-auto-scroll` |
+
+---
+
+## Phase 1: Constants
+
+**File**: `src/lib/constants.ts`
+
+| Step | Action | Detail |
+|------|--------|--------|
+| 1.1 | Existing `// Security Constants` セクションの後に新セクション追加 | DES-002 §4.2 参照 |
+| 1.2 | `SCROLL_POLL_INTERVAL = 1000` 追加 | |
+| 1.3 | `SCROLL_TIMEOUT = 30000` 追加 | |
+| 1.4 | `SCROLL_STABILITY_THRESHOLD = 3` 追加 | |
+
+**Checkpoint 1**:
+```bash
+npm run build   # TypeScript compilation: 0 errors
+npm run lint    # ESLint: 0 errors, 0 warnings
+```
+
+---
+
+## Phase 2: GeminiExtractor Implementation
+
+**File**: `src/content/extractors/gemini.ts`
+
+### Step 2.1: Import 追加
+
+```
+import 文に SCROLL_TIMEOUT, SCROLL_POLL_INTERVAL, SCROLL_STABILITY_THRESHOLD を追加
+```
+
+**依存**: Phase 1 完了
+
+### Step 2.2: SELECTORS に scrollContainer 追加
+
+```
+SELECTORS object に scrollContainer エントリーを追加 (DES-002 §4.3)
+```
+
+### Step 2.3: ScrollResult interface 追加
+
+```
+GeminiExtractor class 定義の直前に module-private interface を追加 (DES-002 §4.1)
+```
+
+### Step 2.4: delay() method 追加
+
+```
+GeminiExtractor class に private delay(ms) method を追加 (DES-002 §5.3)
+```
+
+### Step 2.5: countConversationElements() method 追加
+
+```
+GeminiExtractor class に private countConversationElements() method を追加 (DES-002 §5.2)
+```
+
+### Step 2.6: ensureAllMessagesLoaded() method 追加
+
+```
+GeminiExtractor class に private async ensureAllMessagesLoaded() を追加 (DES-002 §5.1)
+アルゴリズム: scrollTo loop → stability check → timeout
+```
+
+**これが最も複雑なステップ。DES-002 §5.1 のアルゴリズムに厳密に従うこと。**
+
+### Step 2.7: extract() method 修正
+
+```
+1. Deep Research check 後に ensureAllMessagesLoaded() 呼び出しを挿入
+2. buildConversationResult() の戻り値を変数に受ける
+3. timeout warning の追加ロジックを挿入
+(DES-002 §9 の After コード参照)
+```
+
+**Checkpoint 2**:
+```bash
+npm run build   # TypeScript compilation: 0 errors
+npm run lint    # ESLint: 0 errors, 0 warnings
+npm test        # 既存テスト全パス (scroll container がないため skip path を通る)
+```
+
+---
+
+## Phase 3: Test Helpers
+
+**File**: `test/fixtures/dom-helpers.ts`
+
+| Step | Action | Detail |
+|------|--------|--------|
+| 3.1 | `createGeminiScrollableDOM()` 関数追加 | DES-002 §11.2 参照 |
+| 3.2 | `mockScrollContainer()` 関数追加 | DES-002 §11.2 参照 |
+| 3.3 | 両関数を export に追加 | 既存の export パターンに合わせる |
+
+**Checkpoint 3**:
+```bash
+npm run build   # TypeScript compilation: 0 errors
+```
+
+---
+
+## Phase 4: Tests
+
+**File**: `test/extractors/gemini.test.ts`
+
+**依存**: Phase 2 + Phase 3 完了
+
+### Step 4.1: Import 追加
+
+```
+- createGeminiScrollableDOM, mockScrollContainer を dom-helpers から import
+- SCROLL_POLL_INTERVAL, SCROLL_TIMEOUT を constants から import
+```
+
+### Step 4.2: describe('ensureAllMessagesLoaded') ブロック追加
+
+既存の `describe('extract')` ブロックの後に追加。
+
+### Step 4.3: Test Case 1 — skip: scrollTop === 0
+
+```
+Setup: createGeminiScrollableDOM + mockScrollContainer(0)
+Assert: extract() 成功、warning なし、遅延なし
+```
+
+### Step 4.4: Test Case 2 — skip: no scroll container
+
+```
+Setup: createGeminiConversationDOM のみ (#chat-history なし)
+Assert: extract() 成功 (既存動作と同じ)
+```
+
+### Step 4.5: Test Case 3 — stabilization
+
+```
+Setup: mockScrollContainer(1000, onScrollTo)
+  onScrollTo: 最初の 2 回は turn を追加、以降は何もしない
+Timer: vi.useFakeTimers() + vi.advanceTimersByTimeAsync()
+Assert: fullyLoaded = true, 全メッセージ抽出
+```
+
+### Step 4.6: Test Case 4 — timeout
+
+```
+Setup: mockScrollContainer(1000, onScrollTo)
+  onScrollTo: 毎回 1 turn 追加 (安定しない)
+Timer: SCROLL_TIMEOUT まで advance
+Assert: result.warnings に timeout メッセージが含まれる
+```
+
+### Step 4.7: Test Case 5 — Deep Research bypass
+
+```
+Setup: Deep Research panel + scrollContainer(scrollTop > 0)
+Assert: extractDeepResearch() の結果が返る、scroll 未実行
+```
+
+### Step 4.8: Test Case 6 — full integration
+
+```
+Setup: 2 initial turns + mockScrollContainer(500, adds 3 more turns)
+Assert: result.data.messages.length === 10 (5 turns × 2 messages)
+```
+
+### Step 4.9: Test Case 7 — warning merge
+
+```
+Setup: timeout 発生 + buildConversationResult が独自 warning を生成する条件
+Assert: result.warnings.length >= 2
+```
+
+**Checkpoint 4**:
+```bash
+npm test        # 全テストパス (既存 + 新規 7 件)
+```
+
+---
+
+## Phase 5: Full Verification
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 5.1 | `npm run lint` | 0 errors, 0 warnings |
+| 5.2 | `npm run build` | TypeScript + Vite build: 0 errors |
+| 5.3 | `npm test` | 全テストパス |
+| 5.4 | `npm test -- --coverage` | Coverage thresholds met (85% stmts, 75% branch) |
+
+全ステップがパスすれば実装完了。
+
+---
+
+## Phase 6: Documentation Update
+
+| Step | Action | File |
+|------|--------|------|
+| 6.1 | ADR status を `Proposed` → `Accepted` に更新 | `docs/adr/002-gemini-auto-scroll.md` |
+| 6.2 | Design spec status を `Draft` → `Final` に更新 | `docs/design/002-gemini-auto-scroll.md` |
+| 6.3 | Commit hash を ADR に記載 | `docs/adr/002-gemini-auto-scroll.md` |
+
+---
+
+## Checklist Summary
+
+```
+[ ] Phase 0: Branch created
+[ ] Phase 1: Constants added
+    [ ] Checkpoint 1: build + lint pass
+[ ] Phase 2: GeminiExtractor modified
+    [ ] 2.1 Imports
+    [ ] 2.2 SELECTORS.scrollContainer
+    [ ] 2.3 ScrollResult interface
+    [ ] 2.4 delay()
+    [ ] 2.5 countConversationElements()
+    [ ] 2.6 ensureAllMessagesLoaded()
+    [ ] 2.7 extract() modified
+    [ ] Checkpoint 2: build + lint + existing tests pass
+[ ] Phase 3: Test helpers added
+    [ ] 3.1 createGeminiScrollableDOM()
+    [ ] 3.2 mockScrollContainer()
+    [ ] Checkpoint 3: build pass
+[ ] Phase 4: Tests added
+    [ ] 4.3-4.9 Test cases 1-7
+    [ ] Checkpoint 4: all tests pass
+[ ] Phase 5: Full verification
+    [ ] 5.1 lint
+    [ ] 5.2 build
+    [ ] 5.3 test
+    [ ] 5.4 coverage
+[ ] Phase 6: Documentation updated
+```

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -57,10 +57,7 @@ const SELECTORS = {
   // scrollable element (overflow-y: scroll). It fires onScrolledTopPastThreshold
   // when scrollTop crosses below a threshold (edge-triggered).
   // #chat-history is a non-scrolling wrapper — excluded to avoid false matches.
-  scrollContainer: [
-    '[data-test-id="chat-history-container"]',
-    'infinite-scroller',
-  ],
+  scrollContainer: ['[data-test-id="chat-history-container"]', 'infinite-scroller'],
 };
 
 /**
@@ -263,9 +260,7 @@ export class GeminiExtractor extends BaseExtractor {
    * Count .conversation-container elements currently in the DOM
    */
   private countConversationElements(): number {
-    return document.querySelectorAll(
-      SELECTORS.conversationTurn.join(',')
-    ).length;
+    return document.querySelectorAll(SELECTORS.conversationTurn.join(',')).length;
   }
 
   /**
@@ -299,14 +294,14 @@ export class GeminiExtractor extends BaseExtractor {
     if (container.scrollTop === 0) {
       console.info(
         `[G2O] scrollTop=0, scrollHeight=${container.scrollHeight}, ` +
-        `clientHeight=${container.clientHeight}, elements=${initialCount}`
+          `clientHeight=${container.clientHeight}, elements=${initialCount}`
       );
       return { fullyLoaded: true, elementCount: initialCount, scrollIterations: 0, skipped: true };
     }
 
     console.info(
       `[G2O] Partial load detected — scrollTop=${container.scrollTop}, ` +
-      `elements=${initialCount}, auto-scrolling`
+        `elements=${initialCount}, auto-scrolling`
     );
 
     let previousCount = 0;
@@ -331,7 +326,7 @@ export class GeminiExtractor extends BaseExtractor {
 
       console.debug(
         `[G2O] Scroll iteration ${iterations}: elements=${currentCount}, ` +
-        `scrollTop=${container.scrollTop}, scrollHeight=${container.scrollHeight}`
+          `scrollTop=${container.scrollTop}, scrollHeight=${container.scrollHeight}`
       );
 
       if (currentCount === previousCount) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -304,6 +304,7 @@ async function handleSync(): Promise<void> {
     }
 
     showToast('Extracting conversation...', 'info', INFO_TOAST_DURATION);
+    applyExtractorSettings(extractor, settings);
     const result = await extractor.extract();
 
     // Validate extraction
@@ -343,6 +344,18 @@ async function handleSync(): Promise<void> {
     showErrorToast(extractErrorMessage(error));
   } finally {
     setButtonLoading(false);
+  }
+}
+
+/**
+ * Apply user settings to extractor before extraction
+ */
+function applyExtractorSettings(
+  extractor: IConversationExtractor,
+  settings: ExtensionSettings
+): void {
+  if (extractor instanceof GeminiExtractor) {
+    extractor.enableAutoScroll = settings.enableAutoScroll ?? false;
   }
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -114,3 +114,19 @@ export const VALID_OUTPUT_DESTINATIONS = ['obsidian', 'file', 'clipboard'] as co
  * Valid AI platform sources
  */
 export const VALID_SOURCES = ['gemini', 'claude', 'perplexity', 'chatgpt'] as const;
+
+// ============================================================
+// Auto-Scroll Configuration (Gemini)
+// ============================================================
+
+/** Interval between scroll-to-top attempts (milliseconds) */
+export const SCROLL_POLL_INTERVAL = 1000;
+
+/** Maximum time to wait for all messages to load (milliseconds) */
+export const SCROLL_TIMEOUT = 30000;
+
+/** Number of consecutive unchanged element counts to consider loading complete */
+export const SCROLL_STABILITY_THRESHOLD = 3;
+
+/** Brief pause after re-arm scroll to bottom before scrolling back to top (milliseconds) */
+export const SCROLL_REARM_DELAY = 200;

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -42,6 +42,7 @@ const DEFAULT_SYNC_SETTINGS: SyncSettings = {
   vaultPath: 'AI/Gemini',
   templateOptions: DEFAULT_TEMPLATE_OPTIONS,
   outputOptions: DEFAULT_OUTPUT_OPTIONS,
+  enableAutoScroll: false,
 };
 
 const DEFAULT_SETTINGS: ExtensionSettings = {
@@ -75,6 +76,8 @@ export async function getSettings(): Promise<ExtensionSettings> {
         ...DEFAULT_OUTPUT_OPTIONS,
         ...syncResult.settings?.outputOptions,
       },
+      enableAutoScroll:
+        syncResult.settings?.enableAutoScroll ?? DEFAULT_SYNC_SETTINGS.enableAutoScroll,
     };
   } catch (error) {
     console.error('[G2O] Failed to get settings:', error);
@@ -118,6 +121,9 @@ export async function saveSettings(settings: Partial<ExtensionSettings>): Promis
         ...current.outputOptions,
         ...settings.outputOptions,
       };
+    }
+    if (settings.enableAutoScroll !== undefined) {
+      syncData.enableAutoScroll = settings.enableAutoScroll;
     }
 
     if (Object.keys(syncData).length > 0) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -161,6 +161,8 @@ export interface SyncSettings {
   vaultPath: string;
   templateOptions: TemplateOptions;
   outputOptions: OutputOptions;
+  /** Enable auto-scroll to load all messages in long conversations (e.g. Gemini) */
+  enableAutoScroll: boolean;
 }
 
 /**

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -103,6 +103,19 @@
         </section>
 
         <section class="section">
+          <h2 data-i18n="settings_extraction">Extraction</h2>
+          <div class="checkbox-grid">
+            <label class="checkbox-label">
+              <input type="checkbox" id="enableAutoScroll" />
+              <span data-i18n="settings_enableAutoScroll">Auto-scroll (load all messages)</span>
+            </label>
+          </div>
+          <p class="help" data-i18n="settings_autoScrollHelp">
+            Automatically scroll to load all messages in long conversations (e.g. Gemini)
+          </p>
+        </section>
+
+        <section class="section">
           <h2 data-i18n="settings_frontmatter">Frontmatter Fields</h2>
           <div class="checkbox-grid">
             <label class="checkbox-label">

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -76,6 +76,7 @@ const elements = {
   includeSource: getElement<HTMLInputElement>('includeSource'),
   includeDates: getElement<HTMLInputElement>('includeDates'),
   includeMessageCount: getElement<HTMLInputElement>('includeMessageCount'),
+  enableAutoScroll: getElement<HTMLInputElement>('enableAutoScroll'),
   testBtn: getElement<HTMLButtonElement>('testBtn'),
   saveBtn: getElement<HTMLButtonElement>('saveBtn'),
   status: getElement<HTMLDivElement>('status'),
@@ -105,6 +106,9 @@ function populateForm(settings: ExtensionSettings): void {
   elements.outputObsidian.checked = outputOptions?.obsidian ?? true;
   elements.outputFile.checked = outputOptions?.file ?? false;
   elements.outputClipboard.checked = outputOptions?.clipboard ?? false;
+
+  // Extraction options
+  elements.enableAutoScroll.checked = settings.enableAutoScroll ?? false;
 
   // Update Obsidian settings section visibility
   updateObsidianSettingsVisibility();
@@ -248,6 +252,7 @@ function collectSettings(): ExtensionSettings {
     vaultPath: elements.vaultPath.value.trim(),
     templateOptions,
     outputOptions,
+    enableAutoScroll: elements.enableAutoScroll.checked,
   };
 }
 


### PR DESCRIPTION
## Summary

- Add auto-scroll mechanism in `GeminiExtractor` to load all messages in long Gemini conversations via backward infinite scroll (issue #49)
- Detect partial load via `scrollTop > 0` on `infinite-scroller` element; repeatedly scroll to top with edge-trigger re-arm to load older messages
- DOM stabilization: 3 consecutive unchanged `.conversation-container` counts = done; 30s timeout with warning
- Add `enableAutoScroll` boolean setting to `SyncSettings` (default: OFF) with popup UI checkbox in new "Extraction" section
- Pass setting from content script to `GeminiExtractor` via `applyExtractorSettings()` — no interface changes to `IConversationExtractor`
- Add auto-scroll constants to `src/lib/constants.ts` (`SCROLL_POLL_INTERVAL`, `SCROLL_TIMEOUT`, `SCROLL_STABILITY_THRESHOLD`, `SCROLL_REARM_DELAY`)
- Add ADR-002, design spec DES-002, and workflow WF-002 documentation
- Add 8 new test cases covering: setting disabled, scrollTop=0 skip, no container skip, stabilization, timeout, Deep Research bypass, integration, warning merge

## Test plan

- [x] `npm run build` succeeds (0 TypeScript errors)
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npm test` passes (596 tests, all green)
- [x] Manual test: load extension in Chrome, verify "Auto-scroll" checkbox appears in popup settings
- [x] Manual test: enable auto-scroll, open a long Gemini conversation, verify all messages are extracted
- [x] Manual test: with auto-scroll OFF, verify extraction works as before (only DOM-present messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)