### PR TITLE
refactor: reduce extractor code complexity and redundancy

### DIFF
--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -8,9 +8,8 @@
  */
 
 import { BaseExtractor } from './base';
-import { extractErrorMessage } from '../../lib/error-utils';
 import { sanitizeHtml } from '../../lib/sanitize';
-import type { ConversationMessage, ExtractionResult } from '../../lib/types';
+import type { ConversationMessage } from '../../lib/types';
 import { MAX_CONVERSATION_TITLE_LENGTH } from '../../lib/constants';
 
 /**
@@ -224,37 +223,5 @@ export class ChatGPTExtractor extends BaseExtractor {
     return html
       .replace(/href="([^"]+)\?utm_source=chatgpt\.com"/g, (_, url) => `href="${url}"`)
       .replace(/href="([^"]+)&utm_source=chatgpt\.com"/g, (_, url) => `href="${url}"`);
-  }
-
-  // ========== Main Entry Point ==========
-
-  /**
-   * Main extraction method
-   *
-   * Extracts normal conversation
-   * (Deep Research is treated as normal conversation)
-   */
-  async extract(): Promise<ExtractionResult> {
-    try {
-      if (!this.canExtract()) {
-        return {
-          success: false,
-          error: 'Not on a ChatGPT page',
-        };
-      }
-
-      console.info('[G2O] Extracting ChatGPT conversation');
-      const messages = this.extractMessages();
-      const conversationId = this.getConversationId() || `chatgpt-${Date.now()}`;
-      const title = this.getTitle();
-
-      return this.buildConversationResult(messages, conversationId, title, 'chatgpt');
-    } catch (error) {
-      console.error('[G2O] ChatGPT extraction error:', error);
-      return {
-        success: false,
-        error: extractErrorMessage(error),
-      };
-    }
   }
 }

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -8,9 +8,8 @@
  */
 
 import { BaseExtractor } from './base';
-import { extractErrorMessage } from '../../lib/error-utils';
 import { sanitizeHtml } from '../../lib/sanitize';
-import type { ConversationMessage, ExtractionResult } from '../../lib/types';
+import type { ConversationMessage } from '../../lib/types';
 import { MAX_CONVERSATION_TITLE_LENGTH } from '../../lib/constants';
 
 /**
@@ -177,37 +176,5 @@ export class PerplexityExtractor extends BaseExtractor {
     }
 
     return '';
-  }
-
-  // ========== Main Entry Point ==========
-
-  /**
-   * Main extraction method
-   *
-   * Extracts normal conversation
-   * (Deep Research is treated as normal conversation)
-   */
-  async extract(): Promise<ExtractionResult> {
-    try {
-      if (!this.canExtract()) {
-        return {
-          success: false,
-          error: 'Not on a Perplexity page',
-        };
-      }
-
-      console.info('[G2O] Extracting Perplexity conversation');
-      const messages = this.extractMessages();
-      const conversationId = this.getConversationId() || `perplexity-${Date.now()}`;
-      const title = this.getTitle();
-
-      return this.buildConversationResult(messages, conversationId, title, 'perplexity');
-    } catch (error) {
-      console.error('[G2O] Perplexity extraction error:', error);
-      return {
-        success: false,
-        error: extractErrorMessage(error),
-      };
-    }
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,11 @@
  */
 
 /**
+ * Supported AI platform identifiers
+ */
+export type AIPlatform = 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+
+/**
  * Represents a single message in a conversation
  */
 export interface ConversationMessage {
@@ -27,7 +32,7 @@ export interface ConversationData {
   id: string;
   title: string;
   url: string;
-  source: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+  source: AIPlatform;
   type?: 'conversation' | 'deep-research';
   /** Deep Research link information (optional) */
   links?: DeepResearchLinks;
@@ -245,7 +250,7 @@ export interface ValidationResult {
  * Interface for AI platform extractors
  */
 export interface IConversationExtractor {
-  readonly platform: 'gemini' | 'claude' | 'perplexity' | 'chatgpt';
+  readonly platform: AIPlatform;
   canExtract(): boolean;
   extract(): Promise<ExtractionResult>;
   getConversationId(): string | null;

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -481,7 +481,7 @@ describe('background/index', () => {
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       expect(sendResponse).toHaveBeenCalledWith({
         success: false,
-        error: 'API key not configured. Please check settings.',
+        error: 'API key not configured',
       });
     });
   });

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -351,7 +351,7 @@ describe('GeminiExtractor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('DOM parsing failed');
-      expect(consoleSpy).toHaveBeenCalledWith('[G2O] Extraction error:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith('[G2O] Gemini extraction error:', expect.any(Error));
 
       consoleSpy.mockRestore();
     });
@@ -424,12 +424,12 @@ describe('GeminiExtractor', () => {
       });
     });
 
-    describe('extractDeepResearch', () => {
-      it('returns successful result with report data', () => {
+    describe('extractDeepResearch (via extract)', () => {
+      it('returns successful result with report data', async () => {
         setGeminiLocation('test123');
         loadFixture(createDeepResearchDOM('Test Report', '<h1>Title</h1><p>Content</p>'));
 
-        const result = extractor.extractDeepResearch();
+        const result = await extractor.extract();
 
         expect(result.success).toBe(true);
         expect(result.data?.type).toBe('deep-research');
@@ -439,24 +439,24 @@ describe('GeminiExtractor', () => {
         expect(result.data?.messages[0].role).toBe('assistant');
       });
 
-      it('returns error when content is empty', () => {
+      it('returns error when content is empty', async () => {
         setGeminiLocation('test123');
         loadFixture(createEmptyDeepResearchPanel());
 
-        const result = extractor.extractDeepResearch();
+        const result = await extractor.extract();
 
         expect(result.success).toBe(false);
         expect(result.error).toContain('content not found');
       });
 
-      it('generates consistent ID from title for overwrite', () => {
+      it('generates consistent ID from title for overwrite', async () => {
         setGeminiLocation('test123');
         loadFixture(createDeepResearchDOM('Same Title', '<p>Content 1</p>'));
-        const result1 = extractor.extractDeepResearch();
+        const result1 = await extractor.extract();
 
         clearFixture();
         loadFixture(createDeepResearchDOM('Same Title', '<p>Content 2</p>'));
-        const result2 = extractor.extractDeepResearch();
+        const result2 = await extractor.extract();
 
         expect(result1.data?.id).toBe(result2.data?.id);
       });
@@ -571,24 +571,24 @@ describe('GeminiExtractor', () => {
         });
       });
 
-      describe('extractDeepResearch with links', () => {
-        it('includes links in extraction result', () => {
+      describe('extractDeepResearch with links (via extract)', () => {
+        it('includes links in extraction result', async () => {
           setGeminiLocation('test123');
           const content = `<p>Content${createInlineCitation(0)}</p>`;
           loadFixture(createDeepResearchDOMWithLinks('Test Report', content, sampleSources));
 
-          const result = extractor.extractDeepResearch();
+          const result = await extractor.extract();
 
           expect(result.success).toBe(true);
           expect(result.data?.links).toBeDefined();
           expect(result.data?.links?.sources).toHaveLength(3);
         });
 
-        it('handles missing links gracefully', () => {
+        it('handles missing links gracefully', async () => {
           setGeminiLocation('test123');
           loadFixture(createDeepResearchDOM('Test', '<p>No links</p>'));
 
-          const result = extractor.extractDeepResearch();
+          const result = await extractor.extract();
 
           expect(result.success).toBe(true);
           expect(result.data?.links).toBeDefined();


### PR DESCRIPTION
## Summary

- Extract `AIPlatform` type alias replacing 3 inline union types in `types.ts`
- Add template method `extract()` with hooks (`tryExtractDeepResearch`, `onBeforeExtract`, `onAfterExtract`) to `BaseExtractor`, eliminating ~200 lines of duplicated extract/deep-research logic across 4 subclasses
- Add shared `buildDeepResearchResult()`, `sortByDomPosition()`, and `buildMessagesFromElements()` utilities to `BaseExtractor`
- Simplify all 4 extractor subclasses (ChatGPT, Perplexity, Claude, Gemini) by removing duplicated `extract()` and `extractDeepResearch()` methods
- Extract `createCitationReplacer()` factory in `markdown.ts` to deduplicate citation callback
- Consolidate 3 duplicated API key guards in `background/index.ts` with `createObsidianClient()` helper
- Fix bug: Claude `getDeepResearchTitle()` was using `MAX_CONVERSATION_TITLE_LENGTH` (100) instead of `MAX_DEEP_RESEARCH_TITLE_LENGTH` (200)
- Add 9 new tests for template method, hooks, `sortByDomPosition`, and `buildMessagesFromElements`

**Net result:** 11 files changed, 554 insertions, 401 deletions. ~200 lines of cross-file duplication eliminated. 625 tests pass (was 616).

## Test plan

- [x] `npm run build` succeeds (0 TypeScript errors)
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npx vitest --run` passes (625/625 tests)
- [x] `npm run format` clean
- [x] Manual test: verify Gemini conversation extraction
- [x] Manual test: verify Claude Deep Research extraction
- [x] Manual test: verify ChatGPT conversation extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)