### PR TITLE
security: override rollup to 2.80.0 to fix CVE-2026-27606 path traversal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4811,9 +4811,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
     "vite-plugin-static-copy": "^3.1.4",
     "vitest": "^4.0.16"
   },
+  "overrides": {
+    "@crxjs/vite-plugin": {
+      "rollup": "2.80.0"
+    }
+  },
   "author": "",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

- Add npm `overrides` in package.json to force `@crxjs/vite-plugin` to use `rollup@2.80.0` (backport security fix)
- Resolves Dependabot alert #9: CVE-2026-27606 (Arbitrary File Write via Path Traversal in Rollup)
- `rollup@2.80.0` is a security-only backport release (`backports-2` dist-tag), minimizing compatibility risk

## Test plan

- [x] `npm run build` succeeds (401ms, all 41 modules)
- [x] `npm run test` passes (742 tests, 28 test files)
- [x] `npm ls rollup` confirms `2.80.0 overridden` for @crxjs/vite-plugin
- [x] `npm audit` reports 0 vulnerabilities
- [ ] Verify Dependabot alert #9 is auto-closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)