### PR TITLE
docs: add tool content feature to README (en/ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,7 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
 - **Deep Research 対応**: Gemini Deep Research と Claude Extended Thinking レポートを保存
 - **Artifact 対応**: Claude Artifacts をインライン引用とソース付きで抽出
+- **ツールコンテンツ対応**: Claude の Web 検索結果やツール活動を折りたたみ可能な `[!ABSTRACT]` コールアウトとして保存（オプション）
 - **追記モード**: 既存ノートには新しいメッセージのみを追加
 - **Obsidian コールアウト**: `[!QUESTION]` と `[!NOTE]` による見やすいフォーマット
 - **YAML フロントマター**: タイトル、ソース、URL、日時、タグなどのメタデータを自動生成
@@ -136,6 +137,22 @@ message_count: 4
 > [!NOTE] Gemini
 > JWT 認証を実装するには...
 ```
+
+### ツールコンテンツ形式（Claude）
+
+「ツール/検索結果を含める」を有効にすると、Claude の Web 検索やツール活動がアシスタント応答の前に折りたたみコールアウトとして表示されます:
+
+```markdown
+> [!ABSTRACT]- Searched the web
+> Rust latest version 2026 (10 results)
+> - Rust Versions | Rust Changelogs (releases.rs)
+> - Rust | endoflife.date (endoflife.date)
+
+> [!NOTE] Claude
+> Rust の最新バージョンについて...
+```
+
+`[!ABSTRACT]-` コールアウトは Obsidian でデフォルトで折りたたまれます（`-` サフィックス）。
 
 ### Deep Research 形式
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
 - **Deep Research support**: Export Gemini Deep Research and Claude Extended Thinking reports
 - **Artifact support**: Extract Claude Artifacts with inline citations and sources
+- **Tool content support**: Optionally include Claude's web search results and tool activity as collapsible `[!ABSTRACT]` callouts
 - **Append mode**: Only new messages are added to existing notes
 - **Obsidian callouts**: Formatted output with `[!QUESTION]` and `[!NOTE]` callouts
 - **YAML frontmatter**: Metadata including title, source, URL, dates, and tags
@@ -136,6 +137,22 @@ message_count: 4
 > [!NOTE] Gemini
 > To implement JWT authentication, you'll need to...
 ```
+
+### Tool Content Format (Claude)
+
+When "Include tool/search results" is enabled, Claude's web search and tool activity are rendered as collapsible callouts before the assistant response:
+
+```markdown
+> [!ABSTRACT]- Searched the web
+> Rust latest version 2026 (10 results)
+> - Rust Versions | Rust Changelogs (releases.rs)
+> - Rust | endoflife.date (endoflife.date)
+
+> [!NOTE] Claude
+> Here are the latest Rust version details...
+```
+
+The `[!ABSTRACT]-` callout is collapsed by default in Obsidian (the `-` suffix).
 
 ### Deep Research Format
 


### PR DESCRIPTION
## Summary

- Add "Tool content support" to Features list in both README.md and README.ja.md
- Add "Tool Content Format (Claude)" section with `[!ABSTRACT]-` callout output example in both READMEs
- `src/_locales/` and `src/manifest.json` are already up to date from PR #93

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify README.ja.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)