### PR TITLE
refactor: extract magic number to constant and split extractToolContent into helpers

### DIFF
--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -247,14 +247,23 @@ export class ClaudeExtractor extends BaseExtractor {
    */
   private extractToolContent(toolSection: Element): string {
     const parts: string[] = [];
+    this.extractToolSummary(toolSection, parts);
+    this.extractToolQueries(toolSection, parts);
+    this.extractToolResults(toolSection, parts);
+    this.extractToolMarkdown(toolSection, parts);
+    return parts.join('\n\n');
+  }
 
-    // 1. Summary button text (group/status button > span.truncate)
+  /** Summary button text (e.g., "Searched the web") as bold */
+  private extractToolSummary(toolSection: Element, parts: string[]): void {
     const summaryButton = toolSection.querySelector('button span.truncate');
     if (summaryButton?.textContent) {
       parts.push('**' + this.sanitizeText(summaryButton.textContent) + '**');
     }
+  }
 
-    // 2. Search queries (group/row buttons contain query text and result count)
+  /** Search queries (group/row buttons with query text and result count) */
+  private extractToolQueries(toolSection: Element, parts: string[]): void {
     const queryButtons = toolSection.querySelectorAll('[class*="group/row"]');
     queryButtons.forEach(btn => {
       const queryEl = btn.querySelector('.truncate');
@@ -267,28 +276,32 @@ export class ClaudeExtractor extends BaseExtractor {
         parts.push(text);
       }
     });
+  }
 
-    // 3. Search result items (identified by favicon images)
+  /** Search result items (identified by favicon images) */
+  private extractToolResults(toolSection: Element, parts: string[]): void {
     const favicons = toolSection.querySelectorAll('img[alt="favicon"]');
-    if (favicons.length > 0) {
-      const items: string[] = [];
-      favicons.forEach(img => {
-        // Navigate: img → container div → result row div
-        const row = img.parentElement?.parentElement;
-        if (!row || row.children.length < 2) return;
-        // Children: [0]=favicon container, [1]=title, [2]=domain (optional)
-        const title = row.children[1]?.textContent?.trim();
-        const domain = row.children.length > 2 ? row.children[2]?.textContent?.trim() : undefined;
-        if (title) {
-          items.push(domain ? '- ' + title + ' (' + domain + ')' : '- ' + title);
-        }
-      });
-      if (items.length > 0) {
-        parts.push(items.join('\n'));
-      }
-    }
+    if (favicons.length === 0) return;
 
-    // 4. .standard-markdown content (code interpreter, file analysis)
+    const items: string[] = [];
+    favicons.forEach(img => {
+      // Navigate: img → container div → result row div
+      const row = img.parentElement?.parentElement;
+      if (!row || row.children.length < 2) return;
+      // Children: [0]=favicon container, [1]=title, [2]=domain (optional)
+      const title = row.children[1]?.textContent?.trim();
+      const domain = row.children.length > 2 ? row.children[2]?.textContent?.trim() : undefined;
+      if (title) {
+        items.push(domain ? '- ' + title + ' (' + domain + ')' : '- ' + title);
+      }
+    });
+    if (items.length > 0) {
+      parts.push(items.join('\n'));
+    }
+  }
+
+  /** .standard-markdown content (code interpreter, file analysis) */
+  private extractToolMarkdown(toolSection: Element, parts: string[]): void {
     const markdownEls = toolSection.querySelectorAll('.standard-markdown');
     markdownEls.forEach(el => {
       const html = sanitizeHtml(el.innerHTML);
@@ -296,8 +309,6 @@ export class ClaudeExtractor extends BaseExtractor {
         parts.push(html);
       }
     });
-
-    return parts.join('\n\n');
   }
 
   /**

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -1,12 +1,12 @@
 /**
  * Turndown HTML-to-Markdown engine with custom rules
  *
- * Leaf module — only depends on external `turndown` package.
  * Configures Turndown with custom rules for code blocks, inline code,
  * footnote references, math expressions, and tables.
  */
 
 import TurndownService from 'turndown';
+import { MAX_LANG_HINT_LENGTH } from '../lib/constants';
 
 /**
  * Escape angle brackets in a single line of Markdown text.
@@ -139,7 +139,7 @@ turndown.addRule('codemirrorCodeBlocks', {
       if (cmContent.contains(div) || div.contains(cmContent)) continue;
       if (div.querySelector('button, .cm-content, .cm-editor')) continue;
       const text = div.textContent?.trim();
-      if (text && text.length > 0 && text.length < 30) {
+      if (text && text.length > 0 && text.length < MAX_LANG_HINT_LENGTH) {
         const lower = text.toLowerCase();
         if (!buttonTexts.has(lower)) {
           lang = lower;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,6 +21,9 @@ export const MAX_FILENAME_BASE_LENGTH = 50;
 /** Length of conversation ID suffix in filenames */
 export const FILENAME_ID_SUFFIX_LENGTH = 8;
 
+/** Maximum length for a code block language hint (characters) */
+export const MAX_LANG_HINT_LENGTH = 30;
+
 // ============================================================
 // Validation Limits
 // ============================================================


### PR DESCRIPTION
## Summary

- Extract hardcoded magic number `30` to `MAX_LANG_HINT_LENGTH` constant in `src/lib/constants.ts`
- Import and use the constant in `src/content/markdown-rules.ts` for code block language hint detection
- Split 52-line `extractToolContent()` in Claude extractor into 4 focused private helpers: `extractToolSummary`, `extractToolQueries`, `extractToolResults`, `extractToolMarkdown`
- `extractToolContent()` is now a 7-line orchestrator calling the helpers

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (907/907 tests)
- [x] Verify Claude tool-use conversations extract correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)