### PR TITLE
fix: bump undici to >=7.24.0 via npm overrides to resolve security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3551,9 +3551,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5253,9 +5253,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "overrides": {
     "@crxjs/vite-plugin": {
       "rollup": "2.80.0"
-    }
+    },
+    "undici": ">=7.24.0"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
## Summary

- Add `"undici": ">=7.24.0"` to `overrides` in `package.json` to resolve 3 open + 3 auto-dismissed Dependabot alerts
- Fixes CVE-2026-1528 (HIGH: WebSocket 64-bit length overflow), CVE-2026-1527 (MEDIUM: CRLF injection), CVE-2026-1525 (MEDIUM: HTTP smuggling)
- Also addresses auto-dismissed CVE-2026-1526, CVE-2026-2229, CVE-2026-2581
- undici upgraded from 7.19.1 → 7.24.3 (transitive via @crxjs/vite-plugin → cheerio)
- Dev-only dependency; not shipped in the Chrome extension bundle

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] `npm ls undici` shows >= 7.24.0
- [x] `npm audit` no longer reports undici vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)