### PR TITLE
chore: add security type to release-please changelog sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
+    { "type": "security", "section": "Security" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "refactor", "section": "Code Refactoring" },
     { "type": "docs", "section": "Documentation" },


### PR DESCRIPTION
## Summary

- Add `{ "type": "security", "section": "Security" }` to `changelog-sections` in `release-please-config.json`
- Ensures `security:` conventional commits trigger a patch version bump and appear under a dedicated "Security" section in CHANGELOG.md
- Retroactively picks up the already-merged `security: redact API key...` commit (#134) on the next release-please run

## Test plan

- [ ] Verify `release-please-config.json` is valid JSON
- [ ] After merge, release-please creates a release PR including both `chore:` and `security:` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)