### PR TITLE
fix(popup): compact layout with sticky footer and reorganized settings

### DIFF
--- a/docs/design/DES-013-popup-compact-layout.md
+++ b/docs/design/DES-013-popup-compact-layout.md
@@ -1,0 +1,255 @@
+# DES-013: Popup UI コンパクト化 — フッター固定 + 設定再配置
+
+## Context
+
+**Problem**: Chrome拡張ポップアップの高さ上限（~600px）に対し、デフォルト表示の要素が多すぎて **Test Connection** / **Save Settings** ボタンが画面外に押し出される。設定項目は一度決めたら頻繁に変えないため、デフォルト表示は最小限でよい。
+
+**Approach**: C（上級者向け設定を Advanced へ移動）+ D（フッター常時固定）の組み合わせ。
+
+## Design Decisions
+
+### 1. フッター常時表示（Sticky Footer）
+
+Chrome拡張ポップアップは `max-height: 600px` の制約がある。Advanced Settings を展開すると総コンテンツ高が 600px を超えるため、フッターをビューポート下部に固定し `main.settings` のみスクロール可能にする。
+
+```
+┌──────────────────────┐
+│  header (flex-shrink:0)│  ← 固定
+├──────────────────────┤
+│  main.settings        │  ← flex:1, overflow-y:auto
+│  (scrollable)         │
+├──────────────────────┤
+│  footer (flex-shrink:0)│  ← 固定
+│  status (flex-shrink:0)│  ← 固定
+└──────────────────────┘
+```
+
+**CSS変更**:
+
+```css
+body {
+  width: 380px;
+- min-height: 480px;
++ max-height: 600px;
++ overflow: hidden;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+- min-height: 100%;
++ height: 100%;
++ max-height: 600px;
+}
+
++ .header {
++   flex-shrink: 0;
++ }
+
+.settings {
+  flex: 1;
+  overflow-y: auto;
++ min-height: 0;    /* flex子要素のoverflow動作に必須 */
+}
+
++ .actions {
++   flex-shrink: 0;
++ }
+
++ .status {
++   flex-shrink: 0;
++ }
+```
+
+> **Note**: `min-height: 0` は flex 子要素のデフォルト `min-height: auto` を上書きし、`overflow-y: auto` を正しく機能させるために必要。
+
+### 2. ヘッダー subtitle 削除
+
+現在の subtitle（"Export AI conversations from Gemini, Claude, ChatGPT, and Perplexity to Obsidian via Local REST API"）を削除する。拡張名「Obsidian AI Exporter」とアイコンだけで十分識別可能。
+
+**節約**: ~25px
+
+```html
+  <header class="header">
+    <h1>
+      <img src="/icons/icon24.png" alt="" class="logo" width="24" height="24" />
+      <span data-i18n="extName">Obsidian AI Exporter</span>
+    </h1>
+-   <p class="subtitle" data-i18n="extDescription">Export AI conversations to Obsidian</p>
+  </header>
+```
+
+### 3. Extraction セクション再編
+
+**移動対象**: 上級者向け・プラットフォーム固有の2項目を Advanced Settings へ
+
+| 設定 | 現在の位置 | 移動先 | 理由 |
+|------|-----------|--------|------|
+| Auto-scroll | Extraction | Advanced | Gemini専用機能、通常は不要 |
+| Include tool/search results | Extraction | Advanced | Claude専用機能、上級者向け |
+| Append Mode | Extraction | **据え置き** | 全プラットフォーム共通、最も汎用 |
+
+**変更後の Extraction セクション（デフォルト表示）**:
+
+```html
+<section class="section">
+  <h2 data-i18n="settings_extraction">Extraction</h2>
+  <div class="toggle-list">
+    <!-- Append Mode のみ残す -->
+    <label class="toggle-row">
+      <span class="toggle-icon">📎</span>
+      <span class="toggle-label">
+        <span data-i18n="settings_enableAppendMode">Append Mode</span>
+        <span class="toggle-sublabel" data-i18n="settings_appendModeHelp">
+          Only add new messages to existing notes
+        </span>
+      </span>
+      <span class="toggle-switch">
+        <input type="checkbox" id="enableAppendMode" role="switch" aria-checked="false" />
+        <span class="slider" aria-hidden="true"></span>
+      </span>
+    </label>
+  </div>
+</section>
+```
+
+**変更後の Advanced Settings 内部**:
+
+```html
+<details class="advanced-settings">
+  <summary>
+    <span class="advanced-arrow">▶</span>
+    <span data-i18n="settings_advancedSettings">Advanced Settings</span>
+  </summary>
+  <div class="advanced-content">
+    <!-- === 移動してきた Extraction 項目 === -->
+    <section class="section">
+      <h2 data-i18n="settings_extraction">Extraction</h2>
+      <div class="toggle-list">
+        <label class="toggle-row">  <!-- Auto-scroll -->
+          <span class="toggle-icon">🔄</span>
+          <span class="toggle-label">
+            <span data-i18n="settings_enableAutoScroll">Auto-scroll</span>
+            <span class="toggle-sublabel" data-i18n="settings_autoScrollHelp">
+              Load all messages in long conversations
+            </span>
+          </span>
+          <span class="toggle-switch">
+            <input type="checkbox" id="enableAutoScroll" role="switch" aria-checked="false" />
+            <span class="slider" aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="toggle-row">  <!-- Tool Content -->
+          <span class="toggle-icon">🔍</span>
+          <span class="toggle-label">
+            <span data-i18n="settings_enableToolContent">Include tool/search results</span>
+            <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
+              Save web search and tool results from Claude
+            </span>
+          </span>
+          <span class="toggle-switch">
+            <input type="checkbox" id="enableToolContent" role="switch" aria-checked="false" />
+            <span class="slider" aria-hidden="true"></span>
+          </span>
+        </label>
+      </div>
+    </section>
+
+    <!-- === 既存: Obsidian API Settings === -->
+    <section class="section" id="obsidianSettings">
+      ...（変更なし）
+    </section>
+
+    <!-- === 既存: Message Format === -->
+    ...（変更なし）
+
+    <!-- === 既存: Frontmatter Fields === -->
+    ...（変更なし）
+  </div>
+</details>
+```
+
+## 変更後の画面構成
+
+### 折りたたみ時（デフォルト表示）
+
+```
+┌─────────────────────────────┐
+│ 🔮 Obsidian AI Exporter     │
+├─────────────────────────────┤
+│ OUTPUT DESTINATIONS          │
+│  📦 Obsidian (API)    [ON]  │
+│  📄 Download File     [OFF] │
+│  📋 Copy to Clipboard [ON]  │
+│                              │
+│ EXTRACTION                   │
+│  📎 Append Mode       [ON]  │
+│                              │
+│ ▶ ADVANCED SETTINGS          │
+├─────────────────────────────┤
+│ [🔌 Test] [💾 Save Settings]│
+└─────────────────────────────┘
+```
+
+**推定高さ**: ~420px（600px上限に対して十分な余裕）
+
+### 展開時（Advanced Settings 開放）
+
+```
+┌─────────────────────────────┐
+│ 🔮 Obsidian AI Exporter     │
+├─────────────────────────────┤
+│ OUTPUT DESTINATIONS          │  ↑
+│  📦 Obsidian (API)    [ON]  │  │
+│  📄 Download File     [OFF] │  │
+│  📋 Copy to Clipboard [ON]  │  │
+│                              │  │ スクロール可能
+│ EXTRACTION                   │  │
+│  📎 Append Mode       [ON]  │  │
+│                              │  │
+│ ▼ ADVANCED SETTINGS          │  │
+│  EXTRACTION                  │  │
+│   🔄 Auto-scroll     [OFF]  │  │
+│   🔍 Tool results    [ON]   │  │
+│  SETTINGS                    │  │
+│   API Key: [****]            │  │
+│   Port: [27123] Path: [...]  │  │
+│  MESSAGE FORMAT              │  │
+│   [Callout ▼]                │  │
+│   User: [QUESTION]           │  │
+│   Asst: [NOTE]               │  │
+│  FRONTMATTER FIELDS          │  │
+│   [x]ID  [x]Title            │  ↓
+├─────────────────────────────┤
+│ [🔌 Test] [💾 Save Settings]│  ← 常に表示
+└─────────────────────────────┘
+```
+
+**推定高さ**: ~770px（600px超だが main のみスクロール、フッターは固定）
+
+## 変更ファイル一覧
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/popup/styles.css` | body max-height、container height、flex-shrink追加、subtitle CSS削除可 | ~10行 |
+| `src/popup/index.html` | subtitle 削除、Auto-scroll/Tool Content を Advanced へ移動 | ~20行移動 |
+
+## 変更しないファイル
+
+| File | Reason |
+|------|--------|
+| `src/popup/index.ts` | `getElementById` はDOM位置に依存しない。全IDは変更なし |
+| `src/_locales/*/messages.json` | 既存i18nキーの再利用、新規キー不要 |
+| `test/popup/index.test.ts` | validation/storage パターンのテスト、DOM構造に非依存 |
+
+## Verification
+
+1. `npm run build` — TypeScript / Vite ビルド成功
+2. `npm run lint` — 0 errors
+3. `npm test` — 全テスト通過（popup テストは DOM 構造に非依存）
+4. Chrome で拡張を読み込み、以下を目視確認:
+   - デフォルト表示で Test Connection / Save Settings ボタンが見える
+   - Advanced Settings 展開時に main 部分のみスクロールする
+   - フッターが常に画面下部に固定されている
+   - 全トグルが正しく動作する（移動した項目含む）
+   - 設定の保存・読み込みが正常に動作する

--- a/docs/workflow/WF-013-popup-compact-layout.md
+++ b/docs/workflow/WF-013-popup-compact-layout.md
@@ -1,0 +1,258 @@
+# WF-013: Popup UI コンパクト化 実装ワークフロー
+
+**Design**: [DES-013](../design/DES-013-popup-compact-layout.md)
+**Scope**: `src/popup/styles.css`, `src/popup/index.html`
+**JS変更**: なし
+**テスト変更**: なし
+
+---
+
+## Pre-flight
+
+- [ ] `main` ブランチ最新を確認
+- [ ] `feature/popup-compact-layout` ブランチを作成
+
+---
+
+## Step 1: CSS — Sticky Footer レイアウト
+
+**File**: `src/popup/styles.css`
+
+### 1.1 body の高さ制約
+
+```css
+/* Before */
+body {
+  width: 380px;
+  min-height: 480px;
+  ...
+}
+
+/* After */
+body {
+  width: 380px;
+  max-height: 600px;
+  overflow: hidden;
+  ...
+}
+```
+
+- `min-height: 480px` → 削除
+- `max-height: 600px` → 追加（Chrome拡張ポップアップ上限）
+- `overflow: hidden` → 追加（body自体はスクロールさせない）
+
+### 1.2 container の高さ指定
+
+```css
+/* Before */
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+/* After */
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 600px;
+}
+```
+
+### 1.3 flex-shrink 追加
+
+```css
+/* 追加 */
+.header {
+  ...
+  flex-shrink: 0;
+}
+```
+
+```css
+/* 追加 */
+.actions {
+  ...
+  flex-shrink: 0;
+}
+```
+
+```css
+/* 追加 */
+.status {
+  ...
+  flex-shrink: 0;
+}
+```
+
+### 1.4 settings の min-height
+
+```css
+/* 追加 */
+.settings {
+  ...
+  min-height: 0;
+}
+```
+
+> `min-height: 0` は flex子要素の `overflow-y: auto` を正しく動作させるために必須。
+
+### 1.5 subtitle CSS の整理（任意）
+
+`.header .subtitle` ルールは HTML から要素を削除するため不要になる。削除しても残しても動作に影響なし。コード品質のため削除推奨。
+
+### Checkpoint 1
+
+```bash
+npm run build && npm run lint
+```
+
+- [ ] ビルド成功
+- [ ] lint 0 errors
+
+---
+
+## Step 2: HTML — subtitle 削除
+
+**File**: `src/popup/index.html`
+
+### 2.1 subtitle 行を削除
+
+```html
+<!-- 削除 -->
+<p class="subtitle" data-i18n="extDescription">Export AI conversations to Obsidian</p>
+```
+
+ヘッダーは以下のみ残る:
+
+```html
+<header class="header">
+  <h1>
+    <img src="/icons/icon24.png" alt="" class="logo" width="24" height="24" />
+    <span data-i18n="extName">Obsidian AI Exporter</span>
+  </h1>
+</header>
+```
+
+### Checkpoint 2
+
+```bash
+npm run build
+```
+
+- [ ] ビルド成功（HTML変更のみなので lint 不要）
+
+---
+
+## Step 3: HTML — Extraction セクション再編
+
+**File**: `src/popup/index.html`
+
+### 3.1 Extraction から Auto-scroll と Tool Content を切り出す
+
+現在の Extraction セクション（3つのtoggle-row）から、以下2つの `<label class="toggle-row">` ブロックを**カット**する:
+
+1. `id="enableAutoScroll"` を含む toggle-row（L63-75）
+2. `id="enableToolContent"` を含む toggle-row（L89-101）
+
+Extraction セクションには `id="enableAppendMode"` のみ残る。
+
+### 3.2 Advanced Settings の先頭に Extraction セクションを追加
+
+`<div class="advanced-content">` の直後、既存の `<section id="obsidianSettings">` の前に、新しい section を挿入:
+
+```html
+<div class="advanced-content">
+  <!-- Extraction (Advanced) -->
+  <section class="section">
+    <h2 data-i18n="settings_extraction">Extraction</h2>
+    <div class="toggle-list">
+      <!-- Step 3.1 で切り出した Auto-scroll toggle-row -->
+      <!-- Step 3.1 で切り出した Tool Content toggle-row -->
+    </div>
+  </section>
+
+  <!-- Obsidian API Settings (既存・変更なし) -->
+  <section class="section" id="obsidianSettings">
+    ...
+```
+
+### 3.3 確認事項
+
+- [ ] 全ての `id` 属性が重複なく保持されている
+- [ ] `data-i18n` 属性がそのまま維持されている
+- [ ] toggle-row の構造（icon, label, sublabel, switch）が崩れていない
+
+### Checkpoint 3
+
+```bash
+npm run build && npm run lint
+```
+
+- [ ] ビルド成功
+- [ ] lint 0 errors
+
+---
+
+## Step 4: 自動テスト
+
+```bash
+npm test
+```
+
+- [ ] 全テスト通過
+- [ ] popup テスト含め regression なし
+
+---
+
+## Step 5: 目視検証（Chrome 拡張）
+
+```bash
+npm run build
+```
+
+Chrome で `dist/` フォルダをリロードし、以下を確認:
+
+### 5.1 折りたたみ時（デフォルト）
+
+- [ ] ヘッダーにタイトルとアイコンのみ表示（subtitle なし）
+- [ ] Output Destinations: 3つのトグルが表示
+- [ ] Extraction: Append Mode のみ表示
+- [ ] Advanced Settings: 折りたたみ状態
+- [ ] **Test Connection / Save Settings ボタンが画面内に見えている**
+
+### 5.2 展開時（Advanced 開放）
+
+- [ ] Advanced 内の先頭に Auto-scroll と Tool Content が表示
+- [ ] その下に API Key, Port, Vault Path, Message Format, Frontmatter が表示
+- [ ] **main 部分がスクロール可能**
+- [ ] **フッターのボタンが固定表示されている**
+
+### 5.3 機能確認
+
+- [ ] 全トグルの ON/OFF が動作する
+- [ ] Save Settings で全設定が保存される
+- [ ] ページリロード後、保存した設定が復元される
+- [ ] Test Connection が動作する
+- [ ] Obsidian トグル OFF 時に API Settings セクションが disabled になる
+
+### 5.4 テーマ確認
+
+- [ ] ライトテーマ: ボタンが見える、スクロール正常
+- [ ] ダークテーマ: 同上
+
+---
+
+## Step 6: コミット & PR
+
+```bash
+git add src/popup/index.html src/popup/styles.css
+git commit -m "fix(popup): compact layout with sticky footer and reorganized settings
+
+Move Auto-scroll and Tool Content toggles to Advanced Settings.
+Remove header subtitle. Fix footer always visible with flex layout."
+```
+
+- [ ] コミット成功
+- [ ] PR 作成

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -13,7 +13,6 @@
           <img src="/icons/icon24.png" alt="" class="logo" width="24" height="24" />
           <span data-i18n="extName">Obsidian AI Exporter</span>
         </h1>
-        <p class="subtitle" data-i18n="extDescription">Export AI conversations to Obsidian</p>
       </header>
 
       <main class="settings">
@@ -61,19 +60,6 @@
           <h2 data-i18n="settings_extraction">Extraction</h2>
           <div class="toggle-list">
             <label class="toggle-row">
-              <span class="toggle-icon">🔄</span>
-              <span class="toggle-label">
-                <span data-i18n="settings_enableAutoScroll">Auto-scroll</span>
-                <span class="toggle-sublabel" data-i18n="settings_autoScrollHelp">
-                  Load all messages in long conversations
-                </span>
-              </span>
-              <span class="toggle-switch">
-                <input type="checkbox" id="enableAutoScroll" role="switch" aria-checked="false" />
-                <span class="slider" aria-hidden="true"></span>
-              </span>
-            </label>
-            <label class="toggle-row">
               <span class="toggle-icon">📎</span>
               <span class="toggle-label">
                 <span data-i18n="settings_enableAppendMode">Append Mode</span>
@@ -83,19 +69,6 @@
               </span>
               <span class="toggle-switch">
                 <input type="checkbox" id="enableAppendMode" role="switch" aria-checked="false" />
-                <span class="slider" aria-hidden="true"></span>
-              </span>
-            </label>
-            <label class="toggle-row">
-              <span class="toggle-icon">🔍</span>
-              <span class="toggle-label">
-                <span data-i18n="settings_enableToolContent">Include tool/search results</span>
-                <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
-                  Save web search and tool results from Claude
-                </span>
-              </span>
-              <span class="toggle-switch">
-                <input type="checkbox" id="enableToolContent" role="switch" aria-checked="false" />
                 <span class="slider" aria-hidden="true"></span>
               </span>
             </label>
@@ -109,6 +82,49 @@
             <span data-i18n="settings_advancedSettings">Advanced Settings</span>
           </summary>
           <div class="advanced-content">
+            <!-- Extraction (Advanced) -->
+            <section class="section">
+              <h2 data-i18n="settings_extraction">Extraction</h2>
+              <div class="toggle-list">
+                <label class="toggle-row">
+                  <span class="toggle-icon">🔄</span>
+                  <span class="toggle-label">
+                    <span data-i18n="settings_enableAutoScroll">Auto-scroll</span>
+                    <span class="toggle-sublabel" data-i18n="settings_autoScrollHelp">
+                      Load all messages in long conversations
+                    </span>
+                  </span>
+                  <span class="toggle-switch">
+                    <input
+                      type="checkbox"
+                      id="enableAutoScroll"
+                      role="switch"
+                      aria-checked="false"
+                    />
+                    <span class="slider" aria-hidden="true"></span>
+                  </span>
+                </label>
+                <label class="toggle-row">
+                  <span class="toggle-icon">🔍</span>
+                  <span class="toggle-label">
+                    <span data-i18n="settings_enableToolContent">Include tool/search results</span>
+                    <span class="toggle-sublabel" data-i18n="settings_toolContentHelp">
+                      Save web search and tool results from Claude
+                    </span>
+                  </span>
+                  <span class="toggle-switch">
+                    <input
+                      type="checkbox"
+                      id="enableToolContent"
+                      role="switch"
+                      aria-checked="false"
+                    />
+                    <span class="slider" aria-hidden="true"></span>
+                  </span>
+                </label>
+              </div>
+            </section>
+
             <!-- Obsidian API Settings -->
             <section class="section" id="obsidianSettings">
               <h2 data-i18n="settings_title">Settings</h2>

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -60,7 +60,8 @@
 
 body {
   width: 380px;
-  min-height: 480px;
+  max-height: 600px;
+  overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -71,7 +72,8 @@ body {
 .container {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  height: 100%;
+  max-height: 600px;
 }
 
 /* Header */
@@ -79,6 +81,7 @@ body {
   padding: 14px 16px;
   background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .header h1 {
@@ -87,7 +90,6 @@ body {
   gap: 10px;
   font-size: 18px;
   font-weight: 600;
-  margin-bottom: 4px;
 }
 
 .header .logo {
@@ -96,16 +98,12 @@ body {
   object-fit: contain;
 }
 
-.header .subtitle {
-  color: var(--text-secondary);
-  font-size: 13px;
-}
-
 /* Main content */
 .settings {
   flex: 1;
   padding: 12px 16px;
   overflow-y: auto;
+  min-height: 0; /* Required for overflow-y in flex children */
 }
 
 .section {
@@ -226,6 +224,7 @@ select {
   padding: 10px 16px;
   background: var(--bg-secondary);
   border-top: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .btn {
@@ -278,6 +277,7 @@ select {
   text-align: center;
   font-size: 13px;
   min-height: 20px;
+  flex-shrink: 0;
 }
 
 .status.success {


### PR DESCRIPTION
## Summary

- Add sticky footer layout so Test Connection / Save Settings buttons are always visible within Chrome extension's 600px height limit
- Remove header subtitle to save vertical space
- Move Auto-scroll and Include tool/search results toggles from Extraction to Advanced Settings (platform-specific, rarely changed)
- Keep only Append Mode in the default Extraction section (most universal setting)
- Add `min-height: 0` to `.settings` for correct flex overflow scrolling behavior

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Default view: Test Connection / Save Settings buttons visible without scrolling
- [x] Advanced Settings expanded: main area scrolls, footer stays fixed
- [x] All toggles (including moved ones) save and restore correctly
- [x] Light and dark themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)