### PR TITLE
security: redact API key from content scripts and harden input validation

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -8,7 +8,7 @@ import { getSettings, migrateSettings } from '../lib/storage';
 import { validateSender, validateMessageContent } from './validation';
 import { handleSave, handleGetFile, handleTestConnection } from './obsidian-handlers';
 import { handleMultiOutput } from './output-handlers';
-import type { ExtensionMessage } from '../lib/types';
+import type { ExtensionMessage, ContentScriptSettings, ExtensionSettings } from '../lib/types';
 
 // Run settings migration on service worker startup (C-01)
 // Note: top-level await not available in service workers, use .catch() for error handling
@@ -50,7 +50,7 @@ chrome.runtime.onMessage.addListener(
       return false;
     }
 
-    handleMessage(message)
+    handleMessage(message, sender)
       .then(response => {
         try {
           sendResponse(response);
@@ -71,9 +71,31 @@ chrome.runtime.onMessage.addListener(
 );
 
 /**
+ * Check if sender is a content script (tab) vs extension page (popup)
+ */
+function isContentScriptSender(sender: chrome.runtime.MessageSender): boolean {
+  return sender.tab !== undefined;
+}
+
+/**
+ * Redact sensitive settings for content scripts.
+ * Content scripts only need to know IF an API key is configured, not the key itself.
+ */
+function redactSettingsForContentScript(settings: ExtensionSettings): ContentScriptSettings {
+  const { obsidianApiKey, ...syncSettings } = settings;
+  return {
+    ...syncSettings,
+    isApiKeyConfigured: obsidianApiKey.length > 0,
+  };
+}
+
+/**
  * Route messages to appropriate handlers
  */
-async function handleMessage(message: ExtensionMessage): Promise<unknown> {
+async function handleMessage(
+  message: ExtensionMessage,
+  sender: chrome.runtime.MessageSender
+): Promise<unknown> {
   const settings = await getSettings();
 
   switch (message.action) {
@@ -90,7 +112,8 @@ async function handleMessage(message: ExtensionMessage): Promise<unknown> {
       return handleTestConnection(settings);
 
     case 'getSettings':
-      return settings;
+      // Security: Redact API key for content scripts (they run on third-party pages)
+      return isContentScriptSender(sender) ? redactSettingsForContentScript(settings) : settings;
 
     default:
       return { success: false, error: 'Unknown action' };

--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -9,6 +9,7 @@ import { getErrorMessage } from '../lib/error-utils';
 import { generateNoteContent } from '../lib/note-generator';
 import { resolvePathTemplate } from '../lib/path-utils';
 import { lookupExistingFile, buildAppendContent } from '../lib/append-utils';
+import { validateObsidianUrl } from '../lib/validation';
 import type { ExtensionSettings, ObsidianNote, SaveResponse } from '../lib/types';
 
 /**
@@ -20,6 +21,12 @@ export function createObsidianClient(
 ): ObsidianApiClient | { error: string } {
   if (!settings.obsidianApiKey) {
     return { error: 'API key not configured' };
+  }
+  // Defence-in-depth: re-validate URL from storage before sending Bearer token
+  try {
+    validateObsidianUrl(settings.obsidianUrl);
+  } catch (error) {
+    return { error: `Invalid Obsidian URL: ${getErrorMessage(error)}` };
   }
   return new ObsidianApiClient(settings.obsidianUrl, settings.obsidianApiKey);
 }

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -5,7 +5,7 @@
 import type {
   AIPlatform,
   IConversationExtractor,
-  ExtensionSettings,
+  SyncSettings,
   ExtractionResult,
   ValidationResult,
   ConversationMessage,
@@ -116,7 +116,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
    * Apply user settings before extraction.
    * Override in subclasses that have platform-specific settings.
    */
-  applySettings(_settings: ExtensionSettings): void {
+  applySettings(_settings: SyncSettings): void {
     // no-op by default
   }
 

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -13,7 +13,7 @@ import type {
   ConversationMessage,
   DeepResearchSource,
   DeepResearchLinks,
-  ExtensionSettings,
+  SyncSettings,
   ExtractionResult,
 } from '../../lib/types';
 import { MAX_DEEP_RESEARCH_TITLE_LENGTH } from '../../lib/constants';
@@ -126,7 +126,7 @@ export class ClaudeExtractor extends BaseExtractor {
   /**
    * Apply user settings: enable/disable tool content extraction
    */
-  applySettings(settings: ExtensionSettings): void {
+  applySettings(settings: SyncSettings): void {
     this.enableToolContent = settings.enableToolContent ?? false;
   }
 

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -12,7 +12,7 @@ import {
 } from '../../lib/constants';
 import { ensureAllElementsLoaded, type ScrollResult } from '../../lib/scroll-manager';
 import type {
-  ExtensionSettings,
+  SyncSettings,
   ExtractionResult,
   ConversationMessage,
   DeepResearchSource,
@@ -122,7 +122,7 @@ export class GeminiExtractor extends BaseExtractor {
   /**
    * Apply user settings: enable/disable auto-scroll
    */
-  applySettings(settings: ExtensionSettings): void {
+  applySettings(settings: SyncSettings): void {
     this.enableAutoScroll = settings.enableAutoScroll ?? false;
   }
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -25,7 +25,7 @@ import {
   INFO_TOAST_DURATION,
 } from '../lib/constants';
 import type {
-  ExtensionSettings,
+  ContentScriptSettings,
   ObsidianNote,
   OutputDestination,
   OutputResult,
@@ -194,7 +194,7 @@ async function initialize(): Promise<void> {
 /**
  * Get enabled output destinations from settings
  */
-function getEnabledOutputs(settings: ExtensionSettings): OutputDestination[] {
+function getEnabledOutputs(settings: ContentScriptSettings): OutputDestination[] {
   const outputs: OutputDestination[] = [];
   const { outputOptions } = settings;
 
@@ -210,7 +210,7 @@ function getEnabledOutputs(settings: ExtensionSettings): OutputDestination[] {
  * @returns error message if invalid, null if valid
  */
 async function validateOutputConfig(
-  settings: ExtensionSettings,
+  settings: ContentScriptSettings,
   enabledOutputs: OutputDestination[]
 ): Promise<string | null> {
   if (enabledOutputs.length === 0) {
@@ -218,7 +218,7 @@ async function validateOutputConfig(
   }
 
   if (enabledOutputs.includes('obsidian')) {
-    if (!settings.obsidianApiKey) {
+    if (!settings.isApiKeyConfigured) {
       return 'Please configure your Obsidian API key in the extension settings';
     }
 
@@ -347,7 +347,7 @@ async function handleSync(): Promise<void> {
  * Get extension settings from background script (L-01)
  * Uses type-safe messaging utility
  */
-function getSettings(): Promise<ExtensionSettings> {
+function getSettings(): Promise<ContentScriptSettings> {
   return sendMessage({ action: 'getSettings' });
 }
 

--- a/src/lib/message-counter.ts
+++ b/src/lib/message-counter.ts
@@ -55,15 +55,13 @@ function stripCodeBlocks(text: string): string {
 export function countExistingMessages(body: string): number {
   const stripped = stripCodeBlocks(body);
 
-  // Try callout format first
-  CALLOUT_PATTERN.lastIndex = 0;
+  // Try callout format first (.match with /g always searches from 0)
   const calloutMatches = stripped.match(CALLOUT_PATTERN);
   if (calloutMatches && calloutMatches.length > 0) {
     return calloutMatches.length;
   }
 
-  // Try blockquote/plain format
-  LABEL_PATTERN.lastIndex = 0;
+  // Try blockquote/plain format (.match with /g always searches from 0)
   const labelMatches = stripped.match(LABEL_PATTERN);
   if (labelMatches && labelMatches.length > 0) {
     return labelMatches.length;

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -5,7 +5,7 @@
 
 import type {
   ExtensionMessage,
-  ExtensionSettings,
+  ContentScriptSettings,
   SaveResponse,
   MultiOutputResponse,
 } from './types';
@@ -17,7 +17,7 @@ const CONTEXT_INVALIDATED_MESSAGE = 'Extension context invalidated. Please reloa
  * Message response type mapping
  */
 interface MessageResponseMap {
-  getSettings: ExtensionSettings;
+  getSettings: ContentScriptSettings;
   testConnection: { success: boolean; error?: string };
   saveToObsidian: SaveResponse;
   saveToOutputs: MultiOutputResponse;

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -10,6 +10,8 @@
  * legitimate filenames like foo..bar, so a more precise regex is used.
  */
 export function containsPathTraversal(path: string): boolean {
+  // Detect null bytes (filesystem string terminator attack)
+  if (path.includes('\0')) return true;
   // Detect ../ or ..\ only when combined with path separators:
   // ^..   : leading ..
   // /.. or \.. : .. after path separator

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -193,6 +193,17 @@ export interface SyncSettings {
 export interface ExtensionSettings extends SecureSettings, SyncSettings {}
 
 /**
+ * Settings returned to content scripts (API key redacted)
+ *
+ * Security: Content scripts run inside third-party pages and should
+ * never receive the actual API key. They only need to know whether
+ * a key is configured (boolean flag).
+ */
+export interface ContentScriptSettings extends SyncSettings {
+  isApiKeyConfigured: boolean;
+}
+
+/**
  * Template customization options
  */
 export interface TemplateOptions {
@@ -268,5 +279,5 @@ export interface IConversationExtractor {
   getTitle(): string;
   extractMessages(): ConversationMessage[];
   validate(result: ExtractionResult): ValidationResult;
-  applySettings(settings: ExtensionSettings): void;
+  applySettings(settings: SyncSettings): void;
 }

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -51,9 +51,14 @@ function handleClipboardWrite(content: string): boolean {
 chrome.runtime.onMessage.addListener(
   (
     message: ClipboardWriteMessage,
-    _sender: chrome.runtime.MessageSender,
+    sender: chrome.runtime.MessageSender,
     sendResponse: (response: ClipboardWriteResponse) => void
   ) => {
+    // Security: Only accept messages from the same extension
+    if (sender.id !== chrome.runtime.id) {
+      return false;
+    }
+
     // Only handle messages targeted at offscreen document
     if (message.action === 'clipboardWrite' && message.target === 'offscreen') {
       try {

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -367,7 +367,7 @@ describe('background/index', () => {
   describe('getSettings handler', () => {
     const validSender = { url: `chrome-extension://${chrome.runtime.id}/popup.html` };
 
-    it('returns settings', async () => {
+    it('returns full settings including API key for popup sender', async () => {
       const sendResponse = vi.fn();
       capturedListener(
         { action: 'getSettings' },
@@ -382,6 +382,88 @@ describe('background/index', () => {
           obsidianUrl: 'http://127.0.0.1:27123',
         })
       );
+    });
+
+    it('redacts API key for content script (tab) senders', async () => {
+      const tabSender = {
+        tab: { url: 'https://gemini.google.com/app/123' },
+      } as chrome.runtime.MessageSender;
+
+      const sendResponse = vi.fn();
+      capturedListener({ action: 'getSettings' }, tabSender, sendResponse);
+
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      const response = sendResponse.mock.calls[0][0];
+
+      // Should NOT contain the actual API key
+      expect(response).not.toHaveProperty('obsidianApiKey');
+      // Should contain the boolean flag instead
+      expect(response.isApiKeyConfigured).toBe(true);
+      // Should still contain non-sensitive settings
+      expect(response.obsidianUrl).toBe('http://127.0.0.1:27123');
+      expect(response.vaultPath).toBe('AI/Gemini');
+    });
+
+    it('returns isApiKeyConfigured=false when API key is empty', async () => {
+      mockGetSettings = vi.fn(() => Promise.resolve({ ...defaultSettings, obsidianApiKey: '' }));
+
+      const tabSender = {
+        tab: { url: 'https://claude.ai/chat/123' },
+      } as chrome.runtime.MessageSender;
+
+      const sendResponse = vi.fn();
+      capturedListener({ action: 'getSettings' }, tabSender, sendResponse);
+
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      const response = sendResponse.mock.calls[0][0];
+      expect(response.isApiKeyConfigured).toBe(false);
+      expect(response).not.toHaveProperty('obsidianApiKey');
+    });
+  });
+
+  describe('obsidianUrl validation in background', () => {
+    const validSender = { url: `chrome-extension://${chrome.runtime.id}/popup.html` };
+
+    it('rejects invalid obsidianUrl from poisoned storage', async () => {
+      mockGetSettings = vi.fn(() =>
+        Promise.resolve({
+          ...defaultSettings,
+          obsidianUrl: 'javascript:alert(1)',
+        })
+      );
+
+      const sendResponse = vi.fn();
+      capturedListener(
+        { action: 'testConnection' },
+        validSender as chrome.runtime.MessageSender,
+        sendResponse
+      );
+
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      const response = sendResponse.mock.calls[0][0];
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('URL');
+    });
+
+    it('rejects ftp scheme obsidianUrl', async () => {
+      mockGetSettings = vi.fn(() =>
+        Promise.resolve({
+          ...defaultSettings,
+          obsidianUrl: 'ftp://evil.com',
+        })
+      );
+
+      const sendResponse = vi.fn();
+      capturedListener(
+        { action: 'testConnection' },
+        validSender as chrome.runtime.MessageSender,
+        sendResponse
+      );
+
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      const response = sendResponse.mock.calls[0][0];
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('URL');
     });
   });
 

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -63,10 +63,12 @@ describe('ClaudeExtractor', () => {
 
       it('returns false when artifact not present', () => {
         setClaudeLocation('test-123');
-        loadFixture(createClaudeConversationDOM([
-          { role: 'user', content: 'Hello' },
-          { role: 'assistant', content: '<p>Hi there!</p>' },
-        ]));
+        loadFixture(
+          createClaudeConversationDOM([
+            { role: 'user', content: 'Hello' },
+            { role: 'assistant', content: '<p>Hi there!</p>' },
+          ])
+        );
         expect(extractor.isDeepResearchVisible()).toBe(false);
       });
     });
@@ -74,19 +76,23 @@ describe('ClaudeExtractor', () => {
 
   describe('applySettings', () => {
     it('sets enableToolContent to true from settings', () => {
-      extractor.applySettings({ enableToolContent: true } as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({
+        enableToolContent: true,
+      } as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableToolContent).toBe(true);
     });
 
     it('sets enableToolContent to false from settings', () => {
       extractor.enableToolContent = true;
-      extractor.applySettings({ enableToolContent: false } as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({
+        enableToolContent: false,
+      } as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableToolContent).toBe(false);
     });
 
     it('defaults enableToolContent to false when undefined in settings', () => {
       extractor.enableToolContent = true;
-      extractor.applySettings({} as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({} as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableToolContent).toBe(false);
     });
   });
@@ -174,10 +180,12 @@ describe('ClaudeExtractor', () => {
         writable: true,
         configurable: true,
       });
-      loadFixture(createClaudeConversationDOM([
-        { role: 'user', content: 'Hello' },
-        { role: 'assistant', content: '<p>Hi!</p>' },
-      ]));
+      loadFixture(
+        createClaudeConversationDOM([
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '<p>Hi!</p>' },
+        ])
+      );
       const result = await extractor.extract();
       expect(result.success).toBe(true);
       expect(result.data?.id).toMatch(/^claude-\d+$/);
@@ -420,15 +428,10 @@ describe('ClaudeExtractor', () => {
 
     it('extracts inline citations using extractSourceList', () => {
       setClaudeLocation('test-123');
-      createClaudeDeepResearchPage(
-        'test-123',
-        'Report',
-        '<p>Content</p>',
-        [
-          { url: 'https://example.com/source1', title: 'Source 1' },
-          { url: 'https://example.com/source2', title: 'Source 2' },
-        ]
-      );
+      createClaudeDeepResearchPage('test-123', 'Report', '<p>Content</p>', [
+        { url: 'https://example.com/source1', title: 'Source 1' },
+        { url: 'https://example.com/source2', title: 'Source 2' },
+      ]);
       const sources = extractor.extractSourceList();
       expect(sources.length).toBeGreaterThan(0);
     });
@@ -444,12 +447,12 @@ describe('ClaudeExtractor', () => {
       setClaudeLocation('test-123');
       createClaudeDeepResearchPage('test-123', 'Unique Report Title', '<p>Content</p>');
       const result1 = await extractor.extract();
-      
+
       // Reset and extract again
       clearFixture();
       createClaudeDeepResearchPage('test-123', 'Unique Report Title', '<p>Content</p>');
       const result2 = await extractor.extract();
-      
+
       expect(result1.data?.id).toBe(result2.data?.id);
       expect(result1.data?.id).toMatch(/^deep-research-/);
     });
@@ -498,10 +501,10 @@ describe('ClaudeExtractor', () => {
 
     it('handles 100+ citations performance', () => {
       setClaudeLocation('test-123');
-      const citations = Array.from({ length: 100 }, (_, i) => 
+      const citations = Array.from({ length: 100 }, (_, i) =>
         createClaudeInlineCitation(`https://example${i}.com/page`, `Source ${i}`)
       ).join('\n');
-      
+
       loadFixture(`
         <div id="markdown-artifact" class="font-claude-response">
           <div class="standard-markdown">
@@ -510,11 +513,11 @@ describe('ClaudeExtractor', () => {
           </div>
         </div>
       `);
-      
+
       const startTime = performance.now();
       const sources = extractor.extractSourceList();
       const endTime = performance.now();
-      
+
       expect(sources.length).toBe(100);
       expect(endTime - startTime).toBeLessThan(100); // Should be under 100ms
     });
@@ -823,7 +826,7 @@ describe('ClaudeExtractor', () => {
       // Covers: claude.ts lines 475-481 (catch, non-Error)
       setClaudeLocation('12345678-1234-1234-1234-123456789012');
       const originalQSA = document.querySelectorAll.bind(document);
-      vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
+      vi.spyOn(document, 'querySelectorAll').mockImplementation(selector => {
         if (typeof selector === 'string' && selector.includes('whitespace-pre-wrap')) {
           throw 'string thrown as error';
         }
@@ -963,22 +966,19 @@ describe('ClaudeExtractor', () => {
     ];
 
     it('OFF (default): tool-use .row-start-1 skipped, only .row-start-2 extracted', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Search for Rust' },
-          {
-            role: 'assistant',
-            content: '<p>Here are the results.</p>',
-            toolUse: {
-              summaryText: 'Searched the web',
-              searchQuery: 'Rust latest version',
-              searchResultCount: 3,
-              searchResults,
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Search for Rust' },
+        {
+          role: 'assistant',
+          content: '<p>Here are the results.</p>',
+          toolUse: {
+            summaryText: 'Searched the web',
+            searchQuery: 'Rust latest version',
+            searchResultCount: 3,
+            searchResults,
           },
-        ]
-      );
+        },
+      ]);
 
       // Default: enableToolContent = false
       const result = await extractor.extract();
@@ -993,22 +993,19 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: search query and results extracted into toolContent, response in content', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Search for Rust' },
-          {
-            role: 'assistant',
-            content: '<p>Here are the results.</p>',
-            toolUse: {
-              summaryText: 'Searched the web',
-              searchQuery: 'Rust latest version 2026',
-              searchResultCount: 10,
-              searchResults,
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Search for Rust' },
+        {
+          role: 'assistant',
+          content: '<p>Here are the results.</p>',
+          toolUse: {
+            summaryText: 'Searched the web',
+            searchQuery: 'Rust latest version 2026',
+            searchResultCount: 10,
+            searchResults,
           },
-        ]
-      );
+        },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1029,24 +1026,21 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: mixed conversation (user → tool-use response → user → normal response) preserves order', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'First question' },
-          {
-            role: 'assistant',
-            content: '<p>First answer with search.</p>',
-            toolUse: {
-              summaryText: 'Searched the web',
-              searchQuery: 'First query',
-              searchResultCount: 5,
-              searchResults: [{ title: 'Result A', domain: 'example.com' }],
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'First question' },
+        {
+          role: 'assistant',
+          content: '<p>First answer with search.</p>',
+          toolUse: {
+            summaryText: 'Searched the web',
+            searchQuery: 'First query',
+            searchResultCount: 5,
+            searchResults: [{ title: 'Result A', domain: 'example.com' }],
           },
-          { role: 'user', content: 'Second question' },
-          { role: 'assistant', content: '<p>Second answer (no tool).</p>' },
-        ]
-      );
+        },
+        { role: 'user', content: 'Second question' },
+        { role: 'assistant', content: '<p>Second answer (no tool).</p>' },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1089,20 +1083,17 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: content sanitized (DOMPurify applied to .standard-markdown tool content)', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Test' },
-          {
-            role: 'assistant',
-            content: '<p>Response</p>',
-            toolUse: {
-              summaryText: 'Analyzed code',
-              toolSteps: ['<script>alert("xss")</script>Safe analysis content'],
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Test' },
+        {
+          role: 'assistant',
+          content: '<p>Response</p>',
+          toolUse: {
+            summaryText: 'Analyzed code',
+            toolSteps: ['<script>alert("xss")</script>Safe analysis content'],
           },
-        ]
-      );
+        },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1113,17 +1104,14 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: button summary text extracted as bold into toolContent', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Search something' },
-          {
-            role: 'assistant',
-            content: '<p>Results below.</p>',
-            toolUse: { summaryText: 'Gathered API documentation for Express.js' },
-          },
-        ]
-      );
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Search something' },
+        {
+          role: 'assistant',
+          content: '<p>Results below.</p>',
+          toolUse: { summaryText: 'Gathered API documentation for Express.js' },
+        },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1134,20 +1122,17 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: multiple .standard-markdown blocks in .row-start-1 all extracted into toolContent', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Research this topic' },
-          {
-            role: 'assistant',
-            content: '<p>Final summary.</p>',
-            toolUse: {
-              summaryText: 'Analyzed files',
-              toolSteps: ['First analysis result', 'Second analysis result'],
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Research this topic' },
+        {
+          role: 'assistant',
+          content: '<p>Final summary.</p>',
+          toolUse: {
+            summaryText: 'Analyzed files',
+            toolSteps: ['First analysis result', 'Second analysis result'],
           },
-        ]
-      );
+        },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1160,13 +1145,10 @@ describe('ClaudeExtractor', () => {
     });
 
     it('OFF: regression — normal (non-grid) responses unaffected', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Hello Claude' },
-          { role: 'assistant', content: '<p>Hello! How can I help?</p>' },
-        ]
-      );
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Hello Claude' },
+        { role: 'assistant', content: '<p>Hello! How can I help?</p>' },
+      ]);
 
       // enableToolContent stays false (default)
       const result = await extractor.extract();
@@ -1178,22 +1160,19 @@ describe('ClaudeExtractor', () => {
     });
 
     it('ON: search with no results list → summary + query in toolContent, response in content', async () => {
-      createClaudePageWithToolUse(
-        '12345678-1234-1234-1234-123456789012',
-        [
-          { role: 'user', content: 'Quick search' },
-          {
-            role: 'assistant',
-            content: '<p>Here is what I found.</p>',
-            toolUse: {
-              summaryText: 'Searched the web',
-              searchQuery: 'Quick topic',
-              searchResultCount: 5,
-              // No searchResults — only query, no result items
-            },
+      createClaudePageWithToolUse('12345678-1234-1234-1234-123456789012', [
+        { role: 'user', content: 'Quick search' },
+        {
+          role: 'assistant',
+          content: '<p>Here is what I found.</p>',
+          toolUse: {
+            summaryText: 'Searched the web',
+            searchQuery: 'Quick topic',
+            searchResultCount: 5,
+            // No searchResults — only query, no result items
           },
-        ]
-      );
+        },
+      ]);
 
       extractor.enableToolContent = true;
       const result = await extractor.extract();
@@ -1227,14 +1206,17 @@ describe('ClaudeExtractor', () => {
 
       // Mock URL constructor to throw for the specific URL
       const OriginalURL = globalThis.URL;
-      vi.stubGlobal('URL', class extends OriginalURL {
-        constructor(input: string | URL, base?: string | URL) {
-          if (typeof input === 'string' && input.includes('example.com/valid')) {
-            throw new TypeError('Invalid URL');
+      vi.stubGlobal(
+        'URL',
+        class extends OriginalURL {
+          constructor(input: string | URL, base?: string | URL) {
+            if (typeof input === 'string' && input.includes('example.com/valid')) {
+              throw new TypeError('Invalid URL');
+            }
+            super(input, base);
           }
-          super(input, base);
         }
-      });
+      );
 
       const sources = extractor.extractSourceList();
 

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -853,19 +853,23 @@ describe('GeminiExtractor', () => {
 
   describe('applySettings', () => {
     it('sets enableAutoScroll to true from settings', () => {
-      extractor.applySettings({ enableAutoScroll: true } as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({
+        enableAutoScroll: true,
+      } as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableAutoScroll).toBe(true);
     });
 
     it('sets enableAutoScroll to false from settings', () => {
       extractor.enableAutoScroll = true;
-      extractor.applySettings({ enableAutoScroll: false } as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({
+        enableAutoScroll: false,
+      } as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableAutoScroll).toBe(false);
     });
 
     it('defaults enableAutoScroll to false when undefined in settings', () => {
       extractor.enableAutoScroll = true;
-      extractor.applySettings({} as import('../../src/lib/types').ExtensionSettings);
+      extractor.applySettings({} as import('../../src/lib/types').SyncSettings);
       expect(extractor.enableAutoScroll).toBe(false);
     });
   });
@@ -1045,9 +1049,7 @@ describe('GeminiExtractor', () => {
         { role: 'user', content: 'Q1' },
         { role: 'assistant', content: '<p>A1</p>' },
       ]);
-      loadFixture(
-        createGeminiScrollableDOM(conversationHTML) + deepResearchHTML
-      );
+      loadFixture(createGeminiScrollableDOM(conversationHTML) + deepResearchHTML);
       mockScrollContainer(500);
 
       const result = await extractor.extract();

--- a/test/lib/path-utils.test.ts
+++ b/test/lib/path-utils.test.ts
@@ -36,6 +36,12 @@ describe('containsPathTraversal', () => {
     expect(containsPathTraversal('folder..name/subfolder')).toBe(false);
   });
 
+  it('detects null bytes', () => {
+    expect(containsPathTraversal('foo\0bar')).toBe(true);
+    expect(containsPathTraversal('\0')).toBe(true);
+    expect(containsPathTraversal('AI/Gemini\0.md')).toBe(true);
+  });
+
   it('handles edge cases', () => {
     expect(containsPathTraversal('')).toBe(false);
     expect(containsPathTraversal('.')).toBe(false);
@@ -46,39 +52,33 @@ describe('containsPathTraversal', () => {
 
 describe('resolvePathTemplate', () => {
   it('resolves {platform} variable', () => {
-    expect(resolvePathTemplate('AI/{platform}', { platform: 'gemini' }))
-      .toBe('AI/gemini');
+    expect(resolvePathTemplate('AI/{platform}', { platform: 'gemini' })).toBe('AI/gemini');
   });
 
   it('resolves multiple variables', () => {
-    expect(resolvePathTemplate('{type}/{platform}', {
-      platform: 'claude',
-      type: 'conversation',
-    })).toBe('conversation/claude');
+    expect(
+      resolvePathTemplate('{type}/{platform}', {
+        platform: 'claude',
+        type: 'conversation',
+      })
+    ).toBe('conversation/claude');
   });
 
   it('preserves unknown variables', () => {
-    expect(resolvePathTemplate('AI/{unknown}', { platform: 'gemini' }))
-      .toBe('AI/{unknown}');
+    expect(resolvePathTemplate('AI/{unknown}', { platform: 'gemini' })).toBe('AI/{unknown}');
   });
 
   it('returns path unchanged when no variables present', () => {
-    expect(resolvePathTemplate('AI/Gemini', { platform: 'gemini' }))
-      .toBe('AI/Gemini');
+    expect(resolvePathTemplate('AI/Gemini', { platform: 'gemini' })).toBe('AI/Gemini');
   });
 
   it('handles empty path', () => {
-    expect(resolvePathTemplate('', { platform: 'gemini' }))
-      .toBe('');
+    expect(resolvePathTemplate('', { platform: 'gemini' })).toBe('');
   });
 
   it('resolves all supported platforms', () => {
     for (const p of ['gemini', 'claude', 'chatgpt', 'perplexity']) {
-      expect(resolvePathTemplate('AI/{platform}', { platform: p }))
-        .toBe(`AI/${p}`);
+      expect(resolvePathTemplate('AI/{platform}', { platform: p })).toBe(`AI/${p}`);
     }
   });
 });
-
-
-

--- a/test/offscreen/offscreen.test.ts
+++ b/test/offscreen/offscreen.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Offscreen document tests
+ *
+ * Tests sender validation and clipboard operations
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Capture the message listener
+let capturedListener: (
+  message: unknown,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void
+) => boolean | undefined;
+
+// Mock the textarea element for clipboard operations
+const mockTextarea = {
+  value: '',
+  select: vi.fn(),
+};
+
+describe('offscreen/offscreen', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockTextarea.value = '';
+
+    // Mock document.querySelector to return our mock textarea
+    vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+      if (selector === '#clipboard-textarea') {
+        return mockTextarea as unknown as HTMLTextAreaElement;
+      }
+      return null;
+    });
+
+    // Mock document.execCommand (deprecated but used in offscreen for clipboard)
+    // jsdom does not define execCommand, so use Object.defineProperty
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn(() => true),
+      writable: true,
+      configurable: true,
+    });
+
+    // Capture message listener
+    vi.mocked(chrome.runtime.onMessage.addListener).mockImplementation(listener => {
+      capturedListener = listener;
+    });
+
+    // Import fresh
+    vi.resetModules();
+    await import('../../src/offscreen/offscreen');
+  });
+
+  it('registers message listener', () => {
+    expect(chrome.runtime.onMessage.addListener).toHaveBeenCalled();
+    expect(capturedListener).toBeDefined();
+  });
+
+  it('rejects messages from different extension IDs', () => {
+    const sendResponse = vi.fn();
+    const result = capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
+      { id: 'different-extension-id' } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    // Should return false (not handled) and not call sendResponse
+    expect(result).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it('rejects messages when sender.id is undefined', () => {
+    const sendResponse = vi.fn();
+    const result = capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(result).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it('accepts messages from same extension ID', () => {
+    const sendResponse = vi.fn();
+    capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'hello' },
+      { id: chrome.runtime.id } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('handles clipboard write from valid sender', () => {
+    const sendResponse = vi.fn();
+    capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test content' },
+      { id: chrome.runtime.id } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(mockTextarea.value).toBe(''); // Cleared after copy
+    expect(mockTextarea.select).toHaveBeenCalled();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary

- **[HIGH] Redact API key from content script responses**: `getSettings` now returns `ContentScriptSettings` with `isApiKeyConfigured: boolean` instead of the raw API key when called from a tab (content script). Popup still receives the full key.
- **[HIGH] Defence-in-depth URL validation**: `createObsidianClient()` re-validates `obsidianUrl` via `validateObsidianUrl()` before constructing the API client, protecting against poisoned `chrome.storage.sync`.
- **[MEDIUM] Offscreen sender check**: Offscreen document's `onMessage` listener now verifies `sender.id === chrome.runtime.id` before processing clipboard write requests.
- **[MEDIUM] Null-byte path traversal detection**: `containsPathTraversal()` now rejects paths containing `\0` bytes.
- **[MINOR] Remove unnecessary `lastIndex` resets** in `message-counter.ts` — `String.match()` with `/g` flag always searches from index 0.
- Type narrowing: `IConversationExtractor.applySettings()` now accepts `SyncSettings` instead of `ExtensionSettings` (extractors never needed the API key).

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npx vitest run` — 785 tests pass (30 test files)
- [x] New tests: API key redaction (3), URL validation (2), offscreen sender check (5), null-byte detection (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)