### PR TITLE
feat: support {platform} template variable in vault path

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -38,8 +38,12 @@
     "description": "Label for vault path input"
   },
   "settings_vaultPathPlaceholder": {
-    "message": "e.g., AI/Gemini",
+    "message": "e.g., AI/{platform}",
     "description": "Placeholder for vault path input"
+  },
+  "settings_vaultPathHelp": {
+    "message": "Use {platform} to auto-organize by source (gemini, claude, chatgpt, perplexity)",
+    "description": "Help text explaining template variable for vault path"
   },
   "settings_messageFormat": {
     "message": "Message Format",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -29,7 +29,10 @@
     "message": "保存先パス"
   },
   "settings_vaultPathPlaceholder": {
-    "message": "例: AI/Gemini"
+    "message": "例: AI/{platform}"
+  },
+  "settings_vaultPathHelp": {
+    "message": "{platform} でプラットフォームごとにフォルダ分類（gemini, claude, chatgpt, perplexity）"
   },
   "settings_messageFormat": {
     "message": "メッセージ形式"

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,6 +7,7 @@ import { ObsidianApiClient } from '../lib/obsidian-api';
 import { extractErrorMessage, getErrorMessage } from '../lib/error-utils';
 import { getSettings, migrateSettings } from '../lib/storage';
 import { generateNoteContent } from '../lib/note-generator';
+import { resolvePathTemplate } from '../lib/path-utils';
 import {
   MAX_CONTENT_SIZE,
   MAX_FILENAME_LENGTH,
@@ -224,8 +225,11 @@ async function handleSave(settings: ExtensionSettings, note: ObsidianNote): Prom
   const client = new ObsidianApiClient(settings.obsidianPort, settings.obsidianApiKey);
 
   try {
-    // Construct full path
-    const fullPath = settings.vaultPath ? `${settings.vaultPath}/${note.fileName}` : note.fileName;
+    // Resolve template variables (e.g., {platform} → gemini) and construct full path
+    const resolvedPath = resolvePathTemplate(settings.vaultPath, {
+      platform: note.frontmatter.source,
+    });
+    const fullPath = resolvedPath ? `${resolvedPath}/${note.fileName}` : note.fileName;
 
     // Check if file exists for append mode detection
     const existingContent = await client.getFile(fullPath);

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -24,6 +24,21 @@ export function containsPathTraversal(path: string): boolean {
 }
 
 /**
+ * Resolve template variables in a vault path
+ * Supported variables: {platform}
+ * Unknown variables are preserved as-is (safe fallback)
+ *
+ * @example
+ * resolvePathTemplate('AI/{platform}', { platform: 'gemini' })
+ * // → 'AI/gemini'
+ */
+export function resolvePathTemplate(path: string, variables: Record<string, string>): string {
+  return path.replace(/\{(\w+)\}/g, (match, key: string) => {
+    return key in variables ? variables[key] : match;
+  });
+}
+
+/**
  * Normalize and validate a path
  */
 export function validatePath(path: string, fieldName: string): string {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -39,7 +39,7 @@ const DEFAULT_SECURE_SETTINGS: SecureSettings = {
 
 const DEFAULT_SYNC_SETTINGS: SyncSettings = {
   obsidianPort: DEFAULT_OBSIDIAN_PORT,
-  vaultPath: 'AI/Gemini',
+  vaultPath: 'AI/{platform}',
   templateOptions: DEFAULT_TEMPLATE_OPTIONS,
   outputOptions: DEFAULT_OUTPUT_OPTIONS,
   enableAutoScroll: false,

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -68,8 +68,11 @@
                 type="text"
                 id="vaultPath"
                 data-i18n-placeholder="settings_vaultPathPlaceholder"
-                placeholder="AI/Gemini"
+                placeholder="AI/{platform}"
               />
+              <p class="help" data-i18n="settings_vaultPathHelp">
+                Use {platform} to auto-organize by source (gemini, claude, chatgpt, perplexity)
+              </p>
             </div>
           </div>
         </section>

--- a/test/lib/path-utils.test.ts
+++ b/test/lib/path-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { containsPathTraversal, validatePath } from '../../src/lib/path-utils';
+import { containsPathTraversal, validatePath, resolvePathTemplate } from '../../src/lib/path-utils';
 
 describe('containsPathTraversal', () => {
   it('detects ../ patterns', () => {
@@ -41,6 +41,42 @@ describe('containsPathTraversal', () => {
     expect(containsPathTraversal('.')).toBe(false);
     expect(containsPathTraversal('..')).toBe(true);
     expect(containsPathTraversal('...')).toBe(false);
+  });
+});
+
+describe('resolvePathTemplate', () => {
+  it('resolves {platform} variable', () => {
+    expect(resolvePathTemplate('AI/{platform}', { platform: 'gemini' }))
+      .toBe('AI/gemini');
+  });
+
+  it('resolves multiple variables', () => {
+    expect(resolvePathTemplate('{type}/{platform}', {
+      platform: 'claude',
+      type: 'conversation',
+    })).toBe('conversation/claude');
+  });
+
+  it('preserves unknown variables', () => {
+    expect(resolvePathTemplate('AI/{unknown}', { platform: 'gemini' }))
+      .toBe('AI/{unknown}');
+  });
+
+  it('returns path unchanged when no variables present', () => {
+    expect(resolvePathTemplate('AI/Gemini', { platform: 'gemini' }))
+      .toBe('AI/Gemini');
+  });
+
+  it('handles empty path', () => {
+    expect(resolvePathTemplate('', { platform: 'gemini' }))
+      .toBe('');
+  });
+
+  it('resolves all supported platforms', () => {
+    for (const p of ['gemini', 'claude', 'chatgpt', 'perplexity']) {
+      expect(resolvePathTemplate('AI/{platform}', { platform: p }))
+        .toBe(`AI/${p}`);
+    }
   });
 });
 

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -51,7 +51,7 @@ describe('storage', () => {
 
       expect(settings.obsidianApiKey).toBe('');
       expect(settings.obsidianPort).toBe(27123);
-      expect(settings.vaultPath).toBe('AI/Gemini');
+      expect(settings.vaultPath).toBe('AI/{platform}');
       expect(settings.templateOptions.messageFormat).toBe('callout');
     });
 


### PR DESCRIPTION
## Summary

- Add `resolvePathTemplate()` function to resolve `{platform}` in vault path
- Default vault path changed from `AI/Gemini` to `AI/{platform}` for multi-platform auto-organization
- Background worker resolves template using `note.frontmatter.source` (gemini, claude, chatgpt, perplexity)
- Add help text and updated placeholder in popup UI
- Add i18n keys for en/ja

Closes #46

## Test plan

- [x] 616 tests pass (`npx vitest run`)
- [x] Build clean (`npm run build`)
- [x] Lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)