### PR TITLE
fix: resolve 2 QA issues - immutability and race condition

### DIFF
--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -42,23 +42,40 @@ function scheduleOffscreenClose(): void {
   }, OFFSCREEN_TIMEOUT_MS);
 }
 
+/** Singleton promise to prevent concurrent offscreen document creation */
+let offscreenCreationPromise: Promise<void> | null = null;
+
 /**
- * Ensure offscreen document exists for clipboard operations
+ * Ensure offscreen document exists for clipboard operations.
+ * Uses a singleton promise to prevent race conditions when
+ * multiple clipboard operations are triggered concurrently.
  */
 async function ensureOffscreenDocument(): Promise<void> {
-  const existingContexts = await chrome.runtime.getContexts({
-    contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
-  });
-
-  if (existingContexts.length > 0) {
-    return;
+  if (offscreenCreationPromise) {
+    return offscreenCreationPromise;
   }
 
-  await chrome.offscreen.createDocument({
-    url: 'src/offscreen/offscreen.html',
-    reasons: [chrome.offscreen.Reason.CLIPBOARD],
-    justification: 'Copy markdown content to clipboard',
-  });
+  offscreenCreationPromise = (async () => {
+    const existingContexts = await chrome.runtime.getContexts({
+      contextTypes: [chrome.runtime.ContextType.OFFSCREEN_DOCUMENT],
+    });
+
+    if (existingContexts.length > 0) {
+      return;
+    }
+
+    await chrome.offscreen.createDocument({
+      url: 'src/offscreen/offscreen.html',
+      reasons: [chrome.offscreen.Reason.CLIPBOARD],
+      justification: 'Copy markdown content to clipboard',
+    });
+  })();
+
+  try {
+    await offscreenCreationPromise;
+  } finally {
+    offscreenCreationPromise = null;
+  }
 }
 
 /**

--- a/src/lib/frontmatter-parser.ts
+++ b/src/lib/frontmatter-parser.ts
@@ -53,7 +53,7 @@ export function parseFrontmatter(content: string): ParsedFrontmatter | null {
       const existing = fields[currentKey];
       const value = stripQuotes(listMatch[1].trim());
       if (Array.isArray(existing)) {
-        existing.push(value);
+        fields[currentKey] = [...existing, value];
       } else {
         fields[currentKey] = [value];
       }


### PR DESCRIPTION
## Summary

- Fix immutability violation in `frontmatter-parser.ts`: replace `Array.push()` mutation with immutable spread operator (`[...existing, value]`) when building YAML list fields
- Fix race condition in `output-handlers.ts`: guard `ensureOffscreenDocument()` with a singleton promise to prevent concurrent `chrome.offscreen.createDocument()` calls when multiple clipboard operations trigger simultaneously

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (799 tests)
- [x] Verify frontmatter parsing with multi-value YAML fields (e.g., tags list)
- [ ] Verify clipboard copy works when triggered in rapid succession

🤖 Generated with [Claude Code](https://claude.com/claude-code)