### PR TITLE
fix: load .env.local in CDP daemon config so KEEP_ALIVE_INTERVAL_MIN is respected

### DIFF
--- a/e2e/daemon/__tests__/config.test.ts
+++ b/e2e/daemon/__tests__/config.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadConfig } from '../config';
+
+vi.mock('dotenv', () => ({
+  default: {
+    config: vi.fn(),
+  },
+}));
 
 describe('loadConfig', () => {
   const originalEnv = process.env;
@@ -58,5 +64,15 @@ describe('loadConfig', () => {
     expect(config.platformUrls).toContain('https://claude.ai');
     expect(config.platformUrls).toContain('https://chatgpt.com');
     expect(config.platformUrls).toContain('https://www.perplexity.ai');
+  });
+
+  it('loads .env.local via dotenv on startup', async () => {
+    const dotenv = await import('dotenv');
+    loadConfig();
+    expect(dotenv.default.config).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: expect.stringMatching(/e2e\/\.env\.local$/),
+      })
+    );
   });
 });

--- a/e2e/daemon/config.ts
+++ b/e2e/daemon/config.ts
@@ -5,6 +5,7 @@
  */
 
 import path from 'path';
+import dotenv from 'dotenv';
 
 export interface DaemonConfig {
   readonly cdpPort: number;
@@ -18,6 +19,7 @@ export interface DaemonConfig {
 }
 
 const E2E_DIR = path.resolve(import.meta.dirname, '..');
+const ENV_LOCAL_PATH = path.join(E2E_DIR, '.env.local');
 
 function parsePort(raw: string | undefined, fallback: number): number {
   const port = parseInt(raw ?? String(fallback), 10);
@@ -28,6 +30,9 @@ function parsePort(raw: string | undefined, fallback: number): number {
 }
 
 export function loadConfig(): DaemonConfig {
+  // Load .env.local so daemon picks up KEEP_ALIVE_INTERVAL_MIN etc.
+  dotenv.config({ path: ENV_LOCAL_PATH });
+
   const cdpPort = parsePort(process.env.CDP_PORT, 9222);
   const keepAliveMin = parseInt(process.env.KEEP_ALIVE_INTERVAL_MIN ?? '15', 10);
 


### PR DESCRIPTION
## Summary

- Add `dotenv` import to `e2e/daemon/config.ts` and call `dotenv.config()` inside `loadConfig()` to load `.env.local`
- Without this, `KEEP_ALIVE_INTERVAL_MIN=360` in `.env.local` was ignored and the daemon always used the 15-minute default
- Add test verifying `dotenv.config()` is called with the correct `.env.local` path

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run` — 879 tests pass
- [x] `npm run e2e:daemon start` — verify log shows "Keep-alive every 360 minutes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)