### PR TITLE
feat: add CDP daemon for persistent browser sessions in E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ e2e/auth/state.json
 e2e/.env.local
 e2e/results/
 e2e/baselines/
+e2e/daemon/chrome.pid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,18 @@ npm run lint     # ESLint on src/
 npm run format   # Prettier formatting
 ```
 
+### E2E Selector Validation
+
+```bash
+npm run e2e:auth              # Manual login for all platforms
+npm run e2e:selectors         # Run selector validation
+npm run e2e:daemon start      # Start CDP daemon (headless Chrome + keep-alive)
+npm run e2e:daemon stop       # Stop CDP daemon
+npm run e2e:daemon status     # Check daemon health + open tabs
+```
+
+Re-authentication workflow: `e2e:daemon stop` → `e2e:auth` → `e2e:daemon start`
+
 Load the extension in Chrome: `chrome://extensions` → Load unpacked → select `dist/` folder
 
 ## Architecture

--- a/docs/adr/007-cdp-daemon-persistent-sessions.md
+++ b/docs/adr/007-cdp-daemon-persistent-sessions.md
@@ -1,0 +1,108 @@
+# ADR-007: CDP Daemon for Persistent Browser Sessions
+
+## Status
+
+Accepted (2026-03-23)
+
+## Context
+
+The live selector validation system (DES-015) uses `storageState` injection: `e2e:auth` exports cookies/localStorage to `state.json`, and `e2e:selectors` injects them into a new Playwright-controlled browser via `chromium.launch({ channel: 'chrome' })`.
+
+This approach has two fundamental problems that prevent automated periodic testing:
+
+1. **Claudeflare bot detection (claude.ai)**: Playwright-launched browsers set automation flags (`navigator.webdriver=true`, `--enable-automation`). Claude's Cloudflare configuration (Claudeflare) detects these and triggers a human verification challenge after ~30 minutes. This occurs even with `channel: 'chrome'` (real Chrome binary) and `headless: false`.
+
+2. **Short-lived access tokens (chatgpt.com)**: ChatGPT's access tokens expire within ~30 minutes. In a real browser session, the SPA refreshes tokens via background requests. In the storageState approach, the injected tokens are a static snapshot — no background refresh mechanism runs, so tokens expire without renewal.
+
+Both issues make it impossible to run selector validation on a schedule (1-2x daily) without manual re-authentication each time.
+
+## Decision
+
+Replace the storageState injection approach with a **persistent Chrome CDP daemon**:
+
+1. A non-Playwright Chrome process runs continuously with `--remote-debugging-port=9222` and `--user-data-dir=e2e/auth/profiles`
+2. Tests connect via `chromium.connectOverCDP()` and operate in the **existing default browser context** (which carries real session cookies)
+3. A keep-alive mechanism periodically reloads platform tabs to prevent session timeout
+4. Re-authentication is done by stopping the daemon, running headed Chrome for manual login (existing `e2e:auth` flow), and restarting the daemon
+
+### Why CDP connection avoids bot detection
+
+When Chrome is launched as a normal process (not by Playwright):
+- `navigator.webdriver` is `false`
+- No `--enable-automation` flag
+- Browser fingerprint matches a regular Chrome installation
+- Playwright's `connectOverCDP()` merely attaches to the existing instance — it does not modify browser-level properties
+
+### Architecture
+
+```
+Chrome (24/7, headless)  ←── CDP port 9222
+  --user-data-dir=e2e/auth/profiles
+  Tab1-4: platform pages (keep-alive reload every 15min)
+      │
+      ├── daemon.ts     (Node wrapper: spawn Chrome + keep-alive loop)
+      ├── e2e:selectors  (connectOverCDP → new pages → test → close)
+      └── e2e:auth       (daemon stop → headed auth → daemon start)
+```
+
+### Files
+
+| Action | File |
+|--------|------|
+| Create | `e2e/shared/chrome-finder.ts` (extracted from setup-profile.ts) |
+| Create | `e2e/shared/cdp-utils.ts` (extracted from setup-profile.ts) |
+| Create | `e2e/daemon/config.ts` |
+| Create | `e2e/daemon/types.ts` |
+| Create | `e2e/daemon/pid-manager.ts` |
+| Create | `e2e/daemon/chrome-launcher.ts` |
+| Create | `e2e/daemon/keep-alive.ts` |
+| Create | `e2e/daemon/daemon.ts` (CLI entry point) |
+| Create | `e2e/selectors/browser-provider.ts` (CDP/standalone auto-switch) |
+| Modify | `e2e/auth/setup-profile.ts` (use shared modules, daemon check) |
+| Modify | `e2e/selectors/smoke-test.spec.ts` (use browser-provider) |
+
+## Alternatives Considered
+
+### A: `launchPersistentContext()` with shared profile
+
+Use Playwright's persistent context API with the same `user-data-dir`. Rejected because Playwright still sets automation flags when launching, which triggers Claudeflare.
+
+### B: Pre-test session refresh
+
+Before each test run, launch Chrome with the profile to refresh tokens, re-export storageState, then run tests with the fresh state. Rejected because the refresh step itself would trigger Claudeflare (still Playwright-launched).
+
+### C: Two-tier strategy (stable/fragile platforms)
+
+Run Gemini/Perplexity automatically, Claude/ChatGPT only after manual auth. Rejected because the user requires equal coverage across all 4 platforms.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `--headless=new` detected by Claudeflare | Fallback: headed Chrome with off-screen window position |
+| Chrome crashes overnight | Daemon detects crash via PID check, user notified via Obsidian |
+| Session cookies lost on Chrome restart | Persistent cookies survive in profile; session-only cookies refreshed by SPA on page load |
+| CDP `connectOverCDP` lower fidelity | Acceptable: tests only use `page.evaluate()` for `querySelectorAll`, no complex interaction |
+
+## Consequences
+
+### Positive
+
+- Automated 1-2x daily testing without manual re-authentication
+- Sessions maintained indefinitely via keep-alive reloads
+- Backward compatible: existing `e2e:auth` + `e2e:selectors` standalone mode still works
+- Re-authentication flow is simple: stop daemon, run existing auth, restart daemon
+
+### Negative
+
+- Chrome process runs 24/7 (~500MB-1GB memory)
+- Additional infrastructure to manage (daemon lifecycle, PID files)
+- CDP connection has lower fidelity than native Playwright protocol
+- Headless mode may need empirical validation against Claudeflare
+
+### Future: Linux (Debian) Deployment
+
+Document but do not implement yet:
+- systemd service for Chrome daemon
+- Xvfb virtual display if headless detection is an issue
+- `CHROME_PATH` for Chromium binary on Linux

--- a/e2e/.env.local.example
+++ b/e2e/.env.local.example
@@ -20,3 +20,7 @@ PERPLEXITY_CONV_URL=https://www.perplexity.ai/search/YOUR_SEARCH_ID
 OBSIDIAN_URL=http://127.0.0.1:27123
 OBSIDIAN_API_KEY=YOUR_API_KEY
 OBSIDIAN_VAULT_PATH=AI/selector-health
+
+# CDP Daemon (optional overrides)
+# CDP_PORT=9222
+# KEEP_ALIVE_INTERVAL_MIN=15

--- a/e2e/auth/setup-profile.ts
+++ b/e2e/auth/setup-profile.ts
@@ -15,15 +15,18 @@
  */
 
 import { chromium } from 'playwright';
-import { execSync, spawn, type ChildProcess } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
+import { findChromeExecutable } from '../shared/chrome-finder';
+import { waitForCDP } from '../shared/cdp-utils';
+import { ensurePortAvailable, ensureProfileAvailable } from '../daemon/chrome-launcher';
 
 const AUTH_DIR = import.meta.dirname;
 const PROFILE_DIR = path.join(AUTH_DIR, 'profiles');
 const STATE_PATH = path.join(AUTH_DIR, 'state.json');
-const CDP_PORT = 9222;
+const CDP_PORT = parseInt(process.env.CDP_PORT ?? '9222', 10);
 
 const TARGET_URLS = [
   'https://gemini.google.com',
@@ -32,33 +35,9 @@ const TARGET_URLS = [
   'https://www.perplexity.ai',
 ];
 
-function findChromeExecutable(): string {
-  const chromePath = process.env.CHROME_PATH;
-  if (chromePath) return chromePath;
-
-  const candidates = [
-    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
-  ];
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  try {
-    return execSync('which google-chrome', { encoding: 'utf-8' }).trim();
-  } catch {
-    throw new Error(
-      'Google Chrome not found. Install Chrome or set CHROME_PATH environment variable.',
-    );
-  }
-}
-
 function waitForLine(prompt: string): Promise<void> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     rl.question(prompt, () => {
       rl.close();
       resolve();
@@ -66,24 +45,17 @@ function waitForLine(prompt: string): Promise<void> {
   });
 }
 
-/**
- * Wait for Chrome's CDP endpoint to become available.
- */
-async function waitForCDP(port: number, timeoutMs = 15_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
-      if (res.ok) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  throw new Error(`CDP endpoint not available on port ${port} after ${timeoutMs}ms`);
-}
-
 async function setupProfile(): Promise<void> {
+  // Pre-flight: abort if port or profile is already in use.
+  // This catches both daemon Chrome and orphan Chrome processes.
+  try {
+    await ensurePortAvailable(CDP_PORT);
+    ensureProfileAvailable(PROFILE_DIR);
+  } catch (err) {
+    console.error(`[G2O Auth] ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
+
   const chromePath = findChromeExecutable();
 
   if (!fs.existsSync(PROFILE_DIR)) {
@@ -102,15 +74,19 @@ async function setupProfile(): Promise<void> {
   console.log('  5. Chrome will close\n');
 
   // Launch Chrome with CDP port for later connection
-  const chromeProcess: ChildProcess = spawn(chromePath, [
-    `--user-data-dir=${PROFILE_DIR}`,
-    `--remote-debugging-port=${CDP_PORT}`,
-    '--no-first-run',
-    '--no-default-browser-check',
-    ...TARGET_URLS,
-  ], {
-    stdio: 'ignore',
-  });
+  const chromeProcess: ChildProcess = spawn(
+    chromePath,
+    [
+      `--user-data-dir=${PROFILE_DIR}`,
+      `--remote-debugging-port=${CDP_PORT}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+      ...TARGET_URLS,
+    ],
+    {
+      stdio: 'ignore',
+    }
+  );
 
   // Wait for CDP to be ready
   console.log('Waiting for Chrome to start...');
@@ -149,7 +125,7 @@ async function setupProfile(): Promise<void> {
   }
 
   // Wait for Chrome to exit
-  await new Promise<void>((resolve) => {
+  await new Promise<void>(resolve => {
     chromeProcess.on('exit', () => resolve());
     // Give Chrome a moment, then force kill if needed
     setTimeout(() => {

--- a/e2e/daemon/__tests__/chrome-launcher.test.ts
+++ b/e2e/daemon/__tests__/chrome-launcher.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { ensureProfileAvailable, readSingletonLockPid } from '../chrome-launcher';
+
+/** Check if a symlink itself exists (does NOT follow the target). */
+function symlinkExists(p: string): boolean {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('readSingletonLockPid', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no lock exists', () => {
+    expect(readSingletonLockPid(tmpDir)).toBeNull();
+  });
+
+  it('reads PID from a valid lock symlink', () => {
+    fs.symlinkSync(`${os.hostname()}-42`, path.join(tmpDir, 'SingletonLock'));
+    expect(readSingletonLockPid(tmpDir)).toBe(42);
+  });
+
+  it('returns null for unreadable format', () => {
+    fs.symlinkSync('garbled', path.join(tmpDir, 'SingletonLock'));
+    expect(readSingletonLockPid(tmpDir)).toBeNull();
+  });
+});
+
+describe('ensureProfileAvailable', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('passes when no SingletonLock exists', () => {
+    expect(() => ensureProfileAvailable(tmpDir)).not.toThrow();
+  });
+
+  it('removes stale lock when PID is not running', () => {
+    const lockPath = path.join(tmpDir, 'SingletonLock');
+    fs.symlinkSync(`${os.hostname()}-99999999`, lockPath);
+    expect(symlinkExists(lockPath)).toBe(true);
+
+    ensureProfileAvailable(tmpDir);
+    expect(symlinkExists(lockPath)).toBe(false);
+  });
+
+  it('throws when lock is held by a running process', () => {
+    const lockPath = path.join(tmpDir, 'SingletonLock');
+    fs.symlinkSync(`${os.hostname()}-${process.pid}`, lockPath);
+
+    expect(() => ensureProfileAvailable(tmpDir)).toThrow(
+      `Profile is locked by a running Chrome (PID ${process.pid})`,
+    );
+    // Lock must NOT be removed
+    expect(symlinkExists(lockPath)).toBe(true);
+  });
+
+  it('removes lock with unreadable PID format', () => {
+    const lockPath = path.join(tmpDir, 'SingletonLock');
+    fs.symlinkSync('garbled-data', lockPath);
+
+    ensureProfileAvailable(tmpDir);
+    expect(symlinkExists(lockPath)).toBe(false);
+  });
+});

--- a/e2e/daemon/__tests__/config.test.ts
+++ b/e2e/daemon/__tests__/config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadConfig } from '../config';
+
+describe('loadConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns default values', () => {
+    delete process.env.CDP_PORT;
+    delete process.env.KEEP_ALIVE_INTERVAL_MIN;
+
+    const config = loadConfig();
+    expect(config.cdpPort).toBe(9222);
+    expect(config.keepAliveIntervalMs).toBe(15 * 60 * 1000);
+    expect(config.platformUrls).toHaveLength(4);
+    expect(config.profileDir).toMatch(/e2e\/auth\/profiles$/);
+    expect(config.pidFile).toMatch(/e2e\/daemon\/chrome\.pid$/);
+  });
+
+  it('respects CDP_PORT env var', () => {
+    process.env.CDP_PORT = '9333';
+    const config = loadConfig();
+    expect(config.cdpPort).toBe(9333);
+  });
+
+  it('respects KEEP_ALIVE_INTERVAL_MIN env var', () => {
+    process.env.KEEP_ALIVE_INTERVAL_MIN = '5';
+    const config = loadConfig();
+    expect(config.keepAliveIntervalMs).toBe(5 * 60 * 1000);
+  });
+
+  it('includes required Chrome flags', () => {
+    const config = loadConfig();
+    expect(config.chromeFlags).toContain('--no-first-run');
+    expect(config.chromeFlags).toContain('--disable-background-timer-throttling');
+  });
+
+  it('throws on invalid CDP_PORT', () => {
+    process.env.CDP_PORT = 'abc';
+    expect(() => loadConfig()).toThrow('Invalid CDP_PORT');
+  });
+
+  it('throws on out-of-range CDP_PORT', () => {
+    process.env.CDP_PORT = '99999';
+    expect(() => loadConfig()).toThrow('Invalid CDP_PORT');
+  });
+
+  it('includes all 4 platform URLs', () => {
+    const config = loadConfig();
+    expect(config.platformUrls).toContain('https://gemini.google.com');
+    expect(config.platformUrls).toContain('https://claude.ai');
+    expect(config.platformUrls).toContain('https://chatgpt.com');
+    expect(config.platformUrls).toContain('https://www.perplexity.ai');
+  });
+});

--- a/e2e/daemon/__tests__/pid-manager.test.ts
+++ b/e2e/daemon/__tests__/pid-manager.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { writePid, readPid, isProcessRunning, removePid } from '../pid-manager';
+
+describe('pid-manager', () => {
+  let tmpDir: string;
+  let pidFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pid-test-'));
+    pidFile = path.join(tmpDir, 'test.pid');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('writePid', () => {
+    it('writes PID to file', () => {
+      writePid(pidFile, 12345);
+      expect(fs.readFileSync(pidFile, 'utf-8')).toBe('12345');
+    });
+
+    it('overwrites existing PID file', () => {
+      writePid(pidFile, 11111);
+      writePid(pidFile, 22222);
+      expect(fs.readFileSync(pidFile, 'utf-8')).toBe('22222');
+    });
+  });
+
+  describe('readPid', () => {
+    it('returns PID from existing file', () => {
+      fs.writeFileSync(pidFile, '12345');
+      expect(readPid(pidFile)).toBe(12345);
+    });
+
+    it('returns null when file does not exist', () => {
+      expect(readPid(pidFile)).toBeNull();
+    });
+
+    it('returns null for non-numeric content', () => {
+      fs.writeFileSync(pidFile, 'not-a-number');
+      expect(readPid(pidFile)).toBeNull();
+    });
+
+    it('returns null for empty file', () => {
+      fs.writeFileSync(pidFile, '');
+      expect(readPid(pidFile)).toBeNull();
+    });
+  });
+
+  describe('removePid', () => {
+    it('removes existing PID file', () => {
+      fs.writeFileSync(pidFile, '12345');
+      removePid(pidFile);
+      expect(fs.existsSync(pidFile)).toBe(false);
+    });
+
+    it('does nothing when file does not exist', () => {
+      expect(() => removePid(pidFile)).not.toThrow();
+    });
+  });
+
+  describe('isProcessRunning', () => {
+    it('returns true for current process', () => {
+      expect(isProcessRunning(process.pid)).toBe(true);
+    });
+
+    it('returns false for non-existent PID', () => {
+      // PID 99999999 is extremely unlikely to exist
+      expect(isProcessRunning(99999999)).toBe(false);
+    });
+  });
+});

--- a/e2e/daemon/chrome-launcher.ts
+++ b/e2e/daemon/chrome-launcher.ts
@@ -1,0 +1,313 @@
+/**
+ * Chrome process launcher for the CDP daemon.
+ *
+ * Spawns Chrome as a regular process (not via Playwright) to avoid
+ * automation flags that trigger bot detection.
+ *
+ * IMPORTANT: All pre-flight checks (port, SingletonLock) MUST pass
+ * before Chrome is spawned. If any check fails, the function throws
+ * instead of proceeding — no warnings, no partial state.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { chromium, type Cookie } from 'playwright';
+import { findChromeExecutable } from '../shared/chrome-finder';
+import { waitForCDP } from '../shared/cdp-utils';
+import type { DaemonConfig } from './config';
+
+interface StorageState {
+  readonly cookies: Cookie[];
+  readonly origins: Array<{
+    origin: string;
+    localStorage: Array<{ name: string; value: string }>;
+  }>;
+}
+
+// ─── Pre-flight checks ────────────────────────────────────────────
+
+/**
+ * Read the PID from a SingletonLock symlink.
+ * Returns null if the lock doesn't exist or is unreadable.
+ */
+export function readSingletonLockPid(profileDir: string): number | null {
+  const lockPath = path.join(profileDir, 'SingletonLock');
+  try {
+    const target = fs.readlinkSync(lockPath);
+    const pidStr = target.split('-').pop();
+    const pid = pidStr ? parseInt(pidStr, 10) : NaN;
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure no other Chrome is using the profile directory.
+ *
+ * - If SingletonLock exists and the owning process is alive → throw (hard stop)
+ * - If SingletonLock exists but the owning process is dead → remove the stale lock
+ * - If SingletonLock doesn't exist → pass
+ */
+export function ensureProfileAvailable(profileDir: string): void {
+  const lockPath = path.join(profileDir, 'SingletonLock');
+
+  let lockExists: boolean;
+  try {
+    fs.lstatSync(lockPath);
+    lockExists = true;
+  } catch {
+    lockExists = false;
+  }
+
+  if (!lockExists) return;
+
+  const pid = readSingletonLockPid(profileDir);
+
+  if (pid === null) {
+    // Unreadable lock — remove it
+    fs.unlinkSync(lockPath);
+    console.log('[G2O Daemon] Removed unreadable SingletonLock.');
+    return;
+  }
+
+  let processAlive: boolean;
+  try {
+    process.kill(pid, 0);
+    processAlive = true;
+  } catch {
+    processAlive = false;
+  }
+
+  if (processAlive) {
+    throw new Error(
+      `Profile is locked by a running Chrome (PID ${pid}).\n` +
+        `Kill it first:  kill ${pid}\n` +
+        `Then retry:     npm run e2e:daemon start`
+    );
+  }
+
+  // Stale lock — safe to remove
+  fs.unlinkSync(lockPath);
+  console.log(`[G2O Daemon] Removed stale SingletonLock (PID ${pid} not running).`);
+}
+
+/**
+ * Ensure the CDP port is not already occupied.
+ * If it is, someone else is listening — we must NOT proceed.
+ */
+export async function ensurePortAvailable(cdpPort: number): Promise<void> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${cdpPort}/json/version`);
+    if (res.ok) {
+      throw new Error(
+        `CDP port ${cdpPort} is already in use (another Chrome or process is listening).\n` +
+          `Find and kill it:  lsof -i :${cdpPort}\n` +
+          `Then retry:        npm run e2e:daemon start`
+      );
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('already in use')) {
+      throw err; // Re-throw our own error
+    }
+    // fetch failed (connection refused) → port is free, good
+  }
+}
+
+// ─── Launch ────────────────────────────────────────────────────────
+
+/**
+ * Launch Chrome with CDP enabled.
+ *
+ * Pre-flight checks (port, SingletonLock) are enforced before spawn.
+ * Chrome starts with about:blank; platform tabs are opened separately
+ * via {@link openPlatformTabs}.
+ *
+ * @returns The Chrome child process after CDP is confirmed ready.
+ */
+export async function launchChrome(config: DaemonConfig): Promise<ChildProcess> {
+  const chromePath = findChromeExecutable();
+
+  // --- Pre-flight: abort if resources are occupied ---
+  await ensurePortAvailable(config.cdpPort);
+  ensureProfileAvailable(config.profileDir);
+
+  const args = [
+    `--user-data-dir=${config.profileDir}`,
+    `--remote-debugging-port=${config.cdpPort}`,
+    ...(config.headless ? ['--headless=new'] : []),
+    ...config.chromeFlags,
+    'about:blank',
+  ];
+
+  console.log(`[G2O Daemon] Launching Chrome: ${chromePath}`);
+  console.log(`[G2O Daemon] Profile: ${config.profileDir}`);
+  console.log(`[G2O Daemon] CDP port: ${config.cdpPort}`);
+  console.log(`[G2O Daemon] Headless: ${config.headless}`);
+
+  const chromeProcess = spawn(chromePath, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    detached: false,
+  });
+
+  // Surface Chrome stderr for diagnostics
+  chromeProcess.stderr?.on('data', (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) console.error(`[Chrome] ${line}`);
+  });
+
+  // Track spawn errors (emitted asynchronously, e.g. ENOENT).
+  const spawnState = { error: null as Error | null };
+  chromeProcess.on('error', err => {
+    spawnState.error = err;
+    console.error(`[G2O Daemon] Chrome process error: ${err.message}`);
+  });
+
+  // Wait for CDP endpoint to be ready
+  try {
+    await waitForCDP(config.cdpPort);
+    console.log('[G2O Daemon] Chrome CDP ready.');
+  } catch {
+    chromeProcess.kill();
+    throw spawnState.error
+      ? new Error(`Chrome failed to start: ${spawnState.error.message}`)
+      : new Error(
+          `Chrome started but CDP not available on port ${config.cdpPort}. ` +
+            `Is the port already in use?`
+        );
+  }
+
+  return chromeProcess;
+}
+
+// ─── Cookie injection ──────────────────────────────────────────────
+
+/**
+ * Inject session cookies from state.json into the browser context.
+ *
+ * Chrome's profile directory only persists cookies with an explicit
+ * `expires` attribute. Session cookies (no expiry) live in memory only
+ * and are lost when Chrome closes. Since `e2e:auth` captures ALL
+ * cookies (including session cookies) to state.json, we re-inject
+ * them so the daemon has a complete cookie jar.
+ */
+async function injectStorageState(
+  statePath: string,
+  context: import('playwright').BrowserContext
+): Promise<void> {
+  if (!fs.existsSync(statePath)) {
+    console.warn(
+      `[G2O Daemon] state.json not found at ${statePath}. ` +
+        `Session cookies will be missing. Run: npm run e2e:auth`
+    );
+    return;
+  }
+
+  const raw = fs.readFileSync(statePath, 'utf-8');
+  const state: StorageState = JSON.parse(raw);
+
+  if (state.cookies?.length) {
+    await context.addCookies(state.cookies);
+    console.log(`[G2O Daemon] Injected ${state.cookies.length} cookies from state.json.`);
+  }
+}
+
+// ─── Tab management ────────────────────────────────────────────────
+
+/**
+ * Open platform tabs via Playwright CDP connection.
+ *
+ * 1. Injects cookies from state.json (session cookies lost on Chrome restart)
+ * 2. Opens a new page for each platform URL
+ * 3. Disconnects (Chrome and tabs keep running)
+ */
+export async function openPlatformTabs(config: DaemonConfig): Promise<void> {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${config.cdpPort}`);
+  try {
+    const context = browser.contexts()[0];
+    if (!context) {
+      throw new Error('No browser context found. Chrome may not have fully started.');
+    }
+
+    await injectStorageState(config.statePath, context);
+
+    for (const url of config.platformUrls) {
+      try {
+        const page = await context.newPage();
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+        console.log(`[G2O Daemon] Opened: ${url}`);
+      } catch (err) {
+        console.warn(
+          `[G2O Daemon] Failed to open ${url}: ${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`[G2O Daemon] ${config.platformUrls.length} platform tabs ready.`);
+}
+
+// ─── Shutdown ──────────────────────────────────────────────────────
+
+/**
+ * Gracefully stop Chrome. Sends SIGTERM, then SIGKILL after timeout.
+ */
+export async function stopChrome(pid: number, timeoutMs = 5000): Promise<void> {
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return; // Process already gone
+  }
+
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return; // Process exited
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Already gone
+  }
+}
+
+/**
+ * Kill whatever is using the CDP port and profile, regardless of
+ * whether it was started by the daemon or not.
+ *
+ * Used by `stop` to clean up orphaned Chrome processes.
+ */
+export function killOrphanChrome(config: DaemonConfig): boolean {
+  const lockPid = readSingletonLockPid(config.profileDir);
+  if (lockPid === null) return false;
+
+  let alive: boolean;
+  try {
+    process.kill(lockPid, 0);
+    alive = true;
+  } catch {
+    alive = false;
+  }
+
+  if (!alive) {
+    // Just clean up the stale lock
+    ensureProfileAvailable(config.profileDir);
+    return false;
+  }
+
+  console.log(`[G2O Daemon] Killing orphan Chrome (PID ${lockPid})...`);
+  try {
+    process.kill(lockPid, 'SIGTERM');
+  } catch {
+    // already gone
+  }
+  return true;
+}

--- a/e2e/daemon/config.ts
+++ b/e2e/daemon/config.ts
@@ -1,0 +1,61 @@
+/**
+ * CDP daemon configuration.
+ *
+ * All values can be overridden via environment variables.
+ */
+
+import path from 'path';
+
+export interface DaemonConfig {
+  readonly cdpPort: number;
+  readonly profileDir: string;
+  readonly statePath: string;
+  readonly pidFile: string;
+  readonly keepAliveIntervalMs: number;
+  readonly headless: boolean;
+  readonly platformUrls: readonly string[];
+  readonly chromeFlags: readonly string[];
+}
+
+const E2E_DIR = path.resolve(import.meta.dirname, '..');
+
+function parsePort(raw: string | undefined, fallback: number): number {
+  const port = parseInt(raw ?? String(fallback), 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid CDP_PORT: "${raw}". Must be 1–65535.`);
+  }
+  return port;
+}
+
+export function loadConfig(): DaemonConfig {
+  const cdpPort = parsePort(process.env.CDP_PORT, 9222);
+  const keepAliveMin = parseInt(process.env.KEEP_ALIVE_INTERVAL_MIN ?? '15', 10);
+
+  // DAEMON_HEADED=1 disables headless (useful for macOS firewall approval or debugging)
+  const headless = process.env.DAEMON_HEADED !== '1';
+
+  return {
+    cdpPort,
+    headless,
+    profileDir: path.join(E2E_DIR, 'auth', 'profiles'),
+    statePath: path.join(E2E_DIR, 'auth', 'state.json'),
+    pidFile: path.join(E2E_DIR, 'daemon', 'chrome.pid'),
+    keepAliveIntervalMs: keepAliveMin * 60 * 1000,
+    platformUrls: [
+      'https://gemini.google.com',
+      'https://claude.ai',
+      'https://chatgpt.com',
+      'https://www.perplexity.ai',
+    ],
+    chromeFlags: [
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      // Override headless UA to avoid Cloudflare bot detection.
+      // --headless=new still exposes "HeadlessChrome" in User-Agent.
+      '--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.7680.81 Safari/537.36',
+    ],
+  };
+}

--- a/e2e/daemon/daemon.ts
+++ b/e2e/daemon/daemon.ts
@@ -1,0 +1,162 @@
+/**
+ * CDP Daemon CLI entry point.
+ *
+ * Usage:
+ *   npx tsx e2e/daemon/daemon.ts start   — Launch Chrome + keep-alive
+ *   npx tsx e2e/daemon/daemon.ts stop    — Stop Chrome daemon
+ *   npx tsx e2e/daemon/daemon.ts status  — Check daemon health
+ */
+
+import { loadConfig } from './config';
+import { writePid, readPid, isProcessRunning, removePid } from './pid-manager';
+import { launchChrome, openPlatformTabs, stopChrome, killOrphanChrome } from './chrome-launcher';
+import { runKeepAlive } from './keep-alive';
+import type { DaemonCommand } from './types';
+
+async function start(): Promise<void> {
+  const config = loadConfig();
+
+  // 1. Check PID file — is the daemon already running?
+  const existingPid = readPid(config.pidFile);
+  if (existingPid !== null && isProcessRunning(existingPid)) {
+    console.error(
+      `[G2O Daemon] Already running (PID ${existingPid}). ` + `Use 'npm run e2e:daemon stop' first.`
+    );
+    process.exit(1);
+  }
+  if (existingPid !== null) {
+    console.log(`[G2O Daemon] Removing stale PID file (PID ${existingPid} not running).`);
+    removePid(config.pidFile);
+  }
+
+  // 2. launchChrome runs pre-flight checks (port + SingletonLock) and
+  //    throws if resources are occupied. No Chrome is spawned until
+  //    all checks pass.
+  const chromeProcess = await launchChrome(config);
+  const pid = chromeProcess.pid;
+
+  if (pid === undefined) {
+    console.error('[G2O Daemon] Chrome started but PID is undefined.');
+    process.exit(1);
+  }
+
+  if (chromeProcess.exitCode !== null) {
+    console.error(`[G2O Daemon] Chrome exited immediately (code ${chromeProcess.exitCode}).`);
+    process.exit(1);
+  }
+
+  writePid(config.pidFile, pid);
+  console.log(`[G2O Daemon] Started (PID ${pid}).`);
+
+  // 3. Inject session cookies from state.json + open platform tabs
+  await openPlatformTabs(config);
+
+  // 4. Start keep-alive loop
+  const keepAliveInterval = setInterval(async () => {
+    try {
+      await runKeepAlive(config);
+    } catch (err) {
+      console.error(`[G2O Keep-Alive] Error: ${err instanceof Error ? err.message : err}`);
+    }
+  }, config.keepAliveIntervalMs);
+
+  console.log(`[G2O Daemon] Keep-alive every ${config.keepAliveIntervalMs / 60_000} minutes.`);
+
+  // 5. Handle Chrome exit
+  chromeProcess.on('exit', code => {
+    console.log(`[G2O Daemon] Chrome exited with code ${code}.`);
+    clearInterval(keepAliveInterval);
+    removePid(config.pidFile);
+    process.exit(code ?? 1);
+  });
+
+  // 6. Graceful shutdown on signals
+  const shutdown = () => {
+    console.log('\n[G2O Daemon] Shutting down...');
+    clearInterval(keepAliveInterval);
+    chromeProcess.kill('SIGTERM');
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function stop(): Promise<void> {
+  const config = loadConfig();
+  const pid = readPid(config.pidFile);
+
+  if (pid !== null && isProcessRunning(pid)) {
+    // Normal case: daemon PID file points to a live process
+    console.log(`[G2O Daemon] Stopping Chrome (PID ${pid})...`);
+    await stopChrome(pid);
+    removePid(config.pidFile);
+    console.log('[G2O Daemon] Stopped.');
+    return;
+  }
+
+  // PID file is stale or missing — check for orphan Chrome
+  if (pid !== null) {
+    removePid(config.pidFile);
+  }
+
+  const killed = killOrphanChrome(config);
+  if (killed) {
+    // Give it a moment to exit and release SingletonLock
+    await new Promise(r => setTimeout(r, 2000));
+    console.log('[G2O Daemon] Orphan Chrome killed.');
+  } else {
+    console.log('[G2O Daemon] Not running.');
+  }
+}
+
+async function status(): Promise<void> {
+  const config = loadConfig();
+  const pid = readPid(config.pidFile);
+
+  if (pid === null) {
+    console.log('[G2O Daemon] Not running (no PID file).');
+  } else if (!isProcessRunning(pid)) {
+    console.log(`[G2O Daemon] PID ${pid} found but process not running (stale PID file).`);
+  } else {
+    console.log(`[G2O Daemon] Running (PID ${pid}).`);
+  }
+
+  // Check CDP health regardless of PID (another Chrome might be listening)
+  try {
+    const versionRes = await fetch(`http://127.0.0.1:${config.cdpPort}/json/version`);
+    if (versionRes.ok) {
+      const version = (await versionRes.json()) as Record<string, string>;
+      console.log(`[G2O Daemon] Chrome on port ${config.cdpPort}: ${version.Browser ?? 'unknown'}`);
+    }
+
+    const listRes = await fetch(`http://127.0.0.1:${config.cdpPort}/json/list`);
+    if (listRes.ok) {
+      const tabs = (await listRes.json()) as Array<{ url: string; title: string }>;
+      console.log(`[G2O Daemon] Open tabs: ${tabs.length}`);
+      for (const tab of tabs) {
+        console.log(`  - ${tab.url} (${tab.title})`);
+      }
+    }
+  } catch {
+    console.log(`[G2O Daemon] No CDP endpoint on port ${config.cdpPort}.`);
+  }
+}
+
+// --- CLI ---
+
+const command = process.argv[2] as DaemonCommand | undefined;
+
+const commands: Record<DaemonCommand, () => Promise<void>> = {
+  start,
+  stop,
+  status,
+};
+
+if (!command || !(command in commands)) {
+  console.error('Usage: npx tsx e2e/daemon/daemon.ts <start|stop|status>');
+  process.exit(1);
+}
+
+commands[command]().catch(err => {
+  console.error(`[G2O Daemon] Fatal: ${err instanceof Error ? err.message : err}`);
+  process.exit(1);
+});

--- a/e2e/daemon/keep-alive.ts
+++ b/e2e/daemon/keep-alive.ts
@@ -1,0 +1,76 @@
+/**
+ * Keep-alive: periodically reload platform tabs to maintain sessions.
+ *
+ * Connects to Chrome via Playwright's CDP connection, reloads matching
+ * platform tabs, then disconnects. The browser stays running.
+ */
+
+import { chromium } from 'playwright';
+import type { DaemonConfig } from './config';
+import type { KeepAliveResult } from './types';
+
+/**
+ * Reload all platform tabs via CDP.
+ *
+ * Creates a temporary CDP connection, reloads pages whose URLs
+ * match any platform URL prefix, then disconnects.
+ */
+export async function runKeepAlive(config: DaemonConfig): Promise<KeepAliveResult> {
+  let reloaded = 0;
+  let errors = 0;
+
+  let browser;
+  try {
+    browser = await chromium.connectOverCDP(`http://127.0.0.1:${config.cdpPort}`);
+    const contexts = browser.contexts();
+
+    if (contexts.length === 0) {
+      console.warn('[G2O Keep-Alive] No browser contexts found.');
+      return { timestamp: new Date().toISOString(), reloaded: 0, errors: 1 };
+    }
+
+    const pages = contexts[0].pages();
+
+    for (const page of pages) {
+      const url = page.url();
+      const matchesPlatform = config.platformUrls.some(prefix => url.startsWith(prefix));
+
+      if (!matchesPlatform) continue;
+
+      try {
+        await page.reload({ timeout: 30_000, waitUntil: 'domcontentloaded' });
+        reloaded++;
+      } catch (err) {
+        errors++;
+        console.warn(
+          `[G2O Keep-Alive] Failed to reload ${url}: ${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+  } catch (err) {
+    console.error(
+      `[G2O Keep-Alive] CDP connection failed: ${err instanceof Error ? err.message : err}`
+    );
+    return { timestamp: new Date().toISOString(), reloaded: 0, errors: 1 };
+  } finally {
+    if (browser) {
+      try {
+        // Disconnect only — does NOT close Chrome
+        await browser.close();
+      } catch (err) {
+        console.warn(
+          `[G2O Keep-Alive] Disconnect error (non-fatal): ${err instanceof Error ? err.message : err}`
+        );
+      }
+    }
+  }
+
+  const result: KeepAliveResult = {
+    timestamp: new Date().toISOString(),
+    reloaded,
+    errors,
+  };
+
+  console.log(`[G2O Keep-Alive] ${result.timestamp} — reloaded: ${reloaded}, errors: ${errors}`);
+  return result;
+}

--- a/e2e/daemon/pid-manager.ts
+++ b/e2e/daemon/pid-manager.ts
@@ -1,0 +1,40 @@
+/**
+ * PID file management for the Chrome daemon process.
+ */
+
+import fs from 'fs';
+
+/** Write a PID to the specified file. */
+export function writePid(pidFile: string, pid: number): void {
+  fs.writeFileSync(pidFile, String(pid));
+}
+
+/** Read PID from file. Returns null if file doesn't exist or content is invalid. */
+export function readPid(pidFile: string): number | null {
+  try {
+    const content = fs.readFileSync(pidFile, 'utf-8').trim();
+    const pid = parseInt(content, 10);
+    return Number.isNaN(pid) || content === '' ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove PID file. No-op if file doesn't exist. */
+export function removePid(pidFile: string): void {
+  try {
+    fs.unlinkSync(pidFile);
+  } catch {
+    // file doesn't exist, that's fine
+  }
+}
+
+/** Check if a process with the given PID is running. */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/e2e/daemon/types.ts
+++ b/e2e/daemon/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared types for the CDP daemon.
+ */
+
+export type DaemonCommand = 'start' | 'stop' | 'status';
+
+export interface TabInfo {
+  readonly id: string;
+  readonly url: string;
+  readonly title: string;
+  readonly webSocketDebuggerUrl: string;
+}
+
+export interface KeepAliveResult {
+  readonly timestamp: string;
+  readonly reloaded: number;
+  readonly errors: number;
+}

--- a/e2e/selectors/__tests__/browser-provider.test.ts
+++ b/e2e/selectors/__tests__/browser-provider.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isCdpAvailable, type BrowserSession } from '../browser-provider';
+
+describe('browser-provider', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('isCdpAvailable', () => {
+    it('returns true when CDP endpoint responds OK', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+      expect(await isCdpAvailable(9222)).toBe(true);
+    });
+
+    it('returns false when CDP endpoint is unreachable', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+      expect(await isCdpAvailable(9222)).toBe(false);
+    });
+
+    it('returns false when CDP endpoint returns non-OK', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      expect(await isCdpAvailable(9222)).toBe(false);
+    });
+  });
+
+  describe('BrowserSession type', () => {
+    it('has required interface shape', () => {
+      // Type-level test: verify the interface compiles
+      const session: BrowserSession = {
+        context: {} as BrowserSession['context'],
+        mode: 'cdp',
+        cleanup: async () => {},
+      };
+      expect(session.mode).toBe('cdp');
+
+      const standaloneSession: BrowserSession = {
+        context: {} as BrowserSession['context'],
+        mode: 'standalone',
+        cleanup: async () => {},
+      };
+      expect(standaloneSession.mode).toBe('standalone');
+    });
+  });
+});

--- a/e2e/selectors/auth-check.ts
+++ b/e2e/selectors/auth-check.ts
@@ -55,6 +55,7 @@ export async function checkAuthStatus(
       return 'authenticated';
     }
 
+    console.warn(`[G2O Auth] ${platform}: auth_expired — expected ${pattern}, got: ${currentUrl}`);
     return 'auth_expired';
   } catch {
     return 'unreachable';

--- a/e2e/selectors/browser-provider.ts
+++ b/e2e/selectors/browser-provider.ts
@@ -1,0 +1,101 @@
+/**
+ * Browser session provider for E2E selector validation.
+ *
+ * Automatically selects between two modes:
+ * - CDP: Connects to a running Chrome daemon (preferred, avoids bot detection)
+ * - Standalone: Launches a new Playwright browser with storageState (fallback)
+ *
+ * @see docs/adr/007-cdp-daemon-persistent-sessions.md
+ */
+
+import { chromium } from '@playwright/test';
+import type { BrowserContext } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_CDP_PORT = (() => {
+  const port = parseInt(process.env.CDP_PORT ?? '9222', 10);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : 9222;
+})();
+const STATE_PATH = path.join(import.meta.dirname, '..', 'auth', 'state.json');
+
+export interface BrowserSession {
+  readonly context: BrowserContext;
+  readonly mode: 'cdp' | 'standalone';
+  cleanup(): Promise<void>;
+}
+
+/** Check if a CDP endpoint is reachable. */
+export async function isCdpAvailable(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/version`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Acquire a browser session, preferring CDP daemon over standalone.
+ *
+ * In CDP mode:
+ * - Connects to existing Chrome (no automation flags)
+ * - Uses the default browser context (real session cookies)
+ * - cleanup() disconnects without killing Chrome
+ *
+ * In standalone mode:
+ * - Launches a new Chrome via Playwright (existing behavior)
+ * - Injects storageState from state.json
+ * - cleanup() closes browser
+ */
+export async function acquireBrowserSession(
+  cdpPort: number = DEFAULT_CDP_PORT
+): Promise<BrowserSession> {
+  // Try CDP first
+  if (await isCdpAvailable(cdpPort)) {
+    const browser = await chromium.connectOverCDP(`http://127.0.0.1:${cdpPort}`);
+    const contexts = browser.contexts();
+
+    if (contexts.length === 0) {
+      await browser.close();
+      throw new Error('CDP connected but no browser contexts found. Is Chrome fully loaded?');
+    }
+
+    return {
+      context: contexts[0],
+      mode: 'cdp',
+      async cleanup() {
+        // Disconnect only — Chrome keeps running
+        await browser.close();
+      },
+    };
+  }
+
+  // Fallback to standalone mode
+  if (!fs.existsSync(STATE_PATH)) {
+    throw new Error(
+      `Neither CDP daemon nor storageState available.\n` +
+        `Start the daemon: npm run e2e:daemon start\n` +
+        `Or create storageState: npm run e2e:auth`
+    );
+  }
+
+  console.log('[G2O E2E] CDP daemon not available, falling back to standalone mode.');
+
+  const browser = await chromium.launch({
+    channel: 'chrome',
+    headless: false,
+  });
+  const context = await browser.newContext({
+    storageState: STATE_PATH,
+  });
+
+  return {
+    context,
+    mode: 'standalone',
+    async cleanup() {
+      await context.close();
+      await browser.close();
+    },
+  };
+}

--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -1,16 +1,16 @@
 /**
  * Live Selector Validation Smoke Test
  *
- * Uses storageState (cookies + localStorage) exported by e2e:auth
- * and Playwright's bundled Chromium — no Chrome profile directory sharing,
- * no SingletonLock, no keychain encryption issues.
+ * Connects to the CDP daemon (preferred) or falls back to Playwright
+ * with storageState injection.
  *
+ * @see docs/adr/007-cdp-daemon-persistent-sessions.md
  * @see docs/design/DES-015-live-selector-validation.md
  */
 
-import { test, expect, chromium } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import type { BrowserContext, Page } from 'playwright';
-import fs from 'fs';
+import { acquireBrowserSession, type BrowserSession } from './browser-provider';
 import path from 'path';
 import dotenv from 'dotenv';
 import {
@@ -28,8 +28,6 @@ import { hasBaseline, saveBaseline, loadBaseline, compareWithBaseline } from './
 import { classifyResults, type SelectorResult } from './classifier';
 
 dotenv.config({ path: path.join(import.meta.dirname, '..', '.env.local') });
-
-const STATE_PATH = path.join(import.meta.dirname, '..', 'auth', 'state.json');
 
 /**
  * Page-ready selectors: wait for these after navigation to confirm
@@ -141,37 +139,18 @@ async function runPlatformValidation(
   }
 }
 
-// --- Shared context using storageState ---
+// --- Shared browser session (CDP daemon or standalone fallback) ---
 
-let sharedContext: BrowserContext;
+let session: BrowserSession;
 
 test.beforeAll(async () => {
-  if (!fs.existsSync(STATE_PATH)) {
-    throw new Error(
-      `storageState not found at ${STATE_PATH}\n` + `Run 'npm run e2e:auth' first to create it.`
-    );
-  }
-
-  // Use system Chrome in headed mode for maximum reliability:
-  // - channel: 'chrome' — real Chrome binary, not detectable as automation
-  // - headless: false — Cloudflare bot detection is much less aggressive in headed mode
-  // - storageState — cookies injected from state.json, no profile directory sharing
-  const browser = await chromium.launch({
-    channel: 'chrome',
-    headless: false,
-  });
-  sharedContext = await browser.newContext({
-    storageState: STATE_PATH,
-  });
+  session = await acquireBrowserSession();
+  console.log(`[G2O E2E] Browser mode: ${session.mode}`);
 });
 
 test.afterAll(async () => {
-  if (sharedContext) {
-    const browser = sharedContext.browser();
-    await sharedContext.close();
-    if (browser) {
-      await browser.close();
-    }
+  if (session) {
+    await session.cleanup();
   }
 });
 
@@ -180,7 +159,7 @@ test.afterAll(async () => {
 test.describe('Gemini', () => {
   test('conversation selectors', async () => {
     await runPlatformValidation(
-      sharedContext,
+      session.context,
       'gemini',
       process.env.GEMINI_CONV_URL,
       'gemini_conv',
@@ -191,7 +170,7 @@ test.describe('Gemini', () => {
   });
 
   test('deep research selectors', async () => {
-    await runPlatformValidation(sharedContext, 'gemini', process.env.GEMINI_DR_URL, 'gemini_dr', {
+    await runPlatformValidation(session.context, 'gemini', process.env.GEMINI_DR_URL, 'gemini_dr', {
       DEEP_RESEARCH_SELECTORS: GEMINI_DR_SELECTORS,
       DEEP_RESEARCH_LINK_SELECTORS: GEMINI_DR_LINK_SELECTORS,
     });
@@ -201,7 +180,7 @@ test.describe('Gemini', () => {
 test.describe('Claude', () => {
   test('conversation selectors', async () => {
     await runPlatformValidation(
-      sharedContext,
+      session.context,
       'claude',
       process.env.CLAUDE_CONV_URL,
       'claude_conv',
@@ -212,7 +191,7 @@ test.describe('Claude', () => {
   });
 
   test('deep research selectors', async () => {
-    await runPlatformValidation(sharedContext, 'claude', process.env.CLAUDE_DR_URL, 'claude_dr', {
+    await runPlatformValidation(session.context, 'claude', process.env.CLAUDE_DR_URL, 'claude_dr', {
       DEEP_RESEARCH_SELECTORS: CLAUDE_DR_SELECTORS,
     });
   });
@@ -221,7 +200,7 @@ test.describe('Claude', () => {
 test.describe('ChatGPT', () => {
   test('conversation selectors', async () => {
     await runPlatformValidation(
-      sharedContext,
+      session.context,
       'chatgpt',
       process.env.CHATGPT_CONV_URL,
       'chatgpt_conv',
@@ -235,7 +214,7 @@ test.describe('ChatGPT', () => {
 test.describe('Perplexity', () => {
   test('conversation selectors', async () => {
     await runPlatformValidation(
-      sharedContext,
+      session.context,
       'perplexity',
       process.env.PERPLEXITY_CONV_URL,
       'perplexity_conv',

--- a/e2e/shared/__tests__/cdp-utils.test.ts
+++ b/e2e/shared/__tests__/cdp-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { waitForCDP } from '../cdp-utils';
+
+describe('waitForCDP', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('resolves immediately when CDP is ready', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+    await expect(waitForCDP(9222, 1000, 10)).resolves.toBeUndefined();
+    expect(globalThis.fetch).toHaveBeenCalledWith('http://127.0.0.1:9222/json/version');
+  });
+
+  it('retries until CDP becomes ready', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) {
+        return Promise.reject(new Error('connection refused'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    await expect(waitForCDP(9222, 2000, 10)).resolves.toBeUndefined();
+    expect(callCount).toBe(3);
+  });
+
+  it('rejects after timeout', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    await expect(waitForCDP(9222, 100, 10)).rejects.toThrow(
+      'CDP endpoint not available on port 9222 after 100ms',
+    );
+  });
+
+  it('uses default timeout of 15000ms in error message', async () => {
+    // Just verify the default is documented; actual wait is short
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    await expect(waitForCDP(9222, 50, 10)).rejects.toThrow('after 50ms');
+  });
+
+  it('handles non-OK HTTP responses as not ready', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 2) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    await expect(waitForCDP(9222, 2000, 10)).resolves.toBeUndefined();
+    expect(callCount).toBe(2);
+  });
+});

--- a/e2e/shared/__tests__/chrome-finder.test.ts
+++ b/e2e/shared/__tests__/chrome-finder.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { findChromeExecutable, type ChromeFinderDeps } from '../chrome-finder';
+
+describe('findChromeExecutable', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CHROME_PATH;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const noDeps: ChromeFinderDeps = {
+    existsSync: () => false,
+    execWhich: () => {
+      throw new Error('not found');
+    },
+  };
+
+  it('returns CHROME_PATH env var when set', () => {
+    process.env.CHROME_PATH = '/custom/path/chrome';
+    const result = findChromeExecutable(noDeps);
+    expect(result).toBe('/custom/path/chrome');
+  });
+
+  it('returns first existing macOS candidate path', () => {
+    const deps: ChromeFinderDeps = {
+      ...noDeps,
+      existsSync: p => p === '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    };
+    const result = findChromeExecutable(deps);
+    expect(result).toBe('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome');
+  });
+
+  it('returns Canary path when standard Chrome is not found', () => {
+    const deps: ChromeFinderDeps = {
+      ...noDeps,
+      existsSync: p =>
+        p === '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+    };
+    const result = findChromeExecutable(deps);
+    expect(result).toBe(
+      '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
+    );
+  });
+
+  it('falls back to which command when no candidate exists', () => {
+    const deps: ChromeFinderDeps = {
+      existsSync: () => false,
+      execWhich: () => '/usr/bin/google-chrome',
+    };
+    const result = findChromeExecutable(deps);
+    expect(result).toBe('/usr/bin/google-chrome');
+  });
+
+  it('throws when Chrome is not found anywhere', () => {
+    expect(() => findChromeExecutable(noDeps)).toThrow('Google Chrome not found');
+  });
+
+  it.skipIf(!!process.env.CI)('uses default deps when none provided', () => {
+    // Integration test: requires Chrome installed on the machine
+    const result = findChromeExecutable();
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/shared/cdp-utils.ts
+++ b/e2e/shared/cdp-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Chrome DevTools Protocol utilities.
+ *
+ * Shared between e2e/auth/setup-profile.ts and e2e/daemon/.
+ */
+
+/**
+ * Wait for Chrome's CDP endpoint to become available.
+ *
+ * Polls `http://127.0.0.1:{port}/json/version` until a
+ * successful response or the timeout is reached.
+ */
+export async function waitForCDP(
+  port: number,
+  timeoutMs = 15_000,
+  pollIntervalMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/version`);
+      if (res.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  throw new Error(`CDP endpoint not available on port ${port} after ${timeoutMs}ms`);
+}

--- a/e2e/shared/chrome-finder.ts
+++ b/e2e/shared/chrome-finder.ts
@@ -1,0 +1,50 @@
+/**
+ * Chrome executable discovery.
+ *
+ * Shared between e2e/auth/setup-profile.ts and e2e/daemon/.
+ */
+
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+const MAC_CANDIDATES: readonly string[] = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+];
+
+export interface ChromeFinderDeps {
+  readonly existsSync: (path: fs.PathLike) => boolean;
+  readonly execWhich: () => string;
+}
+
+const defaultDeps: ChromeFinderDeps = {
+  existsSync: fs.existsSync,
+  execWhich: () => execSync('which google-chrome', { encoding: 'utf-8' }).trim(),
+};
+
+/**
+ * Find the Chrome executable path.
+ *
+ * Priority:
+ * 1. CHROME_PATH environment variable
+ * 2. macOS application paths
+ * 3. `which google-chrome` (Linux / custom installs)
+ */
+export function findChromeExecutable(deps: ChromeFinderDeps = defaultDeps): string {
+  const chromePath = process.env.CHROME_PATH;
+  if (chromePath) return chromePath;
+
+  for (const candidate of MAC_CANDIDATES) {
+    if (deps.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  try {
+    return deps.execWhich();
+  } catch {
+    throw new Error(
+      'Google Chrome not found. Install Chrome or set CHROME_PATH environment variable.',
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "prepare": "husky",
     "e2e:auth": "npx tsx e2e/auth/setup-profile.ts",
     "e2e:selectors": "npx playwright test --config e2e/playwright.config.ts",
-    "e2e:selectors:headed": "npx playwright test --config e2e/playwright.config.ts --headed"
+    "e2e:selectors:headed": "npx playwright test --config e2e/playwright.config.ts --headed",
+    "e2e:daemon": "npx tsx e2e/daemon/daemon.ts",
+    "e2e:daemon:start": "npx tsx e2e/daemon/daemon.ts start",
+    "e2e:daemon:stop": "npx tsx e2e/daemon/daemon.ts stop",
+    "e2e:daemon:status": "npx tsx e2e/daemon/daemon.ts status"
   },
   "dependencies": {
     "dompurify": "^3.3.2",


### PR DESCRIPTION
## Summary

- Add CDP daemon that runs headless Chrome 24/7 with persistent sessions for E2E selector validation
- Chrome launched as regular process (not Playwright) to avoid Cloudflare bot detection (Claudeflare)
- Keep-alive reloads platform tabs every 15 minutes to maintain session cookies
- Session cookies from `state.json` injected on daemon start (fixes session cookie loss on Chrome restart)
- User-Agent override removes `HeadlessChrome` identifier to bypass Cloudflare Turnstile
- `browser-provider.ts` auto-switches between CDP daemon and standalone mode (backward compatible)
- Pre-flight checks for port conflicts, SingletonLock, and orphan Chrome processes
- Shared utilities extracted from `setup-profile.ts` (`chrome-finder`, `cdp-utils`)
- ADR-007 documents the architectural decision

### New commands

- `npm run e2e:daemon start` — launch headless Chrome daemon
- `npm run e2e:daemon stop` — stop daemon (also kills orphan Chrome)
- `npm run e2e:daemon status` — health check with open tab listing

### Re-auth workflow

`e2e:daemon stop` → `e2e:auth` → `e2e:daemon start`

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (871+ tests)
- [x] `npm run e2e:daemon start` launches Chrome, opens 4 platform tabs
- [x] `npm run e2e:daemon status` shows all platforms authenticated (no Cloudflare challenges)
- [x] `npm run e2e:selectors` passes for Claude, ChatGPT, Perplexity, Gemini
- [x] After 30+ minutes, `npm run e2e:selectors` still passes (session maintained)
- [x] `npm run e2e:daemon stop` cleanly shuts down Chrome
- [x] Without daemon running, `npm run e2e:selectors` falls back to standalone mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)