### PR TITLE
fix: guard against unhandled rejections in background and content scripts

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -51,10 +51,20 @@ chrome.runtime.onMessage.addListener(
     }
 
     handleMessage(message)
-      .then(sendResponse)
+      .then(response => {
+        try {
+          sendResponse(response);
+        } catch {
+          /* sender disconnected */
+        }
+      })
       .catch(error => {
         console.error('[G2O Background] Error handling message:', error);
-        sendResponse({ success: false, error: getErrorMessage(error) });
+        try {
+          sendResponse({ success: false, error: getErrorMessage(error) });
+        } catch {
+          /* sender disconnected */
+        }
       });
     return true; // Indicates async response
   }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -173,9 +173,15 @@ function getExtractor(): IConversationExtractor | null {
 
 // Initialize when DOM is ready
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initialize);
+  document.addEventListener('DOMContentLoaded', () => {
+    initialize().catch(error => {
+      console.error('[G2O] Content script initialization failed:', error);
+    });
+  });
 } else {
-  initialize();
+  initialize().catch(error => {
+    console.error('[G2O] Content script initialization failed:', error);
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Wrap `sendResponse()` calls in background service worker with try-catch to handle sender disconnect gracefully
- Add `.catch()` to async `initialize()` calls in content script to prevent unhandled rejections

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (734/734)
- [x] `npx tsc --noEmit` passes
- [x] `npm run format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)