### PR TITLE
feat: add configurable timezone for frontmatter dates

### DIFF
--- a/e2e/.env.local.example
+++ b/e2e/.env.local.example
@@ -21,6 +21,9 @@ OBSIDIAN_URL=http://127.0.0.1:27123
 OBSIDIAN_API_KEY=YOUR_API_KEY
 OBSIDIAN_VAULT_PATH=AI/selector-health
 
+# Timezone for report dates (IANA format, default: UTC)
+# TIMEZONE=Asia/Tokyo
+
 # CDP Daemon (optional overrides)
 # CDP_PORT=9222
 # KEEP_ALIVE_INTERVAL_MIN=15

--- a/e2e/selectors/obsidian-reporter.ts
+++ b/e2e/selectors/obsidian-reporter.ts
@@ -33,7 +33,7 @@ class ObsidianReporter implements Reporter {
   }
 
   async onEnd(_result: FullResult): Promise<void> {
-    const report = buildValidationReport(this.platformMap);
+    const report = buildValidationReport(this.platformMap, process.env.TIMEZONE);
 
     // Save timestamped JSON report
     const resultsDir = path.join(import.meta.dirname, '..', 'results');

--- a/e2e/selectors/report-builder.ts
+++ b/e2e/selectors/report-builder.ts
@@ -8,6 +8,7 @@
 import type { AuthStatus } from './auth-check';
 import type { ClassificationResult } from './classifier';
 import type { PlatformReport, ValidationReport } from './notifier';
+import { formatDateWithTimezone } from '../../src/lib/date-utils';
 
 /** Minimal input extracted from Playwright's onTestEnd callback. */
 export interface TestEndInput {
@@ -30,10 +31,10 @@ export function extractPlatform(parentTitle: string): string {
  * Returns {pass, warn, fail, baselineIssues} as integers (defaults to 0).
  */
 export function parseAnnotationCounts(
-  annotations: ReadonlyArray<{ type: string; description?: string }>,
+  annotations: ReadonlyArray<{ type: string; description?: string }>
 ): { pass: number; warn: number; fail: number; baselineIssues: number } {
   const getCount = (type: string): number => {
-    const ann = annotations.find((a) => a.type === type);
+    const ann = annotations.find(a => a.type === type);
     if (!ann?.description) return 0;
     const parsed = parseInt(ann.description, 10);
     return Number.isNaN(parsed) ? 0 : parsed;
@@ -52,9 +53,9 @@ export function parseAnnotationCounts(
  * Returns 'auth_expired' | 'unreachable' | null.
  */
 export function detectSkipReason(
-  annotations: ReadonlyArray<{ type: string; description?: string }>,
+  annotations: ReadonlyArray<{ type: string; description?: string }>
 ): 'auth_expired' | 'unreachable' | null {
-  const skipAnn = annotations.find((a) => a.type === 'skip');
+  const skipAnn = annotations.find(a => a.type === 'skip');
   if (!skipAnn?.description) return null;
 
   if (skipAnn.description.includes('AUTH_EXPIRED')) return 'auth_expired';
@@ -68,7 +69,7 @@ export function detectSkipReason(
  */
 export function processTestResult(
   platformMap: ReadonlyMap<string, PlatformReport>,
-  input: TestEndInput,
+  input: TestEndInput
 ): Map<string, PlatformReport> {
   const newMap = new Map(platformMap);
   const { platform, status, annotations } = input;
@@ -94,18 +95,9 @@ export function processTestResult(
 
   // Merge counts using placeholder arrays (notifier reads .length only)
   const classification: ClassificationResult = {
-    pass: [
-      ...(existingClassification?.pass ?? []),
-      ...new Array<null>(counts.pass).fill(null),
-    ],
-    warn: [
-      ...(existingClassification?.warn ?? []),
-      ...new Array<null>(counts.warn).fill(null),
-    ],
-    fail: [
-      ...(existingClassification?.fail ?? []),
-      ...new Array<null>(counts.fail).fill(null),
-    ],
+    pass: [...(existingClassification?.pass ?? []), ...new Array<null>(counts.pass).fill(null)],
+    warn: [...(existingClassification?.warn ?? []), ...new Array<null>(counts.warn).fill(null)],
+    fail: [...(existingClassification?.fail ?? []), ...new Array<null>(counts.fail).fill(null)],
     baselineIssues: [
       ...(existingClassification?.baselineIssues ?? []),
       ...new Array<null>(counts.baselineIssues).fill(null),
@@ -127,19 +119,14 @@ export function processTestResult(
  */
 export function buildValidationReport(
   platformMap: ReadonlyMap<string, PlatformReport>,
+  timezone?: string
 ): ValidationReport {
   const platforms = [...platformMap.values()];
-  const timestamp = new Date().toISOString();
+  const timestamp = formatDateWithTimezone(new Date(), timezone ?? 'UTC');
 
-  const hasFail = platforms.some(
-    (p) => p.classification && p.classification.fail.length > 0,
-  );
-  const hasAuthExpired = platforms.some(
-    (p) => p.authStatus === 'auth_expired',
-  );
-  const hasWarn = platforms.some(
-    (p) => p.classification && p.classification.warn.length > 0,
-  );
+  const hasFail = platforms.some(p => p.classification && p.classification.fail.length > 0);
+  const hasAuthExpired = platforms.some(p => p.authStatus === 'auth_expired');
+  const hasWarn = platforms.some(p => p.classification && p.classification.warn.length > 0);
 
   let overallStatus: ValidationReport['overallStatus'];
   if (hasFail) overallStatus = 'fail';

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -109,6 +109,14 @@
     "message": "Include Message Count",
     "description": "Checkbox label for include message count"
   },
+  "settings_timezone": {
+    "message": "Timezone",
+    "description": "Label for timezone select dropdown"
+  },
+  "settings_timezoneHelp": {
+    "message": "Timezone for created/modified dates in frontmatter",
+    "description": "Help text for timezone select"
+  },
   "settings_testConnection": {
     "message": "Test Connection",
     "description": "Test connection button text"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -82,6 +82,12 @@
   "settings_includeMessageCount": {
     "message": "メッセージ数を含める"
   },
+  "settings_timezone": {
+    "message": "タイムゾーン"
+  },
+  "settings_timezoneHelp": {
+    "message": "フロントマターの日付に使用するタイムゾーン"
+  },
   "settings_testConnection": {
     "message": "接続テスト"
   },

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -17,6 +17,7 @@ import type {
   NoteFrontmatter,
   TemplateOptions,
 } from '../lib/types';
+import { formatDateWithTimezone } from '../lib/date-utils';
 
 // Re-exports (preserve existing import paths)
 export { htmlToMarkdown, escapeAngleBrackets } from './markdown-rules';
@@ -47,7 +48,8 @@ export function generateContentHash(content: string): string {
  * Convert conversation data to Obsidian note
  */
 export function conversationToNote(data: ConversationData, options: TemplateOptions): ObsidianNote {
-  const now = new Date().toISOString();
+  const timezone = options.timezone ?? 'UTC';
+  const now = formatDateWithTimezone(new Date(), timezone);
 
   // Generate frontmatter
   const frontmatter: NoteFrontmatter = {
@@ -56,7 +58,7 @@ export function conversationToNote(data: ConversationData, options: TemplateOpti
     source: data.source,
     ...(data.type && { type: data.type }),
     url: data.url,
-    created: data.extractedAt.toISOString(),
+    created: formatDateWithTimezone(data.extractedAt, timezone),
     modified: now,
     tags:
       data.type === 'deep-research'

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -10,6 +10,7 @@ import type { ObsidianNote, ExtensionSettings } from './types';
 import { parseFrontmatter, updateFrontmatter } from './frontmatter-parser';
 import { countExistingMessages, extractTailMessages } from './message-counter';
 import { generateNoteContent } from './note-generator';
+import { formatDateWithTimezone } from './date-utils';
 
 /**
  * Result of file lookup for append mode
@@ -123,8 +124,9 @@ export function buildAppendContent(
   if (!newMessages) return null;
 
   // 6. Update frontmatter fields
+  const timezone = settings.templateOptions.timezone ?? 'UTC';
   const updatedRaw = updateFrontmatter(parsed.raw, {
-    modified: new Date().toISOString(),
+    modified: formatDateWithTimezone(new Date(), timezone),
     message_count: newTotal,
   });
 

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,81 @@
+/**
+ * Date formatting utilities with timezone support
+ *
+ * Formats dates as ISO 8601 with timezone offset (e.g., 2025-01-15T09:00:00+09:00).
+ * Uses Intl.DateTimeFormat for timezone conversion — no external dependencies.
+ */
+
+const FORMATTER_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+};
+
+/**
+ * Format a Date as ISO 8601 with timezone offset.
+ *
+ * Falls back to UTC if the timezone string is invalid, logging a warning.
+ *
+ * @param date - The date to format
+ * @param timezone - IANA timezone name (e.g., 'Asia/Tokyo', 'UTC', 'America/New_York')
+ * @returns ISO 8601 string with offset, e.g., '2025-01-15T09:00:00+09:00'
+ */
+export function formatDateWithTimezone(date: Date, timezone: string): string {
+  const safeTimezone = validateTimezone(timezone);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    ...FORMATTER_OPTIONS,
+    timeZone: safeTimezone,
+  });
+
+  const parts = formatter.formatToParts(date);
+
+  const getString = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find(p => p.type === type)?.value ?? '00';
+  const getNumber = (type: Intl.DateTimeFormatPartTypes): number => parseInt(getString(type), 10);
+
+  const year = getString('year');
+  const month = getString('month');
+  const day = getString('day');
+  const rawHour = getString('hour');
+  const hour = rawHour === '24' ? '00' : rawHour; // legacy V8 midnight guard
+  const minute = getString('minute');
+  const second = getString('second');
+
+  // Calculate UTC offset: build wall-clock time as UTC millis, then subtract actual UTC millis
+  let localHour = getNumber('hour');
+  if (localHour === 24) localHour = 0;
+  const localAsUtc = Date.UTC(
+    getNumber('year'),
+    getNumber('month') - 1,
+    getNumber('day'),
+    localHour,
+    getNumber('minute'),
+    getNumber('second')
+  );
+  const offsetMinutes = Math.round((localAsUtc - date.getTime()) / 60000);
+
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absMinutes / 60)).padStart(2, '0');
+  const offsetMins = String(absMinutes % 60).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}${sign}${offsetHours}:${offsetMins}`;
+}
+
+/**
+ * Validate an IANA timezone string.
+ * Returns the timezone if valid, or 'UTC' as fallback.
+ */
+function validateTimezone(timezone: string): string {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone });
+    return timezone;
+  } catch {
+    console.warn(`[G2O] Invalid timezone "${timezone}", falling back to UTC`);
+    return 'UTC';
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,6 +227,8 @@ export interface TemplateOptions {
   userCalloutType: string;
   /** Callout type for assistant messages (e.g., 'NOTE') */
   assistantCalloutType: string;
+  /** IANA timezone for created/modified dates (e.g., 'Asia/Tokyo'). Defaults to 'UTC'. */
+  timezone?: string;
   /** Custom frontmatter fields (reserved for future use) */
   customFrontmatter?: Record<string, string>;
 }

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -234,6 +234,16 @@
                   <span data-i18n="settings_includeMessageCount">Message Count</span>
                 </label>
               </div>
+
+              <div class="form-group timezone-group" id="timezoneGroup">
+                <label for="timezone" data-i18n="settings_timezone">Timezone</label>
+                <select id="timezone">
+                  <option value="UTC">UTC</option>
+                </select>
+                <p class="help" data-i18n="settings_timezoneHelp">
+                  Timezone for created/modified dates in frontmatter
+                </p>
+              </div>
             </section>
           </div>
         </details>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -87,6 +87,8 @@ const elements = {
   enableAutoScroll: getElement<HTMLInputElement>('enableAutoScroll'),
   enableAppendMode: getElement<HTMLInputElement>('enableAppendMode'),
   enableToolContent: getElement<HTMLInputElement>('enableToolContent'),
+  timezone: getElement<HTMLSelectElement>('timezone'),
+  timezoneGroup: getElement<HTMLElement>('timezoneGroup'),
   testBtn: getElement<HTMLButtonElement>('testBtn'),
   saveBtn: getElement<HTMLButtonElement>('saveBtn'),
   status: getElement<HTMLDivElement>('status'),
@@ -143,6 +145,11 @@ function populateForm(settings: ExtensionSettings): void {
   elements.includeDates.checked = templateOptions.includeDates ?? true;
   elements.includeMessageCount.checked = templateOptions.includeMessageCount ?? true;
 
+  // Populate timezone dropdown and set value
+  populateTimezoneOptions();
+  elements.timezone.value = templateOptions.timezone ?? 'UTC';
+  updateTimezoneVisibility();
+
   // Sync aria-checked for toggle switches after setting checked state
   syncAllAriaChecked();
 }
@@ -174,6 +181,9 @@ function setupEventListeners(): void {
 
   // Output destination checkbox listeners
   elements.outputObsidian.addEventListener('change', updateObsidianSettingsVisibility);
+
+  // Show/hide timezone when includeDates changes
+  elements.includeDates.addEventListener('change', updateTimezoneVisibility);
 
   // Enable/disable callout inputs based on message format
   elements.messageFormat.addEventListener('change', () => {
@@ -239,6 +249,56 @@ function setupToggleSwitchAccessibility(): void {
 }
 
 /**
+ * Populate timezone select with IANA timezone names
+ * Groups by region for easier navigation
+ */
+function populateTimezoneOptions(): void {
+  const select = elements.timezone;
+  // Only populate once
+  if (select.options.length > 1) return;
+
+  // Intl.supportedValuesOf is available in Chrome 99+
+  // TypeScript ES2020 lib doesn't include it, so we use a type assertion
+  // Falls back to UTC-only if unavailable (Chrome 96-98)
+  let timezones: string[] = [];
+  try {
+    timezones = (Intl as unknown as { supportedValuesOf(key: string): string[] }).supportedValuesOf(
+      'timeZone'
+    );
+  } catch {
+    // Chrome < 99: leave dropdown with just UTC
+    return;
+  }
+  // Clear default UTC option, rebuild with full list
+  select.innerHTML = '';
+
+  const utcOption = document.createElement('option');
+  utcOption.value = 'UTC';
+  utcOption.textContent = 'UTC';
+  select.appendChild(utcOption);
+
+  for (const tz of timezones) {
+    if (tz === 'UTC') continue;
+    const option = document.createElement('option');
+    option.value = tz;
+    option.textContent = tz.replace(/_/g, ' ');
+    select.appendChild(option);
+  }
+}
+
+/**
+ * Show/hide timezone dropdown based on includeDates checkbox
+ */
+function updateTimezoneVisibility(): void {
+  const group = elements.timezoneGroup;
+  if (elements.includeDates.checked) {
+    group.style.display = '';
+  } else {
+    group.style.display = 'none';
+  }
+}
+
+/**
  * Collect output options from form
  */
 function collectOutputOptions(): OutputOptions {
@@ -278,6 +338,7 @@ function collectSettings(): ExtensionSettings {
     includeSource: elements.includeSource.checked,
     includeDates: elements.includeDates.checked,
     includeMessageCount: elements.includeMessageCount.checked,
+    timezone: elements.timezone.value || undefined,
   };
 
   const outputOptions = collectOutputOptions();

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -62,9 +62,7 @@ describe('htmlToMarkdown', () => {
     });
 
     it('converts inline code', () => {
-      expect(htmlToMarkdown('Use <code>npm install</code>')).toBe(
-        'Use `npm install`'
-      );
+      expect(htmlToMarkdown('Use <code>npm install</code>')).toBe('Use `npm install`');
     });
   });
 
@@ -206,7 +204,8 @@ describe('htmlToMarkdown', () => {
     });
 
     it('does not escape angle brackets inside code blocks', () => {
-      const html = '<pre><code class="language-python">File "test.py", in &lt;module&gt;</code></pre>';
+      const html =
+        '<pre><code class="language-python">File "test.py", in &lt;module&gt;</code></pre>';
       const result = htmlToMarkdown(html);
       expect(result).toContain('<module>');
       expect(result).not.toContain('\\<module\\>');
@@ -298,9 +297,7 @@ describe('escapeAngleBrackets', () => {
 
 describe('generateFileName', () => {
   it('creates filename from title and ID', () => {
-    expect(generateFileName('Hello World', 'abc123def456')).toBe(
-      'hello-world-abc123de.md'
-    );
+    expect(generateFileName('Hello World', 'abc123def456')).toBe('hello-world-abc123de.md');
   });
 
   it('preserves Japanese characters', () => {
@@ -315,9 +312,7 @@ describe('generateFileName', () => {
   });
 
   it('removes special characters', () => {
-    expect(generateFileName('Test: Special!', 'abc123def456')).toBe(
-      'test-special-abc123de.md'
-    );
+    expect(generateFileName('Test: Special!', 'abc123def456')).toBe('test-special-abc123de.md');
   });
 
   it('truncates long titles to 50 characters', () => {
@@ -332,9 +327,7 @@ describe('generateFileName', () => {
   });
 
   it('handles title with only special characters', () => {
-    expect(generateFileName('!!!@@@###', 'abc123def456')).toBe(
-      'conversation-abc123de.md'
-    );
+    expect(generateFileName('!!!@@@###', 'abc123def456')).toBe('conversation-abc123de.md');
   });
 });
 
@@ -456,6 +449,27 @@ describe('conversationToNote', () => {
     expect(note.body).toContain('Second answer');
   });
 
+  // ========== Timezone support ==========
+  it('uses UTC format by default when no timezone specified', () => {
+    const note = conversationToNote(mockData, defaultOptions);
+    // extractedAt is 2025-01-10T00:00:00Z → created should be UTC ISO
+    expect(note.frontmatter.created).toBe('2025-01-10T00:00:00+00:00');
+  });
+
+  it('formats created date in specified timezone', () => {
+    const options: TemplateOptions = { ...defaultOptions, timezone: 'Asia/Tokyo' };
+    const note = conversationToNote(mockData, options);
+    // 2025-01-10T00:00:00Z → JST is +09:00
+    expect(note.frontmatter.created).toBe('2025-01-10T09:00:00+09:00');
+  });
+
+  it('formats modified date in specified timezone', () => {
+    const options: TemplateOptions = { ...defaultOptions, timezone: 'Asia/Tokyo' };
+    const note = conversationToNote(mockData, options);
+    // modified is "now" — just verify it has JST offset
+    expect(note.frontmatter.modified).toMatch(/\+09:00$/);
+  });
+
   // ========== Angle bracket escaping in conversationToNote (REQ-083) ==========
   it('escapes angle brackets in assistant messages', () => {
     const data: ConversationData = {
@@ -471,9 +485,7 @@ describe('conversationToNote', () => {
   it('escapes angle brackets in user messages', () => {
     const data: ConversationData = {
       ...mockData,
-      messages: [
-        { id: 'u1', role: 'user', content: 'What is <Generic<T>>?', index: 0 },
-      ],
+      messages: [{ id: 'u1', role: 'user', content: 'What is <Generic<T>>?', index: 0 }],
     };
     const note = conversationToNote(data, defaultOptions);
     expect(note.body).toContain('\\<Generic\\<T\\>\\>');
@@ -483,7 +495,12 @@ describe('conversationToNote', () => {
     const data: ConversationData = {
       ...mockData,
       messages: [
-        { id: 'a1', role: 'assistant', content: '<pre><code>&lt;div&gt;test&lt;/div&gt;</code></pre>', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: '<pre><code>&lt;div&gt;test&lt;/div&gt;</code></pre>',
+          index: 0,
+        },
       ],
     };
     const note = conversationToNote(data, defaultOptions);
@@ -495,7 +512,12 @@ describe('conversationToNote', () => {
     const data: ConversationData = {
       ...mockData,
       messages: [
-        { id: 'a1', role: 'assistant', content: 'Use <code>&lt;span&gt;</code> for this', index: 0 },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: 'Use <code>&lt;span&gt;</code> for this',
+          index: 0,
+        },
       ],
     };
     const note = conversationToNote(data, defaultOptions);
@@ -517,7 +539,12 @@ describe('conversationToNote', () => {
         { id: 'a1', role: 'assistant', content: '<p>Hi</p>', htmlContent: '<p>Hi</p>', index: 1 },
       ],
       extractedAt: new Date('2025-01-01T00:00:00.000Z'),
-      metadata: { messageCount: 2, userMessageCount: 1, assistantMessageCount: 1, hasCodeBlocks: false },
+      metadata: {
+        messageCount: 2,
+        userMessageCount: 1,
+        assistantMessageCount: 1,
+        hasCodeBlocks: false,
+      },
     };
 
     const note = conversationToNote(data, defaultOptions);
@@ -536,10 +563,21 @@ describe('conversationToNote', () => {
       type: 'deep-research',
       links: { sources: [] },
       messages: [
-        { id: 'r0', role: 'assistant', content: '<p>Report content</p>', htmlContent: '<p>Report content</p>', index: 0 },
+        {
+          id: 'r0',
+          role: 'assistant',
+          content: '<p>Report content</p>',
+          htmlContent: '<p>Report content</p>',
+          index: 0,
+        },
       ],
       extractedAt: new Date('2025-01-01T00:00:00.000Z'),
-      metadata: { messageCount: 1, userMessageCount: 0, assistantMessageCount: 1, hasCodeBlocks: false },
+      metadata: {
+        messageCount: 1,
+        userMessageCount: 0,
+        assistantMessageCount: 1,
+        hasCodeBlocks: false,
+      },
     };
 
     const note = conversationToNote(data, defaultOptions);
@@ -589,7 +627,8 @@ describe('convertDeepResearchContent', () => {
   });
 
   it('handles multiple sources with 1-based index mapping', () => {
-    const html = '<p>First<sup data-turn-source-index="1"></sup> second<sup data-turn-source-index="2"></sup></p>';
+    const html =
+      '<p>First<sup data-turn-source-index="1"></sup> second<sup data-turn-source-index="2"></sup></p>';
     const links: DeepResearchLinks = {
       sources: [
         { index: 0, url: 'https://example.com/a', title: 'Article A', domain: 'example.com' },
@@ -609,7 +648,8 @@ describe('convertDeepResearchContent', () => {
   });
 
   it('handles duplicate citations with same footnote number', () => {
-    const html = '<p>First<sup data-turn-source-index="1"></sup> second<sup data-turn-source-index="1"></sup></p>';
+    const html =
+      '<p>First<sup data-turn-source-index="1"></sup> second<sup data-turn-source-index="1"></sup></p>';
     const links: DeepResearchLinks = {
       sources: [{ index: 0, url: 'https://example.com', title: 'Source', domain: 'example.com' }],
     };
@@ -644,7 +684,12 @@ describe('convertDeepResearchContent', () => {
     const links: DeepResearchLinks = {
       sources: [
         { index: 0, url: 'javascript:alert(1)', title: 'XSS', domain: 'bad.com' },
-        { index: 1, url: 'data:text/html,<script>alert(1)</script>', title: 'Data', domain: 'bad.com' },
+        {
+          index: 1,
+          url: 'data:text/html,<script>alert(1)</script>',
+          title: 'Data',
+          domain: 'bad.com',
+        },
         { index: 2, url: 'https://safe.com', title: 'Safe', domain: 'safe.com' },
       ],
     };
@@ -757,7 +802,8 @@ describe('conversationToNote with toolContent', () => {
           id: 'a1',
           role: 'assistant',
           content: '<p>Here are the results.</p>',
-          toolContent: '**Searched the web**\nRust latest version 2026 (10 results)\n- Rust Versions | Rust Changelogs (releases.rs)',
+          toolContent:
+            '**Searched the web**\nRust latest version 2026 (10 results)\n- Rust Versions | Rust Changelogs (releases.rs)',
           index: 1,
         },
       ],

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -272,6 +272,30 @@ describe('buildAppendContent', () => {
     expect(result!.content).not.toContain('2026-01-01T00:00:00.000Z');
   });
 
+  it('uses timezone setting for modified timestamp in frontmatter', () => {
+    const settingsWithTz = {
+      ...testSettings,
+      templateOptions: { ...testSettings.templateOptions, timezone: 'Asia/Tokyo' },
+    };
+    const existing = [
+      '---',
+      'id: claude_test',
+      'message_count: 2',
+      'modified: "2026-01-01T00:00:00.000Z"',
+      '---',
+      '> [!QUESTION] User',
+      '> Hello',
+      '',
+      '> [!NOTE] Claude',
+      '> Hi there!',
+    ].join('\n');
+
+    const result = buildAppendContent(existing, testNote, settingsWithTz);
+    expect(result).not.toBeNull();
+    // Modified timestamp should have JST offset
+    expect(result!.content).toMatch(/modified: .*\+09:00/);
+  });
+
   it('preserves user-added notes in existing body', () => {
     const existing = [
       '---',

--- a/test/lib/date-utils.test.ts
+++ b/test/lib/date-utils.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Date Utilities Tests
+ *
+ * Tests formatDateWithTimezone() for timezone-aware ISO 8601 date formatting.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatDateWithTimezone } from '../../src/lib/date-utils';
+
+describe('formatDateWithTimezone', () => {
+  // Fixed date: 2025-01-15 00:00:00 UTC
+  const utcDate = new Date('2025-01-15T00:00:00.000Z');
+
+  describe('UTC timezone', () => {
+    it('formats date with +00:00 offset', () => {
+      const result = formatDateWithTimezone(utcDate, 'UTC');
+      expect(result).toBe('2025-01-15T00:00:00+00:00');
+    });
+  });
+
+  describe('Asia/Tokyo (JST, UTC+9)', () => {
+    it('shifts time forward by 9 hours', () => {
+      const result = formatDateWithTimezone(utcDate, 'Asia/Tokyo');
+      expect(result).toBe('2025-01-15T09:00:00+09:00');
+    });
+
+    it('handles date boundary crossing', () => {
+      // 2025-01-15 20:00 UTC = 2025-01-16 05:00 JST
+      const lateUtc = new Date('2025-01-15T20:00:00.000Z');
+      const result = formatDateWithTimezone(lateUtc, 'Asia/Tokyo');
+      expect(result).toBe('2025-01-16T05:00:00+09:00');
+    });
+  });
+
+  describe('America/New_York (EST/EDT)', () => {
+    it('formats winter date with EST offset (UTC-5)', () => {
+      // January = EST (no DST)
+      const result = formatDateWithTimezone(utcDate, 'America/New_York');
+      expect(result).toBe('2025-01-14T19:00:00-05:00');
+    });
+
+    it('formats summer date with EDT offset (UTC-4)', () => {
+      // July = EDT (DST active)
+      const summerDate = new Date('2025-07-15T12:00:00.000Z');
+      const result = formatDateWithTimezone(summerDate, 'America/New_York');
+      expect(result).toBe('2025-07-15T08:00:00-04:00');
+    });
+  });
+
+  describe('Asia/Kolkata (IST, UTC+5:30)', () => {
+    it('handles half-hour offset timezone', () => {
+      const result = formatDateWithTimezone(utcDate, 'Asia/Kolkata');
+      expect(result).toBe('2025-01-15T05:30:00+05:30');
+    });
+  });
+
+  describe('Pacific/Chatham (UTC+12:45 / +13:45 DST)', () => {
+    it('handles 45-minute offset timezone in DST (January = summer)', () => {
+      // January in Southern Hemisphere = DST → UTC+13:45
+      const result = formatDateWithTimezone(utcDate, 'Pacific/Chatham');
+      expect(result).toBe('2025-01-15T13:45:00+13:45');
+    });
+
+    it('handles 45-minute offset timezone in standard time (July = winter)', () => {
+      const winterDate = new Date('2025-07-15T00:00:00.000Z');
+      const result = formatDateWithTimezone(winterDate, 'Pacific/Chatham');
+      expect(result).toBe('2025-07-15T12:45:00+12:45');
+    });
+  });
+
+  describe('invalid timezone fallback', () => {
+    it('falls back to UTC for invalid timezone string', () => {
+      const result = formatDateWithTimezone(utcDate, 'Invalid/Timezone');
+      expect(result).toBe('2025-01-15T00:00:00+00:00');
+    });
+
+    it('falls back to UTC for empty string', () => {
+      const result = formatDateWithTimezone(utcDate, '');
+      expect(result).toBe('2025-01-15T00:00:00+00:00');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles midnight boundary', () => {
+      // Midnight UTC → same day in UTC
+      const midnight = new Date('2025-06-01T00:00:00.000Z');
+      const result = formatDateWithTimezone(midnight, 'UTC');
+      expect(result).toBe('2025-06-01T00:00:00+00:00');
+    });
+
+    it('handles year boundary with timezone shift', () => {
+      // 2024-12-31 20:00 UTC = 2025-01-01 05:00 JST
+      const newYearEve = new Date('2024-12-31T20:00:00.000Z');
+      const result = formatDateWithTimezone(newYearEve, 'Asia/Tokyo');
+      expect(result).toBe('2025-01-01T05:00:00+09:00');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `formatDateWithTimezone()` utility using `Intl.DateTimeFormat` for ISO 8601 with offset (e.g., `2025-01-15T09:00:00+09:00`)
- Add `timezone?: string` to `TemplateOptions` (IANA timezone, default: UTC for backward compatibility)
- Wire timezone into `conversationToNote()` and `buildAppendContent()` replacing `toISOString()`
- Add timezone dropdown in popup settings (populated from `Intl.supportedValuesOf`, hidden when dates disabled)
- Add `TIMEZONE` env var support for e2e selector reporter via `.env.local`
- Invalid timezone gracefully falls back to UTC; Chrome < 99 degrades to UTC-only dropdown
- i18n: added timezone labels for en/ja locales

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npx vitest run` passes (897 tests)
- [x] Manual: set timezone to `Asia/Tokyo` in popup, save a conversation, verify frontmatter shows `+09:00` offset
- [x] Manual: verify timezone dropdown hidden when "Dates" checkbox is unchecked
- [x] Manual: add `TIMEZONE=Asia/Tokyo` to `e2e/.env.local`, run `npm run e2e:selectors`, verify report date in JST

🤖 Generated with [Claude Code](https://claude.com/claude-code)