### PR TITLE
feat: separate tool-use content into collapsible [!ABSTRACT] callout

### DIFF
--- a/docs/analysis-report.md
+++ b/docs/analysis-report.md
@@ -1,0 +1,208 @@
+# Comprehensive Code Analysis Report
+
+**Project:** gemini2obsidian (Obsidian AI Exporter)
+**Version:** 0.10.9
+**Date:** 2026-02-27
+**Branch:** feat/phase3-append-mode
+
+---
+
+## Executive Summary
+
+| Domain | Score | Rating |
+|--------|-------|--------|
+| **Code Quality** | 92/100 | Excellent |
+| **Security** | 88/100 | Strong |
+| **Performance** | 90/100 | Very Good |
+| **Architecture** | 87/100 | Good |
+| **Test Coverage** | 95/100 | Excellent |
+| **Overall** | 90/100 | **A** |
+
+The gemini2obsidian codebase is a well-engineered Chrome extension with strong security fundamentals, comprehensive test coverage (96.4% statements, 679 tests), and clean architecture. No critical vulnerabilities were found. Key improvement areas: centralize duplicated platform mappings and harden two medium-severity security gaps.
+
+---
+
+## Metrics Dashboard
+
+```
+Source Files:  37 files, 7,126 lines
+Test Files:    44 files, 37,623 lines (5.3x test-to-source ratio)
+Dependencies:  2 runtime (dompurify, turndown) — minimal attack surface
+
+TypeScript:    0 errors, strict mode, 0 `any` types
+ESLint:        0 errors, 0 warnings
+Prettier:      All clean
+Tests:         679 passed, 0 failed
+
+Coverage:
+  Statements: 96.42% (threshold: 85%)
+  Branches:   91.59% (threshold: 75%)
+  Functions:  96.20% (threshold: 85%)
+  Lines:      96.98% (threshold: 85%)
+```
+
+---
+
+## 1. Security Analysis
+
+### Overview
+0 Critical | 0 High | 2 Medium | 7 Low | 4 Info
+
+The extension demonstrates deliberate security engineering: DOMPurify sanitization on all HTML, strict origin validation, YAML injection prevention, path traversal guards, and proper API key isolation.
+
+### MEDIUM Severity
+
+**S-1: Markdown injection via unsanitized reference titles**
+- **File:** `src/content/markdown.ts:119-131`
+- **Issue:** `source.title` is interpolated into Markdown links without escaping Markdown metacharacters (`[`, `]`, `(`, `)`). A malicious page could craft a title like `](https://evil.com)` to inject links.
+- **Fix:** Escape Markdown metacharacters in `source.title` before interpolation.
+
+**S-2: `getExistingFile` path not validated for traversal**
+- **File:** `src/background/obsidian-handlers.ts:109-132`
+- **Issue:** The `fileName` and `vaultPath` parameters in the `getExistingFile` action skip `containsPathTraversal()` validation (unlike `saveToObsidian`).
+- **Fix:** Add path traversal validation in `validateMessageContent()` for `getExistingFile`.
+
+### LOW Severity
+
+| ID | Finding | File | Notes |
+|----|---------|------|-------|
+| S-3 | Offscreen document lacks sender validation | `offscreen.ts:55-80` | Defense-in-depth; runtime-scoped to extension |
+| S-4 | CSP uses `unsafe-inline` for styles | `manifest.json:29` | Common for extensions; script-src is safe |
+| S-5 | CSP connect-src allows any localhost port | `manifest.json:29` | By design; user-configurable port |
+| S-6 | HTTP for local API (not HTTPS) | `obsidian-api.ts:92` | By design; matches upstream API |
+| S-7 | Regex key interpolation without escaping | `frontmatter-parser.ts:108` | Currently only called with hardcoded keys |
+| S-8 | `data-math` allows arbitrary LaTeX content | `sanitize.ts:30` | Low exploitability via Obsidian renderer |
+| S-9 | `sanitizeUrl` doesn't check encoded schemes | `markdown.ts:33-44` | Mitigated by upstream DOMPurify |
+
+### Good Practices Confirmed
+- All extractors consistently use `sanitizeHtml()` on `innerHTML`
+- User content extracted via `.textContent` (inherently safe)
+- No `eval()`, `new Function()`, or `innerHTML` assignment with untrusted data
+- Origin validation via `URL.origin` strict comparison
+- API key in `chrome.storage.local` (not synced to cloud)
+- YAML injection prevention with comprehensive escaping
+- Path traversal detection with URL-encoded variant checks
+- Message validation with action whitelisting and size limits
+- Filename sanitization via strict allowlist approach
+
+---
+
+## 2. Architecture Analysis
+
+### Strengths
+- Clean extractor hierarchy via `BaseExtractor` abstract class
+- Well-defined message contract (`ExtensionMessage` discriminated union)
+- Background service worker split into focused modules (router, validation, handlers)
+- Type-safe storage with sync/local separation
+- CSS selector fallback chains with stability annotations
+
+### Findings
+
+**A-1: Platform label mapping duplicated in 3 locations** [Medium]
+- `base.ts:33-38` — `PLATFORM_LABELS` Record
+- `markdown.ts:346-358` — `getAssistantLabel()` switch
+- `message-counter.ts:12,18,29` — hardcoded in regex patterns
+
+Adding a new platform requires updating at least 3 files. The regex patterns in `message-counter.ts` are especially fragile.
+
+**A-2: Hostname strings not centralized** [Medium]
+12 occurrences across 6 files. Each extractor's `canExtract()`, `content/index.ts`, and `constants.ts` each independently define the hostname list.
+
+**A-3: Deep Research extraction duplicated** [Low]
+`extractDeepResearchContent()` and `extractDeepResearchLinks()` are structurally identical in both Gemini and Claude extractors. Could be lifted to `BaseExtractor`.
+
+**A-4: `instanceof` check breaks extractor abstraction** [Low]
+`content/index.ts:360-367` — `applyExtractorSettings()` checks `instanceof GeminiExtractor` to apply auto-scroll setting. Better: add `configure(settings)` to `IConversationExtractor`.
+
+**A-5: Popup bypasses type-safe `sendMessage()` wrapper** [Low]
+`popup/index.ts:379-387` uses raw `chrome.runtime.sendMessage()` instead of the typed wrapper, losing type safety.
+
+---
+
+## 3. Code Quality Analysis
+
+### Type Safety
+- **0** `any` types in source
+- **0** non-null assertions (`!`)
+- **13** type assertions (`as Type`) — all reviewed, 2 medium-risk:
+  - `popup/index.ts:56` — `getElement<T>()` silently returns `null as T` (risks cryptic null errors)
+  - `output-handlers.ts:237` — extends type without runtime guard
+
+### Error Handling
+
+**Q-1: `ObsidianApiError` is not an `Error` subclass** [High]
+- **File:** `obsidian-api.ts:272-274`
+- Plain object `{ status, message }` loses stack traces and produces `[object Object]` when reaching generic error handlers like `extractErrorMessage()`.
+
+**Q-2: `getElement<T>()` silently coerces null** [Medium]
+- **File:** `popup/index.ts:56`
+- All 22 uses execute at module load time. Any missing HTML element ID causes cryptic null reference errors later.
+
+**Q-3: `handleTestConnection` lacks local try-catch** [Low]
+- **File:** `obsidian-handlers.ts:137-161`
+- Inconsistent with sibling handlers (`handleSave`, `handleGetFile`) which have local error handling.
+
+### Dead Code
+
+| Item | File | Notes |
+|------|------|-------|
+| `fileExists()` | `obsidian-api.ts:260-267` | Not called anywhere in source |
+| `escapeYamlListItem()` | `yaml-utils.ts:47-49` | Pure pass-through to `escapeYamlValue()` |
+| `NetworkErrorType` export | `obsidian-api.ts:11` | Only referenced in own file |
+| `ConnectionTestResult` export | `obsidian-api.ts:73` | Only used internally |
+
+### Complexity Hotspots
+
+| Function | File | CC | Notes |
+|----------|------|----|-------|
+| `ensureAllMessagesLoaded()` | `gemini.ts:328-406` | ~8 | Well-commented, good test coverage |
+| `handleSync()` | `content/index.ts:290-355` | ~7 | Orchestration; could split into steps |
+| `handleSave()` | `popup/index.ts:315-355` | ~6 | Nested validation |
+| `formatMessage()` | `markdown.ts:364-398` | ~5 | Three format variants; reasonable |
+
+---
+
+## 4. Test Coverage Gaps
+
+Overall coverage is excellent (96.4% stmts). Notable uncovered areas:
+
+| File | Coverage | Uncovered Logic |
+|------|----------|-----------------|
+| `background/index.ts` | 84.6% | Migration error handler, message catch handler, unknown action default |
+| `message-counter.ts` | 88.1% | `stripCodeBlocks()` replacement, `extractTailMessages()` code block toggle |
+| `output-handlers.ts` | 93.7% | `scheduleOffscreenClose()` timer, error catches in save/download |
+| `markdown.ts` | 95.0% | Citation warning path, `removeSourcesCarousel()`, deep-research empty branch |
+| `chatgpt.ts` | 93.3% | Fallback user/assistant content selectors |
+| `storage.ts` | 95.6% | `enableAutoScroll` and `enableAppendMode` save paths |
+
+---
+
+## 5. Prioritized Recommendations
+
+### Priority 1: Security Fixes (Quick Wins)
+1. **Escape Markdown metacharacters in reference titles** (`markdown.ts:119-131`)
+2. **Add path traversal validation for `getExistingFile`** (`obsidian-handlers.ts`)
+
+### Priority 2: Error Handling
+3. **Make `ObsidianApiError` extend `Error`** for stack traces and proper `instanceof` checks
+4. **Add runtime null check in `getElement<T>()`** or throw on missing element
+
+### Priority 3: Reduce Duplication
+5. **Centralize platform label mapping** — single source in `constants.ts`, consumed by extractors, markdown, and message-counter
+6. **Lift `extractDeepResearchContent()` to `BaseExtractor`** — only selector arrays differ
+
+### Priority 4: Clean Up
+7. **Remove `fileExists()` dead code** from `ObsidianApiClient`
+8. **Use `sendMessage()` wrapper in popup** instead of raw `chrome.runtime.sendMessage()`
+
+### Priority 5: Test Coverage
+9. **Add tests for `stripCodeBlocks()` in message-counter** (60% function coverage)
+10. **Add tests for append mode setting save paths** in `storage.ts`
+
+---
+
+## Next Steps
+
+- Use `/sc:improve` to apply recommended fixes
+- Use `/sc:cleanup` for dead code removal
+- Use `/sc:test` to fill identified coverage gaps

--- a/docs/design/DES-006-tool-use-content.md
+++ b/docs/design/DES-006-tool-use-content.md
@@ -1,0 +1,515 @@
+# DES-006: Tool-Use / Intermediate Content Opt-in
+
+## Requirements
+
+- REQ-084: Tool-Use / Intermediate Content Opt-in
+- GitHub: #84
+
+## 1. Overview
+
+Claude's tool-use responses (Web Search results, Code Interpreter output, file analysis) are currently skipped during extraction because they lack the `.font-claude-response` class. This design adds a global opt-in toggle `enableToolContent` to include these intermediate responses alongside normal assistant messages.
+
+### Scope (Phase 1 — Claude only)
+
+| In Scope | Out of Scope |
+|----------|-------------|
+| Settings toggle + storage | ChatGPT/Gemini/Perplexity intermediate content |
+| Claude tool-use DOM extraction | Folding summary text extraction |
+| i18n (en/ja) | New extractor interfaces or message role types |
+| Tests | Separate formatting for tool-use vs normal responses |
+
+### Design Principles
+
+1. **Zero impact when OFF** — No code path changes when `enableToolContent=false`
+2. **Follow existing patterns** — Same property pattern as `GeminiExtractor.enableAutoScroll`
+3. **No base class changes** — `BaseExtractor` and `queryAllWithFallback` remain untouched
+4. **Additive only** — Tool-use elements are collected in a separate pass and merged
+
+## 2. Claude Tool-Use DOM Structure
+
+Based on live DOM investigation, tool-use responses have the following structure:
+
+```html
+<!-- Normal assistant response (EXISTING — has .font-claude-response) -->
+<div data-test-render-count="2" class="group" style="height: auto;">
+  <div class="font-claude-response" data-is-streaming="false">
+    <div class="standard-markdown">
+      <p>Response content</p>
+    </div>
+  </div>
+</div>
+
+<!-- Tool-use response (NEW — NO .font-claude-response) -->
+<div data-test-render-count="2" class="group" style="height: auto;">
+  <div class="grid grid-rows-[auto_auto]">
+    <button>
+      <span>Gathered API documentation for...</span>  <!-- summary text -->
+    </button>
+    <div class="font-claude-response-body">
+      <div class="standard-markdown">
+        <p>Tool result content</p>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Key distinguishing features:
+- Parent div has **no** `.font-claude-response` class
+- Uses `grid grid-rows-[auto_auto]` layout
+- Contains `.font-claude-response-body` (note: **-body** suffix)
+- Has a collapsible `<button>` with summary text (to be excluded per REQ-084 Open Question #1)
+
+### 2.1 CSS Class Relationship (Critical for Deduplication)
+
+```
+.font-claude-response       — normal assistant response wrapper
+.font-claude-response-body  — tool-use response content area
+
+These are DISTINCT classes (not parent-child). However:
+  [class*="font-claude-response"]  ← substring match catches BOTH
+  .font-claude-response            ← exact match catches only normal
+```
+
+This distinction is critical for deduplication logic. See Section 3.7.3.
+
+## 3. Component Design
+
+### 3.1 Type Changes (`src/lib/types.ts`)
+
+```typescript
+// Add to SyncSettings interface (line ~166)
+export interface SyncSettings {
+  obsidianPort: number;
+  vaultPath: string;
+  templateOptions: TemplateOptions;
+  outputOptions: OutputOptions;
+  enableAutoScroll: boolean;
+  enableAppendMode: boolean;
+  /** Include tool-use / intermediate content (e.g., web search results) */
+  enableToolContent: boolean;  // NEW
+}
+```
+
+**Rationale**: Follows the existing flat boolean pattern (`enableAutoScroll`, `enableAppendMode`). No nesting needed since this is a single global toggle.
+
+### 3.2 Storage Changes (`src/lib/storage.ts`)
+
+```typescript
+// DEFAULT_SYNC_SETTINGS (line ~40)
+const DEFAULT_SYNC_SETTINGS: SyncSettings = {
+  // ... existing fields ...
+  enableToolContent: false,  // NEW — OFF by default (preserves existing behavior)
+};
+```
+
+Add to `getSettings()` return object:
+```typescript
+enableToolContent:
+  syncResult.settings?.enableToolContent ?? DEFAULT_SYNC_SETTINGS.enableToolContent,
+```
+
+Add to `saveSettings()` sync data:
+```typescript
+if (settings.enableToolContent !== undefined) {
+  syncData.enableToolContent = settings.enableToolContent;
+}
+```
+
+### 3.3 Popup UI Changes (`src/popup/index.html`)
+
+Add a new toggle in the **Extraction** section, after the Append Mode toggle (line ~88):
+
+```html
+<label class="toggle-row">
+  <span class="toggle-icon">🔍</span>
+  <span class="toggle-label">
+    <span data-i18n="settings_enableToolContent">Include tool/search results</span>
+    <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
+      Save web search and tool results from Claude
+    </span>
+  </span>
+  <span class="toggle-switch">
+    <input type="checkbox" id="enableToolContent" role="switch" aria-checked="false" />
+    <span class="slider" aria-hidden="true"></span>
+  </span>
+</label>
+```
+
+### 3.4 Popup Script Changes (`src/popup/index.ts`)
+
+```typescript
+// elements object: add
+enableToolContent: getElement<HTMLInputElement>('enableToolContent'),
+
+// populateForm(): add
+elements.enableToolContent.checked = settings.enableToolContent ?? false;
+
+// collectSettings(): add to return object
+enableToolContent: elements.enableToolContent.checked,
+```
+
+### 3.5 i18n Changes
+
+**`src/_locales/en/messages.json`**:
+```json
+"settings_enableToolContent": {
+  "message": "Include tool/search results",
+  "description": "Label for tool content toggle"
+},
+"settings_toolContentHelp": {
+  "message": "Save web search and tool results from Claude",
+  "description": "Help text for tool content toggle"
+}
+```
+
+**`src/_locales/ja/messages.json`**:
+```json
+"settings_enableToolContent": {
+  "message": "ツール/検索結果を含める"
+},
+"settings_toolContentHelp": {
+  "message": "Claude の Web 検索やツール結果も保存する"
+}
+```
+
+### 3.6 Content Script Changes (`src/content/index.ts`)
+
+Extend `applyExtractorSettings()` to pass the new setting to the Claude extractor:
+
+```typescript
+function applyExtractorSettings(
+  extractor: IConversationExtractor,
+  settings: ExtensionSettings
+): void {
+  if (extractor instanceof GeminiExtractor) {
+    extractor.enableAutoScroll = settings.enableAutoScroll ?? false;
+  }
+  if (extractor instanceof ClaudeExtractor) {
+    extractor.enableToolContent = settings.enableToolContent ?? false;
+  }
+}
+```
+
+### 3.7 Claude Extractor Changes (`src/content/extractors/claude.ts`)
+
+#### 3.7.1 New Selectors
+
+```typescript
+const SELECTORS = {
+  // ... existing selectors ...
+
+  // Tool-use response selectors (opt-in via enableToolContent)
+  toolUseResponse: [
+    '.font-claude-response-body',           // Semantic (HIGH)
+    '[class*="font-claude-response-body"]',  // Partial match (HIGH)
+  ],
+};
+```
+
+#### 3.7.2 Public Property
+
+```typescript
+export class ClaudeExtractor extends BaseExtractor {
+  readonly platform = 'claude';
+
+  /** Include tool-use / intermediate content in extraction */
+  enableToolContent = false;  // NEW
+
+  // ... rest of class
+}
+```
+
+#### 3.7.3 Modified `extractMessages()`
+
+The key change is to **also collect tool-use response elements** when `enableToolContent` is true, then merge all elements by DOM position.
+
+**CRITICAL: Deduplication selector must use exact class match `.font-claude-response`, NOT substring match `[class*="font-claude-response"]`.**
+
+The substring selector `[class*="font-claude-response"]` matches both `.font-claude-response` AND `.font-claude-response-body` (because the former is a substring of the latter). Since `Element.closest()` starts from the element itself, a tool-use element with class `font-claude-response-body` would match itself and be incorrectly filtered out.
+
+```typescript
+extractMessages(): ConversationMessage[] {
+  const allElements: Array<{ element: Element; type: 'user' | 'assistant' }> = [];
+
+  // Find user messages (skip nested content inside assistant responses)
+  // NOTE: [class*="font-claude-response"] substring match is intentional here —
+  // user-like elements inside BOTH normal responses and tool-use responses
+  // should be excluded (font-claude-response-body also matches, which is correct)
+  const userMessages = this.queryAllWithFallback<HTMLElement>(SELECTORS.userMessage);
+  userMessages.forEach(el => {
+    const assistantParent = el.closest(
+      '.font-claude-response, [class*="font-claude-response"]'
+    );
+    if (!assistantParent) {
+      allElements.push({ element: el, type: 'user' });
+    }
+  });
+
+  // Find normal assistant responses
+  const assistantResponses = this.queryAllWithFallback<HTMLElement>(
+    SELECTORS.assistantResponse
+  );
+  assistantResponses.forEach(el => {
+    allElements.push({ element: el, type: 'assistant' });
+  });
+
+  // NEW: Find tool-use responses when enabled
+  if (this.enableToolContent) {
+    const toolResponses = this.queryAllWithFallback<HTMLElement>(
+      SELECTORS.toolUseResponse
+    );
+    toolResponses.forEach(el => {
+      // Deduplicate: skip if inside a normal .font-claude-response
+      // MUST use exact class match — NOT [class*="font-claude-response"]
+      // because substring match would catch .font-claude-response-body itself
+      const normalParent = el.closest('.font-claude-response');
+      if (!normalParent) {
+        allElements.push({ element: el, type: 'assistant' });
+      }
+    });
+  }
+
+  this.sortByDomPosition(allElements);
+
+  return this.buildMessagesFromElements(
+    allElements,
+    el => this.extractUserContent(el),
+    el => this.extractAssistantContent(el)
+  );
+}
+```
+
+#### 3.7.4 `extractAssistantContent` — No Changes Needed
+
+The existing method already handles the general case:
+1. Looks for `.row-start-2` (Extended Thinking) → extracts markdown
+2. Looks for `.standard-markdown` → extracts markdown
+3. Falls back to `element.innerHTML`
+
+For tool-use responses, `.font-claude-response-body` contains `.standard-markdown`, so step 2 will naturally extract the content. No special-casing needed.
+
+#### 3.7.5 User Message Filtering — No Changes Needed
+
+The existing user message filter uses `[class*="font-claude-response"]` (substring match):
+```typescript
+el.closest('.font-claude-response, [class*="font-claude-response"]')
+```
+
+This **intentionally catches both** `.font-claude-response` and `.font-claude-response-body`, correctly excluding any user-like elements that appear inside tool-use responses. No change needed.
+
+## 4. Data Flow
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Popup UI                                           │
+│  ┌──────────────────────────────────────────────┐   │
+│  │ [Toggle] Include tool/search results: [OFF]  │   │
+│  └──────────────────────────────────────────────┘   │
+│  collectSettings() → { enableToolContent: true }    │
+└──────────────────────┬──────────────────────────────┘
+                       │ saveSettings()
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│  chrome.storage.sync                                │
+│  { settings: { ..., enableToolContent: true } }     │
+└──────────────────────┬──────────────────────────────┘
+                       │ getSettings() message
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│  Content Script (index.ts)                          │
+│  applyExtractorSettings(extractor, settings)        │
+│  → extractor.enableToolContent = true               │
+└──────────────────────┬──────────────────────────────┘
+                       │ extractor.extract()
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│  ClaudeExtractor.extractMessages()                  │
+│                                                     │
+│  1. Collect user messages    (existing)              │
+│  2. Collect assistant msgs   (existing)              │
+│  3. Collect tool-use msgs    (NEW — if enabled)      │
+│  4. Sort all by DOM position (existing)              │
+│  5. Build ConversationMessage[] (existing)           │
+└─────────────────────────────────────────────────────┘
+```
+
+## 5. queryAllWithFallback — No Modification Needed
+
+After analysis, `queryAllWithFallback` does **not** need modification:
+
+- Tool-use selectors (`toolUseResponse`) are a **separate selector group** from `assistantResponse`
+- We call `queryAllWithFallback` **twice** (once per group) and merge results
+- This avoids changing the core utility's behavior, which would affect all 4 extractors
+- Deduplication is handled via `el.closest()` ancestry check, not by modifying the query utility
+
+This is simpler and safer than the union-based approach initially considered in the requirements doc.
+
+## 6. Affected Files
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/lib/types.ts` | Add `enableToolContent: boolean` to `SyncSettings` | ~1 line |
+| `src/lib/storage.ts` | Add default, getSettings field, saveSettings handler | ~5 lines |
+| `src/popup/index.html` | Add toggle UI in Extraction section | ~14 lines |
+| `src/popup/index.ts` | Add element ref, populate, collect | ~3 lines |
+| `src/_locales/en/messages.json` | Add 2 i18n keys | ~8 lines |
+| `src/_locales/ja/messages.json` | Add 2 i18n keys | ~6 lines |
+| `src/content/index.ts` | Extend `applyExtractorSettings` for Claude | ~3 lines |
+| `src/content/extractors/claude.ts` | Add selectors, property, extraction logic | ~15 lines |
+| `test/fixtures/dom-helpers.ts` | Add `createClaudeToolUsePage` helper | ~30 lines |
+| `test/extractors/claude.test.ts` | Add tool-use test cases | ~80 lines |
+
+**Total**: ~165 lines of changes across 10 files
+
+## 7. Impact Analysis
+
+### 7.1 Validation Warning (Acceptable)
+
+`BaseExtractor.validate()` checks `Math.abs(userCount - assistantCount) > 1` and emits an "Unbalanced message count" warning. With tool-use content enabled, `assistantCount` will exceed `userCount`, triggering this warning.
+
+**Decision: Accept for Phase 1.** Rationale:
+- Validation warnings are **console-only** (`console.warn`), never shown to the user as toasts
+- `isValid` remains `true` — warnings don't block extraction or saving
+- Fixing this would require either modifying the base class (affects all extractors) or overriding `validate()` in ClaudeExtractor (adds complexity)
+- Can revisit if user feedback indicates confusion
+
+### 7.2 Metadata Impact
+
+`buildMetadata()` counts all messages by role. Tool-use messages counted as `role: 'assistant'` will inflate `assistantMessageCount`. This is **correct behavior** — tool-use content is assistant-generated output.
+
+### 7.3 Markdown Formatting Impact
+
+`formatMessage()` in `src/content/markdown.ts` only checks `role: 'user' | 'assistant'`. Tool-use content (as `role: 'assistant'`) receives identical formatting to normal responses:
+- Same callout type (e.g., `> [!NOTE] Claude`)
+- Same `htmlToMarkdown()` conversion
+- Same label from `getAssistantLabel(source)`
+
+**No changes needed.** Users who enable this toggle expect tool-use content to appear as regular assistant messages in the note.
+
+### 7.4 User Message Filter Correctness
+
+The existing user message filter (`el.closest('[class*="font-claude-response"]')`) uses a **substring match** that catches both `.font-claude-response` AND `.font-claude-response-body`. This correctly excludes user-like elements inside both normal and tool-use responses. **No change needed.**
+
+## 8. Test Strategy
+
+### 8.1 DOM Helper Addition (`test/fixtures/dom-helpers.ts`)
+
+Add helpers to create tool-use response DOM:
+
+```typescript
+/**
+ * Create Claude tool-use response DOM element
+ * Simulates web search, code interpreter, etc.
+ */
+export function createClaudeToolUseResponse(
+  summaryText: string,
+  content: string
+): string {
+  return `
+    <div data-test-render-count="2" class="group" style="height: auto;">
+      <div class="grid grid-rows-[auto_auto]">
+        <button>
+          <span>${escapeHtmlForClaude(summaryText)}</span>
+        </button>
+        <div class="font-claude-response-body">
+          <div class="standard-markdown">
+            ${content}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+```
+
+Also add a composite page helper (`createClaudePageWithToolUse`) that interleaves tool-use blocks between normal messages in the DOM, using `loadFixture()` to assemble them.
+
+### 8.2 Extractor Test Cases (`test/extractors/claude.test.ts`)
+
+```
+describe('Tool-use content extraction', () => {
+  TC-1: enableToolContent=false (default) → tool-use responses are skipped
+  TC-2: enableToolContent=true  → tool-use responses included as assistant messages
+  TC-3: enableToolContent=true  → mixed normal + tool-use responses maintain DOM order
+  TC-4: enableToolContent=true  → dedup: .font-claude-response-body inside
+        .font-claude-response is not double-counted (exact class match)
+  TC-5: enableToolContent=true  → tool-use content is sanitized via DOMPurify
+  TC-6: enableToolContent=true  → .standard-markdown inside tool-use is extracted
+  TC-7: enableToolContent=true  → summary button text is NOT included in output
+  TC-8: enableToolContent=false → normal responses unaffected (regression)
+  TC-9: enableToolContent=true  → user messages inside tool-use responses are excluded
+        (substring match [class*="font-claude-response"] catches -body)
+})
+```
+
+### 8.3 Storage Tests (`test/lib/storage.test.ts`)
+
+Add 2 tests (following existing patterns):
+
+```
+TC-S1: getSettings() returns enableToolContent default (false) when storage empty
+TC-S2: saveSettings({ enableToolContent: true }) persists and round-trips
+```
+
+### 8.4 Popup Tests (`test/popup/index.test.ts`)
+
+Add 2 tests (following existing patterns):
+
+```
+TC-P1: populateForm() sets enableToolContent checkbox from settings
+TC-P2: collectSettings() includes enableToolContent from checkbox state
+```
+
+### 8.5 Test Coverage Summary
+
+| Component | Existing Tests | New Tests | Total |
+|-----------|---------------|-----------|-------|
+| Claude extractor | 64 | 9 | 73 |
+| Storage | 17 | 2 | 19 |
+| Popup | ~37 | 2 | ~39 |
+| **Total** | **~118** | **13** | **~131** |
+
+## 9. Non-Functional Requirements
+
+| Requirement | How Met |
+|-------------|---------|
+| Toggle OFF preserves existing behavior | `if (this.enableToolContent)` guard; all existing code paths untouched |
+| No page reload needed | Setting is read fresh per sync click via `getSettings()` |
+| No perf impact when OFF | Zero additional DOM queries when `enableToolContent=false` |
+| Security (XSS) | Tool-use content passes through `sanitizeHtml()` (DOMPurify) |
+
+## 10. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Claude DOM changes break tool-use selectors | Medium | Low | Fallback chain (`[class*="font-claude-response-body"]`); toggle OFF restores behavior |
+| Validation warning confuses developers | Low | Low | Console-only; documented in this design |
+| Tool-use content overwhelms note with noise | Low | Low | User-controlled opt-in; OFF by default |
+| Substring selector `[class*=...]` matches unexpected future classes | Low | Low | Dedup uses exact `.font-claude-response` match; edge case handled |
+
+## 11. Open Questions (Resolved)
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Include fold summary text? | **No** | Summary text (`<button>` content) is excluded. Only `.standard-markdown` content inside `.font-claude-response-body` is extracted. |
+| 2 | Modify `queryAllWithFallback`? | **No** | Separate calls + merge is simpler, safer, and avoids touching the base class shared by all 4 extractors. |
+| 3 | Fix "Unbalanced message count" validation warning? | **No (Phase 1)** | Warning is console-only, doesn't affect users. Fixing requires base class changes or per-extractor override. |
+| 4 | Add a new message role (e.g., `'tool'`)? | **No** | Introduces breaking changes across types, markdown, tests. Tool-use content is assistant-generated, so `'assistant'` role is semantically correct. |
+
+## 12. Implementation Order
+
+Recommended implementation sequence (each step independently testable):
+
+1. **Types + Storage** — `types.ts`, `storage.ts` (+ storage tests)
+2. **Popup UI** — `index.html`, `index.ts`, i18n files (+ popup tests)
+3. **Content Script** — `content/index.ts` (wiring only)
+4. **Claude Extractor** — `claude.ts` selectors + extraction (+ extractor tests)
+5. **Verify** — `npm run build && npm run lint && npm test`
+
+## 13. Future Work (Phase 2)
+
+- ChatGPT: Web Browsing, DALL-E, Code Interpreter, Canvas
+- Gemini: Google Search integration, Extensions
+- Perplexity: Source search/citation panels
+- Each platform requires DOM investigation + separate implementation issue

--- a/docs/requirements/REQ-084-tool-use-content.md
+++ b/docs/requirements/REQ-084-tool-use-content.md
@@ -1,0 +1,100 @@
+# REQ-084: Tool-Use / Intermediate Content Opt-in
+
+## Issue
+
+- GitHub: #84 — Not all of Claude's output is being saved
+- Priority: High (ユーザー体験に直接影響)
+
+## Background
+
+各AIプラットフォームにはツール使用時の中間コンテンツ（Web検索結果、コード実行結果、ファイル分析等）がある。これらは意図的に保存対象外としていたが、ユーザーからの要望により opt-in 設定で保存可能にする。
+
+### 各プラットフォームの中間コンテンツ
+
+| Platform | Intermediate Content | DOM特徴 |
+|----------|---------------------|---------|
+| **Claude** | Web Search結果、ファイル分析、Code Interpreter | 親divにクラスなし、子要素に `font-claude-response-body`、折りたたみ可能なサマリーボタン |
+| **ChatGPT** | Web Browsing、DALL-E生成、Code Interpreter、Canvasツール | 調査要 |
+| **Gemini** | Google Search統合、Extensions連携 | 調査要 |
+| **Perplexity** | ソース検索・引用パネル | 調査要 |
+
+## Solution Approach
+
+Advanced Settings に単一グローバルトグルを追加し、中間コンテンツの保存を制御する。
+
+## Functional Requirements
+
+### FR-1: Advanced Settings トグル追加
+
+- 設定名: `enableToolContent` (仮)
+- ラベル: "Include tool/search results" (i18n対応)
+- 位置: Advanced Settings パネル内、既存のMessage Format セクションの上または下
+- デフォルト: OFF (既存動作を維持)
+- UIパターン: 既存の `role="switch"` トグルスイッチに準拠
+
+### FR-2: 設定の永続化
+
+- `SyncSettings` に `enableToolContent: boolean` を追加
+- `chrome.storage.sync` に保存（既存パターンに準拠）
+- デフォルト値: `false`
+
+### FR-3: Claude — ツール使用応答の抽出
+
+- `enableToolContent: true` の場合:
+  - 現在のセレクタ (`font-claude-response`) に加え、ツール使用応答のDOM構造も抽出対象にする
+  - ツール使用応答の特徴: 親divにクラスなし、`grid grid-rows-[auto_auto]` レイアウト、子要素に `font-claude-response-body`
+  - 折りたたみサマリー（「Gathered API documentation...」等）の処理方針を決定する（含める or フィルタする）
+- `enableToolContent: false` の場合:
+  - 現在の動作を維持（ツール使用応答をスキップ）
+
+### FR-4: queryAllWithFallback の改善
+
+- 現在の「最初にマッチしたセレクタで全結果を返す」設計では、通常応答とツール使用応答が混在する場合に後者が漏れる
+- `enableToolContent: true` 時は、全セレクタの結果を集約し、DOM順にソートして重複排除する方式を検討
+- 既存の挙動（`enableToolContent: false`）は変更しない
+
+### FR-5: 他プラットフォーム対応（段階的）
+
+- Phase 1: Claude のツール使用応答対応（本 issue）
+- Phase 2: ChatGPT, Gemini, Perplexity の中間コンテンツ対応（各プラットフォームのDOM調査後に別issueで対応）
+- トグルの仕組みは共通だが、各プラットフォームのextractor改修は段階的に行う
+
+### FR-6: 設定の Content Script への伝達
+
+- Content Script は `getSettings()` メッセージで Background Worker から設定を取得する（既存フロー）
+- `enableToolContent` を extractor に渡す方法:
+  - `extract()` メソッドのオプション引数として渡す、または
+  - extractor のコンストラクタ/セッターで設定する
+
+## Non-Functional Requirements
+
+- トグルOFF時の既存動作に一切影響しないこと
+- トグル切替後、次回の同期操作から反映されること（ページリロード不要）
+
+## Acceptance Criteria
+
+1. Advanced Settings に "Include tool/search results" トグルが表示される
+2. トグルOFF: Claude のツール使用応答が保存されない（現行動作）
+3. トグルON: Claude のツール使用応答が通常の応答と同様に保存される
+4. トグルON: 通常の応答 + ツール使用応答が DOM 順に正しく保存される
+5. 設定がブラウザ再起動後も保持される
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `src/lib/types.ts` | `SyncSettings` に `enableToolContent` 追加 |
+| `src/lib/storage.ts` | デフォルト値追加 |
+| `src/popup/index.html` | トグルUI追加 |
+| `src/popup/index.ts` | トグルのイベントハンドリング追加 |
+| `src/content/extractors/claude.ts` | ツール使用応答セレクタ追加、条件分岐 |
+| `src/content/extractors/base.ts` | `queryAllWithFallback` の拡張（検討） |
+| `src/content/index.ts` | 設定をextractorに渡すフロー追加 |
+| `test/extractors/claude.test.ts` | ツール使用応答のテストケース追加 |
+
+## Open Questions
+
+1. Claude のツール使用応答内の折りたたみサマリーテキスト（「Gathered API documentation...」）は保存に含めるか、フィルタするか？
+   1. 保存しない
+2. ChatGPT / Gemini / Perplexity の中間コンテンツの具体的なDOM構造（Phase 2 で調査）
+   1. 

--- a/docs/workflow/WF-084-tool-use-content.md
+++ b/docs/workflow/WF-084-tool-use-content.md
@@ -1,0 +1,292 @@
+# WF-084: Tool-Use Content Implementation Workflow
+
+**Design Reference**: `docs/design/DES-006-tool-use-content.md`
+**Requirements**: REQ-084 / GitHub #84
+**Estimated Scope**: ~165 lines across 10 files, 13 new tests
+
+---
+
+## Phase 0: Branch Setup
+
+### Step 0.1 — Create feature branch
+
+```bash
+git checkout main && git pull
+git checkout -b feat/tool-use-content-opt-in
+```
+
+**Checkpoint**: On `feat/tool-use-content-opt-in` branch, clean working tree.
+
+---
+
+## Phase 1: Types + Storage Layer
+
+> Foundation layer. All subsequent phases depend on this.
+
+### Step 1.1 — Add `enableToolContent` to `SyncSettings`
+
+**File**: `src/lib/types.ts`
+**Action**: Add field to `SyncSettings` interface (after `enableAppendMode`).
+
+```typescript
+/** Include tool-use / intermediate content (e.g., web search results) */
+enableToolContent: boolean;
+```
+
+**Verify**: `npx tsc --noEmit` — expect errors in `storage.ts` (missing field in defaults).
+
+### Step 1.2 — Add default value and storage handlers
+
+**File**: `src/lib/storage.ts`
+**Actions** (3 locations):
+
+1. `DEFAULT_SYNC_SETTINGS` — add `enableToolContent: false`
+2. `getSettings()` return object — add retrieval line
+3. `saveSettings()` — add persistence conditional
+
+**Verify**: `npx tsc --noEmit` — 0 errors.
+
+### Step 1.3 — Add storage tests
+
+**File**: `test/lib/storage.test.ts`
+**Actions**: Add 2 tests inside existing describe blocks:
+
+- `getSettings()` returns `enableToolContent: false` when storage empty
+- `saveSettings({ enableToolContent: true })` round-trips correctly
+
+**Verify**: `npx vitest run test/lib/storage.test.ts` — all pass.
+
+**Phase 1 Checkpoint**: `npm run build` succeeds. Storage tests pass.
+
+---
+
+## Phase 2: Popup UI
+
+> Settings UI. Depends on Phase 1 types.
+
+### Step 2.1 — Add i18n keys
+
+**Files**: `src/_locales/en/messages.json`, `src/_locales/ja/messages.json`
+**Action**: Add 2 keys each (`settings_enableToolContent`, `settings_toolContentHelp`).
+
+### Step 2.2 — Add toggle HTML
+
+**File**: `src/popup/index.html`
+**Action**: Insert toggle row after the Append Mode toggle (after line ~88), before `</div>` closing the toggle-list in the Extraction section.
+
+```html
+<label class="toggle-row">
+  <span class="toggle-icon">🔍</span>
+  <span class="toggle-label">
+    <span data-i18n="settings_enableToolContent">Include tool/search results</span>
+    <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
+      Save web search and tool results from Claude
+    </span>
+  </span>
+  <span class="toggle-switch">
+    <input type="checkbox" id="enableToolContent" role="switch" aria-checked="false" />
+    <span class="slider" aria-hidden="true"></span>
+  </span>
+</label>
+```
+
+### Step 2.3 — Wire popup script
+
+**File**: `src/popup/index.ts`
+**Actions** (3 locations):
+
+1. `elements` object — add `enableToolContent: getElement<HTMLInputElement>('enableToolContent')`
+2. `populateForm()` — add `elements.enableToolContent.checked = settings.enableToolContent ?? false;`
+3. `collectSettings()` return object — add `enableToolContent: elements.enableToolContent.checked`
+
+### Step 2.4 — Add popup tests
+
+**File**: `test/popup/index.test.ts`
+**Actions**: Add 2 tests following existing patterns:
+
+- `populateForm()` sets `enableToolContent` checkbox from settings
+- `collectSettings()` includes `enableToolContent` from checkbox state
+
+**Verify**: `npx vitest run test/popup/index.test.ts` — all pass.
+
+**Phase 2 Checkpoint**: `npm run build` succeeds. Popup tests pass. `npm run dev` → toggle visible in Extraction section.
+
+---
+
+## Phase 3: Content Script Wiring
+
+> Connects settings to extractor. Depends on Phase 1.
+
+### Step 3.1 — Extend `applyExtractorSettings()`
+
+**File**: `src/content/index.ts`
+**Action**: Add `ClaudeExtractor` import and `instanceof` check:
+
+```typescript
+import { ClaudeExtractor } from './extractors/claude';
+
+// Inside applyExtractorSettings():
+if (extractor instanceof ClaudeExtractor) {
+  extractor.enableToolContent = settings.enableToolContent ?? false;
+}
+```
+
+**Verify**: `npx tsc --noEmit` — expect error (property doesn't exist on ClaudeExtractor yet). This is expected; will resolve in Phase 4.
+
+**Phase 3 Checkpoint**: Change is ready, will compile after Phase 4.
+
+---
+
+## Phase 4: Claude Extractor Implementation
+
+> Core extraction logic. Depends on Phases 1 + 3.
+
+### Step 4.1 — Add `enableToolContent` property
+
+**File**: `src/content/extractors/claude.ts`
+**Action**: Add public property to `ClaudeExtractor` class (after `readonly platform`):
+
+```typescript
+/** Include tool-use / intermediate content in extraction */
+enableToolContent = false;
+```
+
+**Verify**: `npx tsc --noEmit` — 0 errors (Phase 3 import now resolves).
+
+### Step 4.2 — Add tool-use selectors
+
+**File**: `src/content/extractors/claude.ts`
+**Action**: Add `toolUseResponse` entry to `SELECTORS` constant:
+
+```typescript
+// Tool-use response selectors (opt-in via enableToolContent)
+toolUseResponse: [
+  '.font-claude-response-body',           // Semantic (HIGH)
+  '[class*="font-claude-response-body"]',  // Partial match (HIGH)
+],
+```
+
+### Step 4.3 — Modify `extractMessages()`
+
+**File**: `src/content/extractors/claude.ts`
+**Action**: Add tool-use collection block after existing assistant response collection, guarded by `if (this.enableToolContent)`.
+
+**CRITICAL IMPLEMENTATION NOTE**: Deduplication MUST use exact class match:
+```typescript
+const normalParent = el.closest('.font-claude-response');
+```
+NOT substring match `[class*="font-claude-response"]` which would match the element itself.
+
+See DES-006 Section 3.7.3 for the complete code.
+
+**Verify**: `npx tsc --noEmit` — 0 errors.
+
+### Step 4.4 — Add DOM test helpers
+
+**File**: `test/fixtures/dom-helpers.ts`
+**Actions**:
+
+1. Add `createClaudeToolUseResponse(summaryText, content)` helper
+2. Add `createClaudePageWithToolUse(conversationId, messages, toolUseInsertions)` composite helper
+
+### Step 4.5 — Add extractor tests
+
+**File**: `test/extractors/claude.test.ts`
+**Action**: Add new describe block `'Tool-use content extraction'` with 9 test cases:
+
+| TC | Description | Key Assertion |
+|----|-------------|---------------|
+| 1 | OFF: tool-use skipped (default) | `messages.length === 2` (user+assistant only) |
+| 2 | ON: tool-use included | `messages.length === 3` (user+tool+assistant) |
+| 3 | ON: mixed responses maintain DOM order | `messages[1].content` is tool-use, `messages[2].content` is normal |
+| 4 | ON: no double-count when inside .font-claude-response | `messages.length` is not inflated |
+| 5 | ON: content sanitized via DOMPurify | No `<script>` tags in output |
+| 6 | ON: .standard-markdown extraction works | Content matches expected markdown |
+| 7 | ON: summary button text excluded | `content` does not contain summary text |
+| 8 | OFF: normal responses unaffected (regression) | Identical output with/without tool-use DOM present |
+| 9 | ON: user-like elements inside tool-use excluded | User content inside `.font-claude-response-body` not in user messages |
+
+**Verify**: `npx vitest run test/extractors/claude.test.ts` — all 73 tests pass.
+
+**Phase 4 Checkpoint**: `npm run build` succeeds. All extractor tests pass.
+
+---
+
+## Phase 5: Final Verification
+
+### Step 5.1 — Full build + lint + test
+
+```bash
+npm run build    # TypeScript check + Vite production build
+npm run lint     # ESLint — 0 errors, 0 warnings
+npm run format   # Prettier — all clean
+npx vitest run   # All tests pass, coverage thresholds met
+```
+
+### Step 5.2 — Verify acceptance criteria
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| AC-1 | Toggle visible in Advanced Settings → Extraction | Visual check in `npm run dev` |
+| AC-2 | OFF: tool-use not saved | TC-1, TC-8 |
+| AC-3 | ON: tool-use saved | TC-2, TC-6 |
+| AC-4 | ON: DOM order preserved | TC-3 |
+| AC-5 | Settings persist across restart | TC-S1, TC-S2 |
+
+### Step 5.3 — Commit
+
+```bash
+git add <specific files>
+git commit -m "feat: add enableToolContent opt-in for Claude tool-use responses (#84)"
+```
+
+**Phase 5 Checkpoint**: Clean build, all tests pass, conventional commit created.
+
+---
+
+## Dependency Graph
+
+```
+Phase 0: Branch Setup
+    │
+    ▼
+Phase 1: Types + Storage ──────────────────┐
+    │                                       │
+    ▼                                       ▼
+Phase 2: Popup UI            Phase 3: Content Script Wiring
+    │                                       │
+    └───────────────┬───────────────────────┘
+                    │
+                    ▼
+             Phase 4: Claude Extractor
+                    │
+                    ▼
+             Phase 5: Final Verification
+```
+
+## Files Changed (Implementation Order)
+
+| # | File | Phase | Lines |
+|---|------|-------|-------|
+| 1 | `src/lib/types.ts` | 1.1 | +2 |
+| 2 | `src/lib/storage.ts` | 1.2 | +5 |
+| 3 | `test/lib/storage.test.ts` | 1.3 | +20 |
+| 4 | `src/_locales/en/messages.json` | 2.1 | +8 |
+| 5 | `src/_locales/ja/messages.json` | 2.1 | +6 |
+| 6 | `src/popup/index.html` | 2.2 | +14 |
+| 7 | `src/popup/index.ts` | 2.3 | +3 |
+| 8 | `test/popup/index.test.ts` | 2.4 | +15 |
+| 9 | `src/content/index.ts` | 3.1 | +4 |
+| 10 | `src/content/extractors/claude.ts` | 4.1-4.3 | +20 |
+| 11 | `test/fixtures/dom-helpers.ts` | 4.4 | +35 |
+| 12 | `test/extractors/claude.test.ts` | 4.5 | +90 |
+| | **Total** | | **~222** |
+
+## Risk Checkpoints
+
+| After Phase | Check | Abort If |
+|-------------|-------|----------|
+| 1 | `tsc --noEmit` + storage tests | Type errors in unrelated files |
+| 2 | `npm run build` | Popup rendering broken |
+| 4 | Full test suite | Existing 64 Claude tests regress |
+| 5 | `npm run build && npm run lint && npx vitest run` | Any failure |

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -316,6 +316,15 @@
     "message": "Only add new messages to existing notes",
     "description": "Help text for append mode toggle"
   },
+  "settings_enableToolContent": {
+    "message": "Include tool/search results",
+    "description": "Label for tool content toggle"
+  },
+  "settings_toolContentHelp": {
+    "message": "Save web search and tool results from Claude",
+    "description": "Help text for tool content toggle"
+  },
+
   "toast_appended": {
     "message": "$COUNT$ new message(s) appended",
     "description": "Toast when messages are appended",

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -223,5 +223,12 @@
   },
   "output_clipboard": {
     "message": "クリップボード"
+  },
+
+  "settings_enableToolContent": {
+    "message": "ツール/検索結果を含める"
+  },
+  "settings_toolContentHelp": {
+    "message": "Claude の Web 検索やツール結果も保存する"
   }
 }

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -310,8 +310,7 @@ export class ClaudeExtractor extends BaseExtractor {
     const toolSection = element.querySelector('.row-start-1');
     if (!toolSection) return null;
 
-    const isExtendedThinking =
-      toolSection.querySelector('[class*="group/thinking"]') !== null;
+    const isExtendedThinking = toolSection.querySelector('[class*="group/thinking"]') !== null;
     if (isExtendedThinking) return null;
 
     const toolContent = this.extractToolContent(toolSection);
@@ -360,8 +359,7 @@ export class ClaudeExtractor extends BaseExtractor {
         if (!row || row.children.length < 2) return;
         // Children: [0]=favicon container, [1]=title, [2]=domain (optional)
         const title = row.children[1]?.textContent?.trim();
-        const domain =
-          row.children.length > 2 ? row.children[2]?.textContent?.trim() : undefined;
+        const domain = row.children.length > 2 ? row.children[2]?.textContent?.trim() : undefined;
         if (title) {
           items.push(domain ? '- ' + title + ' (' + domain + ')' : '- ' + title);
         }

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -119,6 +119,8 @@ const JOINED_SELECTORS = {
  */
 export class ClaudeExtractor extends BaseExtractor {
   readonly platform = 'claude';
+  /** Include tool-use / intermediate content (web search, code interpreter, etc.) */
+  enableToolContent = false;
 
   // ========== Platform Detection ==========
 
@@ -228,11 +230,36 @@ export class ClaudeExtractor extends BaseExtractor {
 
     this.sortByDomPosition(allElements);
 
-    return this.buildMessagesFromElements(
+    // Pre-extract tool content keyed by element index
+    const toolContentMap = new Map<number, string>();
+    if (this.enableToolContent) {
+      allElements.forEach((item, index) => {
+        if (item.type === 'assistant') {
+          const tc = this.extractToolContentFromElement(item.element);
+          if (tc) toolContentMap.set(index, tc);
+        }
+      });
+    }
+
+    const messages = this.buildMessagesFromElements(
       allElements,
       el => this.extractUserContent(el),
       el => this.extractAssistantContent(el)
     );
+
+    // Attach tool content to corresponding assistant messages
+    if (toolContentMap.size > 0) {
+      for (const msg of messages) {
+        if (msg.role === 'assistant') {
+          // msg.id = "assistant-N" where N is the allElements index
+          const idx = parseInt(msg.id.split('-')[1], 10);
+          const tc = toolContentMap.get(idx);
+          if (tc) msg.toolContent = tc;
+        }
+      }
+    }
+
+    return messages;
   }
 
   /**
@@ -254,19 +281,13 @@ export class ClaudeExtractor extends BaseExtractor {
    * @see NFR-001-2 in design document
    */
   private extractAssistantContent(element: Element): string {
-    // Extended Thinking: scope to .row-start-2 to skip thinking in .row-start-1
+    // Grid layout: Extended Thinking or Tool-Use (.row-start-1 + .row-start-2)
     const responseSection = element.querySelector('.row-start-2');
     if (responseSection) {
-      const markdownEl = this.queryWithFallback<HTMLElement>(
-        SELECTORS.markdownContent,
-        responseSection
-      );
-      if (markdownEl) {
-        return sanitizeHtml(markdownEl.innerHTML);
-      }
+      return this.extractMarkdownFromSection(responseSection);
     }
 
-    // Non-Extended-Thinking fallback: existing behavior
+    // Non-grid fallback: existing behavior
     const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
     if (markdownEl) {
       return sanitizeHtml(markdownEl.innerHTML);
@@ -274,6 +295,103 @@ export class ClaudeExtractor extends BaseExtractor {
 
     // Fallback: use the element's innerHTML
     return sanitizeHtml(element.innerHTML);
+  }
+
+  /**
+   * Extract tool content from a full .font-claude-response element
+   *
+   * Returns tool content string if .row-start-1 contains tool-use content,
+   * null otherwise (no grid, no tool section, or Extended Thinking).
+   */
+  private extractToolContentFromElement(element: Element): string | null {
+    const responseSection = element.querySelector('.row-start-2');
+    if (!responseSection) return null; // Non-grid → no tool content
+
+    const toolSection = element.querySelector('.row-start-1');
+    if (!toolSection) return null;
+
+    const isExtendedThinking =
+      toolSection.querySelector('[class*="group/thinking"]') !== null;
+    if (isExtendedThinking) return null;
+
+    const toolContent = this.extractToolContent(toolSection);
+    return toolContent || null;
+  }
+
+  /**
+   * Extract tool content from .row-start-1 section
+   *
+   * Extracts:
+   * 1. Summary button text (e.g., "Searched the web") as bold
+   * 2. Search queries (group/row buttons with query text and result count)
+   * 3. Search result items (identified by favicon images)
+   * 4. .standard-markdown content (code interpreter, file analysis)
+   */
+  private extractToolContent(toolSection: Element): string {
+    const parts: string[] = [];
+
+    // 1. Summary button text (group/status button > span.truncate)
+    const summaryButton = toolSection.querySelector('button span.truncate');
+    if (summaryButton?.textContent) {
+      parts.push('**' + this.sanitizeText(summaryButton.textContent) + '**');
+    }
+
+    // 2. Search queries (group/row buttons contain query text and result count)
+    const queryButtons = toolSection.querySelectorAll('[class*="group/row"]');
+    queryButtons.forEach(btn => {
+      const queryEl = btn.querySelector('.truncate');
+      const countEl = btn.querySelector('p');
+      if (queryEl?.textContent?.trim()) {
+        let text = this.sanitizeText(queryEl.textContent);
+        if (countEl?.textContent?.trim()) {
+          text += ' (' + this.sanitizeText(countEl.textContent) + ')';
+        }
+        parts.push(text);
+      }
+    });
+
+    // 3. Search result items (identified by favicon images)
+    const favicons = toolSection.querySelectorAll('img[alt="favicon"]');
+    if (favicons.length > 0) {
+      const items: string[] = [];
+      favicons.forEach(img => {
+        // Navigate: img → container div → result row div
+        const row = img.parentElement?.parentElement;
+        if (!row || row.children.length < 2) return;
+        // Children: [0]=favicon container, [1]=title, [2]=domain (optional)
+        const title = row.children[1]?.textContent?.trim();
+        const domain =
+          row.children.length > 2 ? row.children[2]?.textContent?.trim() : undefined;
+        if (title) {
+          items.push(domain ? '- ' + title + ' (' + domain + ')' : '- ' + title);
+        }
+      });
+      if (items.length > 0) {
+        parts.push(items.join('\n'));
+      }
+    }
+
+    // 4. .standard-markdown content (code interpreter, file analysis)
+    const markdownEls = toolSection.querySelectorAll('.standard-markdown');
+    markdownEls.forEach(el => {
+      const html = sanitizeHtml(el.innerHTML);
+      if (html.trim()) {
+        parts.push(html);
+      }
+    });
+
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Extract markdown content from a grid section (.row-start-1 or .row-start-2)
+   */
+  private extractMarkdownFromSection(section: Element): string {
+    const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, section);
+    if (markdownEl) {
+      return sanitizeHtml(markdownEl.innerHTML);
+    }
+    return sanitizeHtml(section.innerHTML);
   }
 
   // ========== Deep Research Extraction ==========

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -364,6 +364,9 @@ function applyExtractorSettings(
   if (extractor instanceof GeminiExtractor) {
     extractor.enableAutoScroll = settings.enableAutoScroll ?? false;
   }
+  if (extractor instanceof ClaudeExtractor) {
+    extractor.enableToolContent = settings.enableToolContent ?? false;
+  }
 }
 
 /**

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -457,6 +457,51 @@ function formatMessage(
 }
 
 /**
+ * Format tool-use content as a collapsible callout or equivalent format
+ *
+ * Renders tool content (web search, code interpreter) as a separate block
+ * before the assistant response message.
+ *
+ * @param toolContent Raw tool content string (may contain bold summary, queries, results)
+ * @param options Template options for format selection
+ */
+function formatToolContent(toolContent: string, options: TemplateOptions): string {
+  const lines = toolContent.split('\n').filter(l => l.trim());
+
+  // Extract first bold line as callout title (e.g., "**Searched the web**" → "Searched the web")
+  let title = 'Tool Activity';
+  let bodyLines = lines;
+  if (lines[0]?.startsWith('**') && lines[0]?.endsWith('**')) {
+    title = lines[0].slice(2, -2);
+    bodyLines = lines.slice(1);
+  }
+
+  switch (options.messageFormat) {
+    case 'callout': {
+      // Collapsible callout: [!ABSTRACT]- collapsed by default
+      if (bodyLines.length === 0) {
+        return `> [!ABSTRACT]- ${title}`;
+      }
+      const formatted = bodyLines.map(line => `> ${line}`);
+      return `> [!ABSTRACT]- ${title}\n${formatted.join('\n')}`;
+    }
+
+    case 'blockquote': {
+      const header = `**${title}**`;
+      const quoted = bodyLines.map(line => `> ${line}`);
+      return quoted.length > 0 ? `${header}\n${quoted.join('\n')}` : header;
+    }
+
+    case 'plain':
+    default: {
+      return bodyLines.length > 0
+        ? `**${title}**\n${bodyLines.join('\n')}`
+        : `**${title}**`;
+    }
+  }
+}
+
+/**
  * Convert conversation data to Obsidian note
  */
 export function conversationToNote(data: ConversationData, options: TemplateOptions): ObsidianNote {
@@ -493,6 +538,10 @@ export function conversationToNote(data: ConversationData, options: TemplateOpti
     const bodyParts: string[] = [];
 
     for (const message of data.messages) {
+      // Render tool content as separate collapsible callout before assistant message
+      if (message.toolContent) {
+        bodyParts.push(formatToolContent(message.toolContent, options));
+      }
       const formatted = formatMessage(message.content, message.role, options, data.source);
       bodyParts.push(formatted);
     }

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -494,9 +494,7 @@ function formatToolContent(toolContent: string, options: TemplateOptions): strin
 
     case 'plain':
     default: {
-      return bodyLines.length > 0
-        ? `**${title}**\n${bodyLines.join('\n')}`
-        : `**${title}**`;
+      return bodyLines.length > 0 ? `**${title}**\n${bodyLines.join('\n')}` : `**${title}**`;
     }
   }
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -44,6 +44,7 @@ const DEFAULT_SYNC_SETTINGS: SyncSettings = {
   outputOptions: DEFAULT_OUTPUT_OPTIONS,
   enableAutoScroll: false,
   enableAppendMode: false,
+  enableToolContent: false,
 };
 
 const DEFAULT_SETTINGS: ExtensionSettings = {
@@ -81,6 +82,8 @@ export async function getSettings(): Promise<ExtensionSettings> {
         syncResult.settings?.enableAutoScroll ?? DEFAULT_SYNC_SETTINGS.enableAutoScroll,
       enableAppendMode:
         syncResult.settings?.enableAppendMode ?? DEFAULT_SYNC_SETTINGS.enableAppendMode,
+      enableToolContent:
+        syncResult.settings?.enableToolContent ?? DEFAULT_SYNC_SETTINGS.enableToolContent,
     };
   } catch (error) {
     console.error('[G2O] Failed to get settings:', error);
@@ -134,6 +137,9 @@ export async function saveSettings(settings: Partial<ExtensionSettings>): Promis
     }
     if (settings.enableAppendMode !== undefined) {
       syncData.enableAppendMode = settings.enableAppendMode;
+    }
+    if (settings.enableToolContent !== undefined) {
+      syncData.enableToolContent = settings.enableToolContent;
     }
 
     if (Object.keys(syncData).length > 0) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,8 @@ export interface ConversationMessage {
   content: string;
   /** Original HTML content (for assistant messages, used in HTML→Markdown conversion) */
   htmlContent?: string;
+  /** Tool-use content (web search, code interpreter) — rendered as separate callout */
+  toolContent?: string;
   /** Message timestamp (reserved for future use - not currently extracted) */
   timestamp?: Date;
   /** Zero-based message order in conversation */
@@ -172,6 +174,8 @@ export interface SyncSettings {
   enableAutoScroll: boolean;
   /** Enable append mode to only add new messages to existing notes */
   enableAppendMode: boolean;
+  /** Include tool-use / intermediate content (e.g., web search results) */
+  enableToolContent: boolean;
 }
 
 /**

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -86,6 +86,19 @@
                 <span class="slider" aria-hidden="true"></span>
               </span>
             </label>
+            <label class="toggle-row">
+              <span class="toggle-icon">🔍</span>
+              <span class="toggle-label">
+                <span data-i18n="settings_enableToolContent">Include tool/search results</span>
+                <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
+                  Save web search and tool results from Claude
+                </span>
+              </span>
+              <span class="toggle-switch">
+                <input type="checkbox" id="enableToolContent" role="switch" aria-checked="false" />
+                <span class="slider" aria-hidden="true"></span>
+              </span>
+            </label>
           </div>
         </section>
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -81,6 +81,7 @@ const elements = {
   includeMessageCount: getElement<HTMLInputElement>('includeMessageCount'),
   enableAutoScroll: getElement<HTMLInputElement>('enableAutoScroll'),
   enableAppendMode: getElement<HTMLInputElement>('enableAppendMode'),
+  enableToolContent: getElement<HTMLInputElement>('enableToolContent'),
   testBtn: getElement<HTMLButtonElement>('testBtn'),
   saveBtn: getElement<HTMLButtonElement>('saveBtn'),
   status: getElement<HTMLDivElement>('status'),
@@ -115,6 +116,7 @@ function populateForm(settings: ExtensionSettings): void {
   // Extraction options
   elements.enableAutoScroll.checked = settings.enableAutoScroll ?? false;
   elements.enableAppendMode.checked = settings.enableAppendMode ?? false;
+  elements.enableToolContent.checked = settings.enableToolContent ?? false;
 
   // Update Obsidian settings section visibility
   updateObsidianSettingsVisibility();
@@ -284,6 +286,7 @@ function collectSettings(): ExtensionSettings {
     outputOptions,
     enableAutoScroll: elements.enableAutoScroll.checked,
     enableAppendMode: elements.enableAppendMode.checked,
+    enableToolContent: elements.enableToolContent.checked,
   };
 }
 

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -715,3 +715,172 @@ describe('conversationToNote with Deep Research links', () => {
     expect(note.body).toContain('[^1]: [Source](https://example.com)');
   });
 });
+
+// ============================================================
+// Tool Content Callout Rendering Tests (REQ-084 Step 5)
+// ============================================================
+
+describe('conversationToNote with toolContent', () => {
+  const defaultOptions: TemplateOptions = {
+    includeId: true,
+    includeTitle: true,
+    includeSource: true,
+    includeTags: true,
+    includeDates: true,
+    includeMessageCount: true,
+    messageFormat: 'callout',
+    userCalloutType: 'QUESTION',
+    assistantCalloutType: 'NOTE',
+  };
+
+  const baseData: ConversationData = {
+    id: 'tc-test',
+    title: 'Tool Content Test',
+    url: 'https://claude.ai/chat/tc-test',
+    source: 'claude',
+    messages: [],
+    extractedAt: new Date('2025-01-10T00:00:00Z'),
+    metadata: {
+      messageCount: 2,
+      userMessageCount: 1,
+      assistantMessageCount: 1,
+      hasCodeBlocks: false,
+    },
+  };
+
+  it('callout format: renders [!ABSTRACT]- callout before [!NOTE] callout', () => {
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Search for Rust', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<p>Here are the results.</p>',
+          toolContent: '**Searched the web**\nRust latest version 2026 (10 results)\n- Rust Versions | Rust Changelogs (releases.rs)',
+          index: 1,
+        },
+      ],
+    };
+
+    const note = conversationToNote(data, defaultOptions);
+
+    // Tool content rendered as [!ABSTRACT]- callout
+    expect(note.body).toContain('> [!ABSTRACT]- Searched the web');
+    expect(note.body).toContain('> Rust latest version 2026 (10 results)');
+    expect(note.body).toContain('> - Rust Versions | Rust Changelogs (releases.rs)');
+    // Assistant response rendered as [!NOTE] callout
+    expect(note.body).toContain('[!NOTE] Claude');
+    expect(note.body).toContain('Here are the results.');
+    // [!ABSTRACT]- appears before [!NOTE]
+    const abstractIdx = note.body.indexOf('[!ABSTRACT]-');
+    const noteIdx = note.body.indexOf('[!NOTE] Claude');
+    expect(abstractIdx).toBeLessThan(noteIdx);
+  });
+
+  it('callout format: summary extracted as title from bold first line', () => {
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Test', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<p>Response</p>',
+          toolContent: '**Analyzed code**\nFile analysis complete',
+          index: 1,
+        },
+      ],
+    };
+
+    const note = conversationToNote(data, defaultOptions);
+
+    expect(note.body).toContain('> [!ABSTRACT]- Analyzed code');
+    expect(note.body).toContain('> File analysis complete');
+  });
+
+  it('callout format: no body renders title-only callout', () => {
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Test', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<p>Response</p>',
+          toolContent: '**Searched the web**',
+          index: 1,
+        },
+      ],
+    };
+
+    const note = conversationToNote(data, defaultOptions);
+
+    expect(note.body).toContain('> [!ABSTRACT]- Searched the web');
+    // Should not have extra empty body lines
+    expect(note.body).not.toMatch(/> \[!ABSTRACT\]- Searched the web\n>/);
+  });
+
+  it('blockquote format: renders bold title + blockquoted body', () => {
+    const options = { ...defaultOptions, messageFormat: 'blockquote' as const };
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Test', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<p>Response</p>',
+          toolContent: '**Searched the web**\nQuery results here',
+          index: 1,
+        },
+      ],
+    };
+
+    const note = conversationToNote(data, options);
+
+    expect(note.body).toContain('**Searched the web**');
+    expect(note.body).toContain('> Query results here');
+  });
+
+  it('plain format: renders bold title + plain body', () => {
+    const options = { ...defaultOptions, messageFormat: 'plain' as const };
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Test', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<p>Response</p>',
+          toolContent: '**Searched the web**\nQuery results here',
+          index: 1,
+        },
+      ],
+    };
+
+    const note = conversationToNote(data, options);
+
+    expect(note.body).toContain('**Searched the web**');
+    expect(note.body).toContain('Query results here');
+    // Should not have blockquote markers in plain mode
+    expect(note.body).not.toContain('> Query results here');
+    expect(note.body).not.toContain('[!ABSTRACT]');
+  });
+
+  it('no toolContent: assistant message renders normally', () => {
+    const data: ConversationData = {
+      ...baseData,
+      messages: [
+        { id: 'u0', role: 'user', content: 'Hello', index: 0 },
+        { id: 'a1', role: 'assistant', content: '<p>Hi there!</p>', index: 1 },
+      ],
+    };
+
+    const note = conversationToNote(data, defaultOptions);
+
+    expect(note.body).not.toContain('[!ABSTRACT]');
+    expect(note.body).toContain('[!NOTE] Claude');
+    expect(note.body).toContain('Hi there!');
+  });
+});

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -13,6 +13,7 @@ import {
   createClaudePage,
   createClaudeDeepResearchPage,
   createEmptyClaudeDeepResearchPanel,
+  createClaudePageWithToolUse,
 } from '../fixtures/dom-helpers';
 
 describe('ClaudeExtractor', () => {
@@ -931,6 +932,259 @@ describe('ClaudeExtractor', () => {
       const title = extractor.getDeepResearchTitle();
 
       expect(title).toBe('Untitled Deep Research Report');
+    });
+  });
+
+  // ========== Tool-Use Content (REQ-084) ==========
+  describe('Tool-Use Content (enableToolContent)', () => {
+    const searchResults = [
+      { title: 'Rust Versions | Rust Changelogs', domain: 'releases.rs' },
+      { title: 'Rust | endoflife.date', domain: 'endoflife.date' },
+      { title: 'Releases · rust-lang/rust', domain: 'github.com' },
+    ];
+
+    it('OFF (default): tool-use .row-start-1 skipped, only .row-start-2 extracted', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Search for Rust' },
+          {
+            role: 'assistant',
+            content: '<p>Here are the results.</p>',
+            toolUse: {
+              summaryText: 'Searched the web',
+              searchQuery: 'Rust latest version',
+              searchResultCount: 3,
+              searchResults,
+            },
+          },
+        ]
+      );
+
+      // Default: enableToolContent = false
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(2);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).toContain('Here are the results.');
+      expect(assistantMsg?.content).not.toContain('Searched the web');
+      expect(assistantMsg?.content).not.toContain('Rust latest version');
+      expect(assistantMsg?.content).not.toContain('releases.rs');
+      expect(assistantMsg?.toolContent).toBeUndefined();
+    });
+
+    it('ON: search query and results extracted into toolContent, response in content', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Search for Rust' },
+          {
+            role: 'assistant',
+            content: '<p>Here are the results.</p>',
+            toolUse: {
+              summaryText: 'Searched the web',
+              searchQuery: 'Rust latest version 2026',
+              searchResultCount: 10,
+              searchResults,
+            },
+          },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(2);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      // toolContent has the tool-use data
+      expect(assistantMsg?.toolContent).toContain('**Searched the web**');
+      expect(assistantMsg?.toolContent).toContain('Rust latest version 2026');
+      expect(assistantMsg?.toolContent).toContain('10 results');
+      expect(assistantMsg?.toolContent).toContain('Rust Versions | Rust Changelogs');
+      expect(assistantMsg?.toolContent).toContain('releases.rs');
+      expect(assistantMsg?.toolContent).toContain('Releases · rust-lang/rust');
+      expect(assistantMsg?.toolContent).toContain('github.com');
+      // content has ONLY the response (no tool content)
+      expect(assistantMsg?.content).toContain('Here are the results.');
+      expect(assistantMsg?.content).not.toContain('**Searched the web**');
+    });
+
+    it('ON: mixed conversation (user → tool-use response → user → normal response) preserves order', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'First question' },
+          {
+            role: 'assistant',
+            content: '<p>First answer with search.</p>',
+            toolUse: {
+              summaryText: 'Searched the web',
+              searchQuery: 'First query',
+              searchResultCount: 5,
+              searchResults: [{ title: 'Result A', domain: 'example.com' }],
+            },
+          },
+          { role: 'user', content: 'Second question' },
+          { role: 'assistant', content: '<p>Second answer (no tool).</p>' },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(4);
+
+      const roles = result.data?.messages.map(m => m.role);
+      expect(roles).toEqual(['user', 'assistant', 'user', 'assistant']);
+
+      // First assistant has tool content in toolContent, response in content
+      expect(result.data?.messages[1].toolContent).toContain('**Searched the web**');
+      expect(result.data?.messages[1].toolContent).toContain('Result A');
+      expect(result.data?.messages[1].content).toContain('First answer with search.');
+      expect(result.data?.messages[1].content).not.toContain('**Searched the web**');
+      // Second assistant has no tool content
+      expect(result.data?.messages[3].content).toContain('Second answer (no tool).');
+      expect(result.data?.messages[3].toolContent).toBeUndefined();
+    });
+
+    it('ON: Extended Thinking .row-start-1 still skipped (not tool-use)', async () => {
+      setClaudeLocation('12345678-1234-1234-1234-123456789012');
+      createClaudePage('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Think about this' },
+        {
+          role: 'assistant',
+          content: '<p>My response after thinking.</p>',
+          thinking: ['Internal reasoning step 1', 'Internal reasoning step 2'],
+        },
+      ]);
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).toContain('My response after thinking.');
+      // Extended Thinking content should NOT be extracted even when enableToolContent is ON
+      expect(assistantMsg?.content).not.toContain('Internal reasoning step 1');
+      expect(assistantMsg?.content).not.toContain('Internal reasoning step 2');
+      expect(assistantMsg?.toolContent).toBeUndefined();
+    });
+
+    it('ON: content sanitized (DOMPurify applied to .standard-markdown tool content)', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Test' },
+          {
+            role: 'assistant',
+            content: '<p>Response</p>',
+            toolUse: {
+              summaryText: 'Analyzed code',
+              toolSteps: ['<script>alert("xss")</script>Safe analysis content'],
+            },
+          },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.toolContent).toContain('Safe analysis content');
+      expect(assistantMsg?.toolContent).not.toContain('<script>');
+    });
+
+    it('ON: button summary text extracted as bold into toolContent', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Search something' },
+          {
+            role: 'assistant',
+            content: '<p>Results below.</p>',
+            toolUse: { summaryText: 'Gathered API documentation for Express.js' },
+          },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.toolContent).toContain('**Gathered API documentation for Express.js**');
+      expect(assistantMsg?.content).not.toContain('**Gathered API documentation for Express.js**');
+    });
+
+    it('ON: multiple .standard-markdown blocks in .row-start-1 all extracted into toolContent', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Research this topic' },
+          {
+            role: 'assistant',
+            content: '<p>Final summary.</p>',
+            toolUse: {
+              summaryText: 'Analyzed files',
+              toolSteps: ['First analysis result', 'Second analysis result'],
+            },
+          },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.toolContent).toContain('First analysis result');
+      expect(assistantMsg?.toolContent).toContain('Second analysis result');
+      expect(assistantMsg?.content).toContain('Final summary.');
+      expect(assistantMsg?.content).not.toContain('First analysis result');
+    });
+
+    it('OFF: regression — normal (non-grid) responses unaffected', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Hello Claude' },
+          { role: 'assistant', content: '<p>Hello! How can I help?</p>' },
+        ]
+      );
+
+      // enableToolContent stays false (default)
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.messages.length).toBe(2);
+      expect(result.data?.messages[0].role).toBe('user');
+      expect(result.data?.messages[1].role).toBe('assistant');
+      expect(result.data?.messages[1].content).toContain('Hello! How can I help?');
+    });
+
+    it('ON: search with no results list → summary + query in toolContent, response in content', async () => {
+      createClaudePageWithToolUse(
+        '12345678-1234-1234-1234-123456789012',
+        [
+          { role: 'user', content: 'Quick search' },
+          {
+            role: 'assistant',
+            content: '<p>Here is what I found.</p>',
+            toolUse: {
+              summaryText: 'Searched the web',
+              searchQuery: 'Quick topic',
+              searchResultCount: 5,
+              // No searchResults — only query, no result items
+            },
+          },
+        ]
+      );
+
+      extractor.enableToolContent = true;
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.toolContent).toContain('**Searched the web**');
+      expect(assistantMsg?.toolContent).toContain('Quick topic');
+      expect(assistantMsg?.toolContent).toContain('5 results');
+      expect(assistantMsg?.content).toContain('Here is what I found.');
+      expect(assistantMsg?.content).not.toContain('**Searched the web**');
     });
   });
 

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -677,6 +677,158 @@ function escapeHtmlForClaude(text: string): string {
 }
 
 
+/**
+ * Search result item for tool-use test fixtures
+ */
+interface SearchResultItem {
+  title: string;
+  domain: string;
+}
+
+/**
+ * Options for creating a tool-use grid block
+ */
+interface ToolUseGridOptions {
+  /** Summary button text (e.g., "Searched the web") */
+  summaryText: string;
+  /** Search query text (e.g., "Rust latest version 2026") */
+  searchQuery?: string;
+  /** Number of search results (e.g., 10) */
+  searchResultCount?: number;
+  /** Search result items with title and domain */
+  searchResults?: SearchResultItem[];
+  /** Intermediate text blocks in .standard-markdown within .row-start-1 */
+  toolSteps?: string[];
+  /** Response text in .row-start-2 */
+  responseText: string;
+}
+
+/**
+ * Create a tool-use assistant response inside .font-claude-response
+ *
+ * Matches the real Claude DOM structure verified via DevTools:
+ * .row-start-1 = tool activity (summary button, search query, search results, intermediate text)
+ * .row-start-2 = summary/response text
+ *
+ * @see docs/design/DES-006-tool-use-content.md
+ */
+export function createClaudeToolUseBlock(options: ToolUseGridOptions): string {
+  const toolStepsHtml = (options.toolSteps ?? [])
+    .map(step => `
+              <div class="standard-markdown grid-cols-1 grid">
+                <p class="font-claude-response-body text-sm">${step}</p>
+              </div>`)
+    .join('\n');
+
+  // Search query button (group/row)
+  const searchQueryHtml = options.searchQuery ? `
+              <div class="flex flex-col shrink-0">
+                <div class="transition-colors rounded-lg duration-150">
+                  <div class="flex flex-row items-center py-1">
+                    <div class="flex-1 min-w-0">
+                      <button class="group/row flex flex-row items-center rounded-lg px-2.5 w-full justify-between text-text-300 !cursor-default">
+                        <div class="flex flex-row items-center gap-2 min-w-0 flex-1">
+                          <div class="text-sm text-text-500 text-left truncate w-0 flex-grow">${escapeHtmlForClaude(options.searchQuery)}</div>
+                        </div>
+                        <div class="flex flex-row items-center gap-1.5 shrink-0">
+                          <p class="pl-1 text-text-500 font-small shrink-0 whitespace-nowrap">${options.searchResultCount ?? 0} results</p>
+                        </div>
+                      </button>
+                    </div>
+                  </div>` + (options.searchResults ? `
+                  <div class="flex flex-row">
+                    <div class="flex-1 min-w-0">
+                      <div class="border-[0.5px] border-border-300 rounded-lg p-1 mx-2.5 mt-1 mb-2 max-h-[150px] overflow-y-auto bg-bg-000/50">
+                        <div class="flex flex-col gap-1">${options.searchResults.map(r => `
+                          <div class="flex flex-row gap-3 items-center px-2 py-1.5 w-full rounded-md cursor-pointer transition-colors hover:bg-bg-200">
+                            <div class="flex-shrink-0"><img alt="favicon" loading="lazy" width="12" height="12" src="" /></div>
+                            <div class="w-0 flex-grow font-small text-text-300 truncate">${escapeHtmlForClaude(r.title)}</div>
+                            <div class="text-xs text-text-400 shrink-0">${escapeHtmlForClaude(r.domain)}</div>
+                          </div>`).join('')}
+                        </div>
+                      </div>
+                    </div>
+                  </div>` : '') + `
+                </div>
+              </div>` : '';
+
+  return `
+    <div data-test-render-count="2" class="group" style="height: auto;">
+      <div class="font-claude-response" data-is-streaming="false">
+        <div><div class="grid grid-rows-[auto_auto] min-w-0">
+          <div class="row-start-1 col-start-1 min-w-0">
+            <div class="min-w-0 pl-2 py-1.5">
+              <button class="group/status"><span class="truncate text-sm font-base">${escapeHtmlForClaude(options.summaryText)}</span></button>
+              ${searchQueryHtml}
+              ${toolStepsHtml}
+            </div>
+          </div>
+          <div class="row-start-2 col-start-1 relative grid isolate min-w-0">
+            <div class="standard-markdown">${options.responseText}</div>
+          </div>
+        </div></div>
+      </div>
+    </div>`;
+}
+
+/**
+ * Create a Claude page with tool-use blocks in the conversation
+ *
+ * Each message can optionally include tool-use grid structure.
+ * Tool-use is specified on assistant messages via the `toolUse` property.
+ *
+ * @param conversationId UUID for URL
+ * @param messages Conversation messages (assistant messages may include toolUse)
+ */
+export function createClaudePageWithToolUse(
+  conversationId: string,
+  messages: Array<ClaudeConversationMessage & { toolUse?: Omit<ToolUseGridOptions, 'responseText'> }>
+): void {
+  setClaudeLocation(conversationId);
+
+  const blocks: string[] = [];
+
+  messages.forEach((msg) => {
+    if (msg.role === 'user') {
+      blocks.push(`
+        <div data-test-render-count="2" class="group" style="height: auto;">
+          <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
+            <div data-testid="user-message">
+              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(msg.content)}</p>
+            </div>
+            <span class="text-text-500 text-xs" data-state="closed">Dec 6, 2025</span>
+          </div>
+        </div>
+      `);
+    } else if (msg.toolUse) {
+      // Assistant message with tool-use grid structure
+      blocks.push(createClaudeToolUseBlock({
+        ...msg.toolUse,
+        responseText: msg.content,
+      }));
+    } else {
+      // Normal assistant message
+      blocks.push(`
+        <div data-test-render-count="2" class="group" style="height: auto;">
+          <div class="font-claude-response" data-is-streaming="false">
+            <div class="standard-markdown">
+              ${msg.content}
+            </div>
+          </div>
+        </div>
+      `);
+    }
+  });
+
+  loadFixture(`
+    <div class="app-container">
+      <div class="conversation-thread">
+        ${blocks.join('\n')}
+      </div>
+    </div>
+  `);
+}
+
 // ========== ChatGPT DOM Helpers ==========
 
 /**

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -86,6 +86,11 @@ describe('storage', () => {
       expect(settings.templateOptions.includeId).toBe(true); // default preserved
     });
 
+    it('returns default enableToolContent false when empty', async () => {
+      const settings = await getSettings();
+      expect(settings.enableToolContent).toBe(false);
+    });
+
     it('returns default settings on error', async () => {
       vi.mocked(chrome.storage.local.get).mockRejectedValue(
         new Error('Storage error')
@@ -148,6 +153,16 @@ describe('storage', () => {
       await expect(saveSettings({ obsidianApiKey: 'key' })).rejects.toThrow(
         'Save failed'
       );
+    });
+
+    it('round-trips enableToolContent true', async () => {
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({ settings: {} });
+
+      await saveSettings({ enableToolContent: true });
+
+      expect(chrome.storage.sync.set).toHaveBeenCalled();
+      const callArgs = vi.mocked(chrome.storage.sync.set).mock.calls[0][0];
+      expect(callArgs.settings.enableToolContent).toBe(true);
     });
 
     it('merges outputOptions with current settings', async () => {

--- a/test/popup/index.test.ts
+++ b/test/popup/index.test.ts
@@ -126,6 +126,7 @@ describe('popup/index patterns', () => {
         <input id="includeSource" type="checkbox">
         <input id="includeDates" type="checkbox">
         <input id="includeMessageCount" type="checkbox">
+        <input id="enableToolContent" type="checkbox">
       `;
     });
 
@@ -180,6 +181,14 @@ describe('popup/index patterns', () => {
       expect(assistantCallout.value).toBe('NOTE');
     });
 
+    it('populates enableToolContent checkbox', () => {
+      const enableToolContent = document.getElementById('enableToolContent') as HTMLInputElement;
+      const settings = { enableToolContent: true };
+
+      enableToolContent.checked = settings.enableToolContent ?? false;
+      expect(enableToolContent.checked).toBe(true);
+    });
+
     it('populates checkbox fields', () => {
       const includeId = document.getElementById('includeId') as HTMLInputElement;
       const includeTags = document.getElementById('includeTags') as HTMLInputElement;
@@ -213,6 +222,7 @@ describe('popup/index patterns', () => {
         <input id="includeSource" type="checkbox" checked>
         <input id="includeDates" type="checkbox" checked>
         <input id="includeMessageCount" type="checkbox" checked>
+        <input id="enableToolContent" type="checkbox" checked>
       `;
     });
 
@@ -262,6 +272,16 @@ describe('popup/index patterns', () => {
       expect(settings.obsidianPort).toBe(27123);
       expect(settings.vaultPath).toBe('AI/Gemini');
       expect(settings.templateOptions.messageFormat).toBe('callout');
+    });
+
+    it('collectSettings includes enableToolContent', () => {
+      const enableToolContent = document.getElementById('enableToolContent') as HTMLInputElement;
+      expect(enableToolContent.checked).toBe(true);
+
+      const settings = {
+        enableToolContent: enableToolContent.checked,
+      };
+      expect(settings.enableToolContent).toBe(true);
     });
 
     it('trims whitespace from text inputs', () => {


### PR DESCRIPTION
Closes #84

## Summary

- Add `toolContent?: string` field to `ConversationMessage` to cleanly separate tool-use data from response content at the data model level
- Revert `extractAssistantContent()` to return only `.row-start-2` response; add `extractToolContentFromElement()` and attach via index Map in `extractMessages()`
- Add `formatToolContent()` in `markdown.ts` — renders tool content as collapsible `[!ABSTRACT]-` callout (callout mode), bold+blockquote (blockquote mode), or bold+plain (plain mode)
- Insert tool callout before assistant message in `conversationToNote()` loop
- Add enableToolContent toggle UI, storage, i18n (en/ja), and content script wiring (from prior REQ-084 steps)
- Add design doc (DES-006), requirements doc (REQ-084), workflow doc (WF-084), and analysis report
- Update 8 existing tool-use test assertions for separated `toolContent` field; add 6 new callout rendering tests

## Test plan

- [x] `npm run build` succeeds (0 TypeScript errors)
- [x] `npm run lint` passes (0 ESLint errors/warnings)
- [x] `npx vitest run` passes (732 tests, 28 test files)
- [ ] Manual test: enable Tool Content toggle, extract Claude conversation with web search, verify `[!ABSTRACT]-` callout appears before `[!NOTE]` response in Obsidian
- [ ] Manual test: verify Extended Thinking conversations are unaffected (no `toolContent`)
- [ ] Manual test: verify toggle OFF still produces clean extraction without tool content

🤖 Generated with [Claude Code](https://claude.com/claude-code)