### PR TITLE
fix: improve Gemini title extraction with top bar selector

### DIFF
--- a/test/extractors/base.test.ts
+++ b/test/extractors/base.test.ts
@@ -52,6 +52,10 @@ class TestExtractor extends BaseExtractor {
   public testGenerateHashValue(content: string): string {
     return this.generateHashValue(content);
   }
+
+  public testGetPageTitle(): string | null {
+    return this.getPageTitle();
+  }
 }
 
 describe('BaseExtractor', () => {
@@ -326,6 +330,55 @@ describe('BaseExtractor', () => {
       expect(Array.from(results).every((el) => el.classList.contains('first'))).toBe(
         true
       );
+    });
+  });
+
+  describe('getPageTitle', () => {
+    it('strips " - Claude" suffix', () => {
+      document.title = 'Test Topic - Claude';
+      expect(extractor.testGetPageTitle()).toBe('Test Topic');
+    });
+
+    it('strips " - ChatGPT" suffix', () => {
+      document.title = 'Test Topic - ChatGPT';
+      expect(extractor.testGetPageTitle()).toBe('Test Topic');
+    });
+
+    it('strips " - Perplexity" suffix', () => {
+      document.title = 'Test Topic - Perplexity';
+      expect(extractor.testGetPageTitle()).toBe('Test Topic');
+    });
+
+    it('strips " - Google Gemini" suffix', () => {
+      document.title = 'Test Topic - Google Gemini';
+      expect(extractor.testGetPageTitle()).toBe('Test Topic');
+    });
+
+    it('strips " | Gemini" suffix', () => {
+      document.title = 'Test Topic | Gemini';
+      expect(extractor.testGetPageTitle()).toBe('Test Topic');
+    });
+
+    it('returns raw title when no known suffix', () => {
+      document.title = 'Some Conversation Title';
+      expect(extractor.testGetPageTitle()).toBe('Some Conversation Title');
+    });
+
+    it('returns null when title is only a platform name', () => {
+      for (const name of ['Gemini', 'Google Gemini', 'Claude', 'ChatGPT', 'Perplexity']) {
+        document.title = name;
+        expect(extractor.testGetPageTitle()).toBeNull();
+      }
+    });
+
+    it('returns null for empty title', () => {
+      document.title = '';
+      expect(extractor.testGetPageTitle()).toBeNull();
+    });
+
+    it('truncates to MAX_CONVERSATION_TITLE_LENGTH', () => {
+      document.title = 'a'.repeat(200);
+      expect(extractor.testGetPageTitle()!.length).toBe(100);
     });
   });
 

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -115,6 +115,48 @@ describe('GeminiExtractor', () => {
       `);
       expect(extractor.getTitle()).toBe('Multiple spaces');
     });
+
+    it('extracts title from document.title with " - Google Gemini" suffix', () => {
+      setGeminiLocation('test123');
+      document.title = 'Test Chat - Google Gemini';
+      loadFixture('<div>Empty page</div>');
+      expect(extractor.getTitle()).toBe('Test Chat');
+    });
+
+    it('extracts title from document.title with " | Gemini" suffix', () => {
+      setGeminiLocation('test123');
+      document.title = 'Test Chat | Gemini';
+      loadFixture('<div>Empty page</div>');
+      expect(extractor.getTitle()).toBe('Test Chat');
+    });
+
+    it('skips document.title when it is just "Gemini"', () => {
+      setGeminiLocation('test123');
+      document.title = 'Gemini';
+      loadFixture(`
+        <p class="query-text-line">Query text fallback</p>
+      `);
+      expect(extractor.getTitle()).toBe('Query text fallback');
+    });
+
+    it('skips empty document.title', () => {
+      setGeminiLocation('test123');
+      document.title = '';
+      loadFixture(`
+        <p class="query-text-line">Query text fallback</p>
+      `);
+      expect(extractor.getTitle()).toBe('Query text fallback');
+    });
+
+    it('document.title takes priority over DOM selectors', () => {
+      setGeminiLocation('test123');
+      document.title = 'Page Title - Google Gemini';
+      loadFixture(`
+        <p class="query-text-line">Query text</p>
+        <div class="conversation-title">Sidebar Title</div>
+      `);
+      expect(extractor.getTitle()).toBe('Page Title');
+    });
   });
 
   describe('extractMessages', () => {

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -116,46 +116,46 @@ describe('GeminiExtractor', () => {
       expect(extractor.getTitle()).toBe('Multiple spaces');
     });
 
-    it('extracts title from document.title with " - Google Gemini" suffix', () => {
+    it('extracts title from data-test-id="conversation-title" element', () => {
       setGeminiLocation('test123');
-      document.title = 'Test Chat - Google Gemini';
-      loadFixture('<div>Empty page</div>');
-      expect(extractor.getTitle()).toBe('Test Chat');
-    });
-
-    it('extracts title from document.title with " | Gemini" suffix', () => {
-      setGeminiLocation('test123');
-      document.title = 'Test Chat | Gemini';
-      loadFixture('<div>Empty page</div>');
-      expect(extractor.getTitle()).toBe('Test Chat');
-    });
-
-    it('skips document.title when it is just "Gemini"', () => {
-      setGeminiLocation('test123');
-      document.title = 'Gemini';
       loadFixture(`
-        <p class="query-text-line">Query text fallback</p>
+        <span data-test-id="conversation-title" class="gds-title-m">Top Bar Title</span>
       `);
-      expect(extractor.getTitle()).toBe('Query text fallback');
+      expect(extractor.getTitle()).toBe('Top Bar Title');
     });
 
-    it('skips empty document.title', () => {
+    it('data-test-id="conversation-title" takes priority over query text', () => {
       setGeminiLocation('test123');
-      document.title = '';
       loadFixture(`
-        <p class="query-text-line">Query text fallback</p>
-      `);
-      expect(extractor.getTitle()).toBe('Query text fallback');
-    });
-
-    it('document.title takes priority over DOM selectors', () => {
-      setGeminiLocation('test123');
-      document.title = 'Page Title - Google Gemini';
-      loadFixture(`
+        <span data-test-id="conversation-title" class="gds-title-m">Top Bar Title</span>
         <p class="query-text-line">Query text</p>
-        <div class="conversation-title">Sidebar Title</div>
       `);
-      expect(extractor.getTitle()).toBe('Page Title');
+      expect(extractor.getTitle()).toBe('Top Bar Title');
+    });
+
+    it('falls back to query text when conversation-title is empty', () => {
+      setGeminiLocation('test123');
+      loadFixture(`
+        <span data-test-id="conversation-title" class="gds-title-m">   </span>
+        <p class="query-text-line">Query text fallback</p>
+      `);
+      expect(extractor.getTitle()).toBe('Query text fallback');
+    });
+
+    it('falls back to query text when no conversation-title element', () => {
+      setGeminiLocation('test123');
+      loadFixture(`
+        <p class="query-text-line">Query text fallback</p>
+      `);
+      expect(extractor.getTitle()).toBe('Query text fallback');
+    });
+
+    it('sanitizes whitespace in top bar title', () => {
+      setGeminiLocation('test123');
+      loadFixture(`
+        <span data-test-id="conversation-title" class="gds-title-m">  Spaced   Title  </span>
+      `);
+      expect(extractor.getTitle()).toBe('Spaced Title');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `[data-test-id="conversation-title"]` as highest-priority selector for Gemini title extraction (stable attribute, not affected by class name changes)
- Add `getPageTitle()` helper to `BaseExtractor` for `document.title`-based extraction (for Claude, ChatGPT, Perplexity where it contains the conversation title)
- Gemini's `document.title` is always "Google Gemini" so it uses DOM selectors instead

Closes #47

## Test plan

- [x] 611 tests pass (`npx vitest run`)
- [x] Build clean (`npm run build`)
- [x] Lint/format clean (`npm run lint && npm run format`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)