### PR TITLE
ci: skip commitlint for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         run: npm ci
 
       - name: Validate commit messages
-        if: github.event_name == 'pull_request'
+        # Skip for Dependabot PRs: commit messages use "Bump" (sentence-case) which
+        # violates subject-case rule. Final message is controlled via squash merge.
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
       - name: Run linter


### PR DESCRIPTION
## Summary

- Fix CI failure caused by Dependabot commit messages (`Bump ...`) violating commitlint's `subject-case` rule
- Skip commitlint validation for Dependabot PRs via `github.actor != 'dependabot[bot]'` condition
- Safe because this project enforces squash merge only, so the final commit message is controlled at merge time

## Context

- Prerequisite fix for PR #150 (flatted 3.4.1 → 3.4.2) CI failure
- Unblocks Dependabot Security Alert #21 (CVE-2026-33228, HIGH)

## Test plan

- [x] CI passes on this PR
- [ ] After merge, rebase PR #150 and confirm CI passes