### PR TITLE
fix: strengthen validation, extract constants, and resolve type issues

### DIFF
--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -67,7 +67,7 @@ async function ensureOffscreenDocument(): Promise<void> {
 async function handleSaveToObsidian(
   note: ObsidianNote,
   settings: ExtensionSettings
-): Promise<OutputResult & { messagesAppended?: number }> {
+): Promise<OutputResult> {
   try {
     const result = await handleSave(settings, note);
     return {
@@ -235,8 +235,7 @@ export async function handleMultiOutput(
   let messagesAppended: number | undefined;
   settled.forEach((result, index) => {
     if (result.status === 'fulfilled' && outputs[index] === 'obsidian') {
-      const obsidianResult = result.value as OutputResult & { messagesAppended?: number };
-      messagesAppended = obsidianResult.messagesAppended;
+      messagesAppended = result.value.messagesAppended;
     }
   });
 

--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -11,6 +11,7 @@ import {
   MAX_FRONTMATTER_TITLE_LENGTH,
   MAX_TAGS_COUNT,
   MAX_TAG_LENGTH,
+  MAX_VAULT_PATH_LENGTH,
   ALLOWED_ORIGINS,
   VALID_MESSAGE_ACTIONS,
   VALID_OUTPUT_DESTINATIONS,
@@ -65,8 +66,13 @@ export function validateMessageContent(message: ExtensionMessage): boolean {
     if (containsPathTraversal(message.fileName)) {
       return false;
     }
-    if (typeof message.vaultPath === 'string' && containsPathTraversal(message.vaultPath)) {
-      return false;
+    if (typeof message.vaultPath === 'string') {
+      if (containsPathTraversal(message.vaultPath)) {
+        return false;
+      }
+      if (message.vaultPath.length > MAX_VAULT_PATH_LENGTH) {
+        return false;
+      }
     }
   }
 

--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -10,6 +10,7 @@ import {
   MAX_FILENAME_LENGTH,
   MAX_FRONTMATTER_TITLE_LENGTH,
   MAX_TAGS_COUNT,
+  MAX_TAG_LENGTH,
   ALLOWED_ORIGINS,
   VALID_MESSAGE_ACTIONS,
   VALID_OUTPUT_DESTINATIONS,
@@ -140,6 +141,29 @@ export function validateNoteData(note: ObsidianNote): boolean {
   }
   if (!Array.isArray(note.frontmatter.tags) || note.frontmatter.tags.length > MAX_TAGS_COUNT) {
     return false;
+  }
+  // Validate individual tag values: must be strings within length limit
+  if (
+    !note.frontmatter.tags.every(
+      (t: unknown) => typeof t === 'string' && t.length > 0 && t.length <= MAX_TAG_LENGTH
+    )
+  ) {
+    return false;
+  }
+
+  // Validate frontmatter URL scheme (prevent javascript: or data: injection)
+  if (typeof note.frontmatter.url !== 'string') {
+    return false;
+  }
+  if (note.frontmatter.url.length > 0) {
+    try {
+      const parsed = new URL(note.frontmatter.url);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return false;
+      }
+    } catch {
+      return false;
+    }
   }
 
   return true;

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -238,13 +238,13 @@ export class ClaudeExtractor extends BaseExtractor {
 
     const sortedElements = this.sortByDomPosition(allElements);
 
-    // Pre-extract tool content keyed by element index
-    const toolContentMap = new Map<number, string>();
+    // Pre-extract tool content keyed by message ID (matches buildMessagesFromElements format)
+    const toolContentById = new Map<string, string>();
     if (this.enableToolContent) {
       sortedElements.forEach((item, index) => {
         if (item.type === 'assistant') {
           const tc = this.extractToolContentFromElement(item.element);
-          if (tc) toolContentMap.set(index, tc);
+          if (tc) toolContentById.set(`assistant-${index}`, tc);
         }
       });
     }
@@ -256,12 +256,10 @@ export class ClaudeExtractor extends BaseExtractor {
     );
 
     // Attach tool content to corresponding assistant messages (DES-014 H-5: immutable)
-    if (toolContentMap.size === 0) return messages;
+    if (toolContentById.size === 0) return messages;
 
     return messages.map(msg => {
-      if (msg.role !== 'assistant') return msg;
-      const idx = parseInt(msg.id.split('-')[1], 10);
-      const tc = toolContentMap.get(idx);
+      const tc = toolContentById.get(msg.id);
       return tc ? { ...msg, toolContent: tc } : msg;
     });
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,9 +44,6 @@ export const MAX_TAG_LENGTH = 100;
 /** Default Obsidian Local REST API URL */
 export const DEFAULT_OBSIDIAN_URL = 'http://127.0.0.1:27123';
 
-/** Default Obsidian Local REST API port (legacy, used for migration) */
-export const DEFAULT_OBSIDIAN_PORT = 27123;
-
 /** Minimum valid port number */
 export const MIN_PORT = 1024;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -125,6 +125,11 @@ export const VALID_OUTPUT_DESTINATIONS = ['obsidian', 'file', 'clipboard'] as co
 export const VALID_SOURCES = ['gemini', 'claude', 'perplexity', 'chatgpt'] as const;
 
 /**
+ * Valid message format options for template rendering
+ */
+export const VALID_MESSAGE_FORMATS = ['callout', 'plain', 'blockquote'] as const;
+
+/**
  * Human-readable display labels for AI platforms
  */
 export const PLATFORM_LABELS: Record<string, string> = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,6 +37,12 @@ export const MAX_TAGS_COUNT = 50;
 /** Maximum length for a single tag string (characters) */
 export const MAX_TAG_LENGTH = 100;
 
+/** Maximum length for vault path (filesystem constraint) */
+export const MAX_VAULT_PATH_LENGTH = 200;
+
+/** Minimum length for API key (security constraint) */
+export const MIN_API_KEY_LENGTH = 16;
+
 // ============================================================
 // Network Configuration
 // ============================================================

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,6 +34,9 @@ export const MAX_FRONTMATTER_TITLE_LENGTH = 500;
 /** Maximum number of tags allowed in frontmatter */
 export const MAX_TAGS_COUNT = 50;
 
+/** Maximum length for a single tag string (characters) */
+export const MAX_TAG_LENGTH = 100;
+
 // ============================================================
 // Network Configuration
 // ============================================================

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,8 @@ export interface OutputResult {
   destination: OutputDestination;
   success: boolean;
   error?: string;
+  /** Number of messages appended (Obsidian append mode only) */
+  messagesAppended?: number;
 }
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -4,7 +4,7 @@
  */
 
 import { containsPathTraversal } from './path-utils';
-import { MIN_PORT, MAX_PORT } from './constants';
+import { MIN_PORT, MAX_PORT, MAX_VAULT_PATH_LENGTH, MIN_API_KEY_LENGTH } from './constants';
 
 /**
  * Allowed callout types
@@ -64,8 +64,8 @@ export function validateVaultPath(path: string): string {
   }
 
   // Length limit (filesystem constraint)
-  if (path.length > 200) {
-    throw new Error('Vault path is too long (max 200 characters)');
+  if (path.length > MAX_VAULT_PATH_LENGTH) {
+    throw new Error(`Vault path is too long (max ${MAX_VAULT_PATH_LENGTH} characters)`);
   }
 
   return path.trim();
@@ -132,8 +132,8 @@ export function validateApiKey(key: string): string {
   }
 
   // Minimum length check (for security)
-  if (trimmed.length < 16) {
-    throw new Error('API key is too short (minimum 16 characters for security)');
+  if (trimmed.length < MIN_API_KEY_LENGTH) {
+    throw new Error(`API key is too short (minimum ${MIN_API_KEY_LENGTH} characters for security)`);
   }
 
   return trimmed;

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -411,8 +411,21 @@ async function handleTest(): Promise<void> {
       return;
     }
 
-    // Temporarily save settings for the test
-    await saveSettings(settings);
+    // Validate Obsidian settings before saving (same as handleSave)
+    const validation = validateObsidianSettings(settings);
+    if (validation.error) {
+      showStatus(validation.error, 'error');
+      elements.testBtn.disabled = false;
+      return;
+    }
+
+    // Save validated and normalized settings for the test
+    await saveSettings({
+      ...settings,
+      obsidianApiKey: validation.normalizedApiKey,
+      obsidianUrl: validation.normalizedUrl,
+      vaultPath: validation.normalizedVaultPath,
+    });
 
     // Send test connection message to background script
     const response = await sendMessage({ action: 'testConnection' });

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -11,7 +11,7 @@ import {
   validateApiKey,
   validateObsidianUrl,
 } from '../lib/validation';
-import { DEFAULT_OBSIDIAN_URL } from '../lib/constants';
+import { DEFAULT_OBSIDIAN_URL, VALID_MESSAGE_FORMATS } from '../lib/constants';
 import { getMessage } from '../lib/i18n';
 import { sendMessage } from '../lib/messaging';
 
@@ -255,8 +255,6 @@ function collectOutputOptions(): OutputOptions {
 function validateOutputOptions(outputOptions: OutputOptions): boolean {
   return outputOptions.obsidian || outputOptions.file || outputOptions.clipboard;
 }
-
-const VALID_MESSAGE_FORMATS = ['callout', 'plain', 'blockquote'] as const;
 
 /**
  * Collect settings from form

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -803,6 +803,24 @@ describe('background/index', () => {
       });
     });
 
+    it('rejects vaultPath exceeding MAX_VAULT_PATH_LENGTH', () => {
+      const sendResponse = vi.fn();
+      capturedListener(
+        {
+          action: 'getExistingFile',
+          fileName: 'test.md',
+          vaultPath: 'a'.repeat(201),
+        },
+        validSender as chrome.runtime.MessageSender,
+        sendResponse
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: 'Invalid message content',
+      });
+    });
+
     it('handles getFile errors gracefully', async () => {
       mockClient.getFile.mockRejectedValue(new Error('Network timeout'));
 

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -361,6 +361,132 @@ describe('background/index', () => {
           error: 'Invalid message content',
         });
       });
+
+      it('rejects non-string tag values', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: { ...validNote.frontmatter, tags: [123, null] },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects tag strings exceeding 100 characters', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: { ...validNote.frontmatter, tags: ['a'.repeat(101)] },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects empty tag strings', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: { ...validNote.frontmatter, tags: [''] },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects javascript: URL scheme in frontmatter', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: { ...validNote.frontmatter, url: 'javascript:alert(1)' },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects data: URL scheme in frontmatter', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: {
+                ...validNote.frontmatter,
+                url: 'data:text/html,<script>alert(1)</script>',
+              },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('accepts valid https URL in frontmatter', () => {
+        const sendResponse = vi.fn();
+        // This should NOT be rejected - it should proceed to save
+        capturedListener(
+          {
+            action: 'saveToObsidian',
+            data: {
+              ...validNote,
+              frontmatter: { ...validNote.frontmatter, url: 'https://gemini.google.com/app/123' },
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        // Should not immediately reject with validation error
+        // (it proceeds to async handling)
+        expect(sendResponse).not.toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Strengthen input validation in `validation.ts` and remove fragile ID parsing
- Extract magic numbers to named constants in `constants.ts`
- Remove unused `DEFAULT_OBSIDIAN_PORT` constant
- Fix output types and validation issues across `output-handlers.ts`, `types.ts`, `popup/index.ts`, and `claude.ts`
- Add 144 lines of new tests in `background/index.test.ts`

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes
- [x] Verify no regressions in popup settings UI
- [x] Verify Claude extractor still works on claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)