### PR TITLE
refactor: remove unused exports and dead TabInfo interface

### DIFF
--- a/e2e/daemon/types.ts
+++ b/e2e/daemon/types.ts
@@ -4,13 +4,6 @@
 
 export type DaemonCommand = 'start' | 'stop' | 'status';
 
-export interface TabInfo {
-  readonly id: string;
-  readonly url: string;
-  readonly title: string;
-  readonly webSocketDebuggerUrl: string;
-}
-
 export interface KeepAliveResult {
   readonly timestamp: string;
   readonly reloaded: number;

--- a/e2e/selectors/notifier.ts
+++ b/e2e/selectors/notifier.ts
@@ -9,7 +9,7 @@ import type { ClassificationResult, WarnDetail, SelectorResult } from './classif
 import type { BaselineComparison } from './baseline';
 import type { AuthStatus } from './auth-check';
 
-export interface NotificationConfig {
+interface NotificationConfig {
   obsidianUrl: string;
   obsidianApiKey: string;
   vaultPath: string;

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -1058,7 +1058,7 @@ interface PerplexityDeepResearchConfig {
  * - Report card with header (telescope icon + title) and prose body
  * - Optional summary response in markdown-content div
  */
-export function createPerplexityDeepResearchDOM(config: PerplexityDeepResearchConfig): string {
+function createPerplexityDeepResearchDOM(config: PerplexityDeepResearchConfig): string {
   const summaryBlock = config.summaryContent
     ? `
       <div id="markdown-content-0" class="markdown-content">


### PR DESCRIPTION
## Summary

- Remove dead `TabInfo` interface from `e2e/daemon/types.ts` (exported but never imported anywhere)
- Unexport `NotificationConfig` in `e2e/selectors/notifier.ts` (only used internally)
- Unexport `createPerplexityDeepResearchDOM` in `test/fixtures/dom-helpers.ts` (internal helper called only by `createPerplexityDeepResearchPage`)
- Identified via `knip` analysis; all false positives (Chrome extension entry points, e2e tooling) verified and skipped

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm test` — all 878 tests passing
- [x] Re-ran `knip` to confirm actionable findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)