### PR TITLE
fix: update Gemini Deep Research title selector for new DOM structure

### DIFF
--- a/src/content/extractors/selectors/gemini.ts
+++ b/src/content/extractors/selectors/gemini.ts
@@ -52,11 +52,11 @@ export const DEEP_RESEARCH_SELECTORS = {
   // Deep Research panel (existence check)
   panel: ['deep-research-immersive-panel'],
 
-  // Report title
+  // Report title (moved from toolbar h2 to content h1 as of 2026-03)
   title: [
-    'deep-research-immersive-panel h2.title-text.gds-title-s',
-    'deep-research-immersive-panel .title-text',
-    'toolbar h2.title-text',
+    '#extended-response-markdown-content > h1',
+    'deep-research-immersive-panel h1[data-path-to-node]',
+    'deep-research-immersive-panel h2.title-text',
   ],
 
   // Report content

--- a/test/extractors/e2e/__snapshots__/gemini.e2e.test.ts.snap
+++ b/test/extractors/e2e/__snapshots__/gemini.e2e.test.ts.snap
@@ -74,7 +74,7 @@ message_count: 6
 exports[`Gemini E2E Extraction > Deep Research Report > should generate Deep Research markdown with footnotes 1`] = `
 "---
 id: gemini_e2e-gemini-dr-001
-title: Deep Research HTML構造調査レポート
+title: Deep Research インターフェースの技術的設計：HTML 構造、DOM アーキテクチャ、およびエージェント指向の UI 設計に関する包括的分析
 source: gemini
 url: "https://gemini.google.com/app/e2e-gemini-dr-001"
 created: "2025-01-01T00:00:00.000Z"

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -164,23 +164,25 @@ function escapeHtml(text: string): string {
 
 /**
  * Create Deep Research パネル DOM 構造
+ *
+ * Updated 2026-03-23: Gemini moved the report title from the toolbar
+ * (h2.title-text.gds-title-s) into the content area as the first <h1>.
+ * The toolbar now contains only close/action buttons.
  */
 export function createDeepResearchDOM(title: string, content: string): string {
   return `
     <deep-research-immersive-panel class="ng-star-inserted">
-      <toolbar>
-        <div class="toolbar has-title">
-          <div class="left-panel">
-            <h2 class="title-text gds-title-s">${title}</h2>
-          </div>
-        </div>
-      </toolbar>
+      <div class="toolbar has-title mobile-layout">
+        <div class="left-panel"></div>
+        <div class="action-buttons mobile-layout"></div>
+      </div>
       <div class="container">
         <response-container>
           <structured-content-container data-test-id="message-content">
             <message-content id="extended-response-message-content">
-              <div id="extended-response-markdown-content" 
+              <div id="extended-response-markdown-content"
                    class="markdown markdown-main-panel">
+                <h1>${title}</h1>
                 ${content}
               </div>
             </message-content>
@@ -215,19 +217,17 @@ export function createDeepResearchDOMWithLinks(
 
   return `
     <deep-research-immersive-panel class="ng-star-inserted">
-      <toolbar>
-        <div class="toolbar has-title">
-          <div class="left-panel">
-            <h2 class="title-text gds-title-s">${title}</h2>
-          </div>
-        </div>
-      </toolbar>
+      <div class="toolbar has-title mobile-layout">
+        <div class="left-panel"></div>
+        <div class="action-buttons mobile-layout"></div>
+      </div>
       <div class="container">
         <response-container>
           <structured-content-container data-test-id="message-content">
             <message-content id="extended-response-message-content">
               <div id="extended-response-markdown-content"
                    class="markdown markdown-main-panel">
+                <h1>${title}</h1>
                 ${contentWithCitations}
               </div>
             </message-content>
@@ -269,13 +269,10 @@ export function createInlineCitation(arrayIndex: number): string {
 export function createEmptyDeepResearchPanel(): string {
   return `
     <deep-research-immersive-panel class="ng-star-inserted">
-      <toolbar>
-        <div class="toolbar has-title">
-          <div class="left-panel">
-            <h2 class="title-text gds-title-s">Test Report</h2>
-          </div>
-        </div>
-      </toolbar>
+      <div class="toolbar has-title mobile-layout">
+        <div class="left-panel"></div>
+        <div class="action-buttons mobile-layout"></div>
+      </div>
       <div class="container">
         <response-container>
         </response-container>

--- a/test/fixtures/html/gemini/deep-research.html
+++ b/test/fixtures/html/gemini/deep-research.html
@@ -38,9 +38,7 @@
             style=""
           ></mat-icon
           ><!----><!---->
-          <h2 _ngcontent-ng-c2947187592="" class="title-text gds-title-s ng-star-inserted" style="">
-            Deep Research HTML構造調査レポート
-          </h2>
+          <!-- Title removed from toolbar (2026-03 DOM change) -->
           <!----><!----><!----><!----><!----><!----><!----><!----><!----><!---->
         </div>
         <div _ngcontent-ng-c2947187592="" class="action-buttons">


### PR DESCRIPTION
## Summary

- Update `DEEP_RESEARCH_SELECTORS.title` in `src/content/extractors/selectors/gemini.ts` — Gemini moved the report title from toolbar `<h2>` to content area `<h1>` (2026-03 DOM change)
- New primary selector: `#extended-response-markdown-content > h1` with `data-path-to-node` fallback and legacy `h2.title-text` fallback
- Update DOM fixtures in `test/fixtures/dom-helpers.ts` to reflect new toolbar structure (no title) and title-as-h1-in-content pattern
- Remove old toolbar title from captured E2E fixture `test/fixtures/html/gemini/deep-research.html`
- Update E2E snapshot for new title extraction

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run` — 878/878 tests pass
- [x] `npm run e2e:selectors` — 6/6 selector smoke tests pass (including Gemini DR)
- [x] Manual verification: load extension in Chrome, open a Gemini Deep Research report, confirm title is extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)