### PR TITLE
fix: preserve Gemini KaTeX math blocks as LaTeX in Obsidian output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ data/
 .serena/
 .claude/settings.local.json
 
+# Claude Code session files
+tasks/
+
 # Dependencies
 node_modules/
 

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -234,6 +234,34 @@ turndown.addRule('footnoteRef', {
   },
 });
 
+// Custom rule for display math blocks (Gemini KaTeX: <div data-math="...">)
+turndown.addRule('mathBlock', {
+  filter: node => {
+    return node.nodeName === 'DIV' && (node as HTMLElement).hasAttribute('data-math');
+  },
+  replacement: (_content, node) => {
+    const latex = (node as HTMLElement).getAttribute('data-math');
+    if (!latex) return _content;
+    return `\n$$\n${latex}\n$$\n`;
+  },
+});
+
+// Custom rule for inline math (Gemini KaTeX: <span data-math="...">)
+turndown.addRule('mathInline', {
+  filter: node => {
+    return (
+      node.nodeName === 'SPAN' &&
+      (node as HTMLElement).hasAttribute('data-math') &&
+      !(node as HTMLElement).hasAttribute('data-footnote-ref')
+    );
+  },
+  replacement: (_content, node) => {
+    const latex = (node as HTMLElement).getAttribute('data-math');
+    if (!latex) return _content;
+    return `$${latex}$`;
+  },
+});
+
 // Custom rule for tables
 turndown.addRule('tables', {
   filter: 'table',

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -17,8 +17,9 @@ import DOMPurify from 'dompurify';
  *   use ADD_ATTR to extend the allow-list instead
  * - FORBID_TAGS adds <style> to the deny-list (CSS injection prevention)
  *
- * The uponSanitizeAttribute hook selectively allows data-turn-source-index
- * (used by Deep Research inline citations as a 1-based index into the source list)
+ * The uponSanitizeAttribute hook selectively allows:
+ * - data-turn-source-index (Deep Research inline citations, 1-based index into source list)
+ * - data-math (Gemini KaTeX math expressions, contains LaTeX source for $$/$$ rendering)
  * while blocking all other data-* attributes.
  *
  * Note: The hook is added/removed per call to avoid cross-contamination
@@ -26,7 +27,7 @@ import DOMPurify from 'dompurify';
  */
 export function sanitizeHtml(html: string): string {
   DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
-    if (data.attrName === 'data-turn-source-index') {
+    if (data.attrName === 'data-turn-source-index' || data.attrName === 'data-math') {
       data.forceKeepAttr = true;
     } else if (data.attrName.startsWith('data-')) {
       data.keepAttr = false;

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -109,6 +109,52 @@ describe('htmlToMarkdown', () => {
     });
   });
 
+  describe('math rendering', () => {
+    it('converts display math div to $$ block', () => {
+      const html = '<div data-math="\\frac{a}{b}"><span class="katex">nested spans</span></div>';
+      const result = htmlToMarkdown(html);
+      expect(result).toBe('$$\n\\frac{a}{b}\n$$');
+    });
+
+    it('converts inline math span to $ delimiters', () => {
+      const html = '<span data-math="x^2"><span class="katex">nested</span></span>';
+      const result = htmlToMarkdown(html);
+      expect(result).toBe('$x^2$');
+    });
+
+    it('falls through when data-math attribute is absent', () => {
+      const html = '<div class="math-block">plain text</div>';
+      const result = htmlToMarkdown(html);
+      expect(result).toBe('plain text');
+    });
+
+    it('falls through when data-math is empty', () => {
+      const html = '<div data-math="">fallback content</div>';
+      const result = htmlToMarkdown(html);
+      expect(result).toContain('fallback content');
+    });
+
+    it('preserves LaTeX backslash commands', () => {
+      const html = '<div data-math="\\int_0^1 \\frac{dx}{x}">katex</div>';
+      const result = htmlToMarkdown(html);
+      expect(result).toContain('\\int_0^1 \\frac{dx}{x}');
+    });
+
+    it('handles inline math within a paragraph', () => {
+      const html = '<p>The value of <span data-math="x^2">x²</span> is important.</p>';
+      const result = htmlToMarkdown(html);
+      expect(result).toBe('The value of $x^2$ is important.');
+    });
+
+    it('handles display math between paragraphs', () => {
+      const html = '<p>Before</p><div data-math="E = mc^2">katex</div><p>After</p>';
+      const result = htmlToMarkdown(html);
+      expect(result).toContain('Before');
+      expect(result).toContain('$$\nE = mc^2\n$$');
+      expect(result).toContain('After');
+    });
+  });
+
   describe('edge cases', () => {
     it('handles empty input', () => {
       expect(htmlToMarkdown('')).toBe('');

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -89,6 +89,18 @@ describe('sanitizeHtml', () => {
       expect(result).toContain('data-turn-source-index="1"');
     });
 
+    it('keeps data-math attribute on div (Gemini KaTeX math blocks)', () => {
+      expect(
+        sanitizeHtml('<div data-math="\\frac{a}{b}">KaTeX content</div>')
+      ).toBe('<div data-math="\\frac{a}{b}">KaTeX content</div>');
+    });
+
+    it('keeps data-math attribute on span (Gemini KaTeX inline math)', () => {
+      expect(
+        sanitizeHtml('<span data-math="x^2">KaTeX content</span>')
+      ).toBe('<span data-math="x^2">KaTeX content</span>');
+    });
+
     it('keeps id attributes (allowed by DOMPurify profile)', () => {
       // Note: USE_PROFILES: { html: true } allows id attribute by default
       // ALLOWED_ATTR adds to the profile, doesn't restrict it


### PR DESCRIPTION
## Summary

- Allow `data-math` attribute through DOMPurify sanitization (alongside existing `data-turn-source-index`)
- Add Turndown rules `mathBlock` and `mathInline` to convert Gemini KaTeX elements to `$$...$$` and `$...$` LaTeX syntax
- Display math (`<div data-math="...">`) renders as fenced `$$` blocks; inline math (`<span data-math="...">`) renders as `$...$`
- Empty or missing `data-math` falls back to normal Turndown content processing
- Add 2 sanitize tests and 7 markdown conversion tests for math rendering

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npm test` passes (640 tests, all green)
- [x] Manual test: load extension, save a Gemini conversation containing math formulas, verify `$$`/`$` LaTeX blocks render correctly in Obsidian

🤖 Generated with [Claude Code](https://claude.com/claude-code)