### PR TITLE
fix: address static analysis findings — security hardening, dead code removal, type safety

### DIFF
--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -7,7 +7,7 @@
 import { ObsidianApiClient } from '../lib/obsidian-api';
 import { getErrorMessage } from '../lib/error-utils';
 import { generateNoteContent } from '../lib/note-generator';
-import { resolvePathTemplate } from '../lib/path-utils';
+import { resolvePathTemplate, containsPathTraversal } from '../lib/path-utils';
 import { lookupExistingFile, buildAppendContent } from '../lib/append-utils';
 import { validateObsidianUrl } from '../lib/validation';
 import type { ExtensionSettings, ObsidianNote, SaveResponse } from '../lib/types';
@@ -89,6 +89,10 @@ export async function handleSave(
     });
     const fullPath = resolvedPath ? `${resolvedPath}/${note.fileName}` : note.fileName;
 
+    if (containsPathTraversal(fullPath)) {
+      return { success: false, error: 'Invalid file path' };
+    }
+
     const appendResult = await tryAppendMode(client, settings, note, fullPath, resolvedPath);
     if (appendResult) return appendResult;
 
@@ -119,6 +123,11 @@ export async function handleGetFile(
 
   try {
     const path = vaultPath ? `${vaultPath}/${fileName}` : fileName;
+
+    if (containsPathTraversal(path)) {
+      return { success: false, error: 'Invalid file path' };
+    }
+
     const content = await client.getFile(path);
 
     if (content === null) {

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -173,13 +173,24 @@ export class ChatGPTExtractor extends BaseExtractor {
   /**
    * Clean utm_source parameter from citation URLs
    *
-   * ChatGPT adds ?utm_source=chatgpt.com to citation URLs
+   * ChatGPT adds ?utm_source=chatgpt.com to citation URLs.
+   * Uses DOM-level manipulation instead of regex for safety.
    * @see DES-003-chatgpt-extractor.md Section 8.2
    */
   private cleanCitationUrls(html: string): string {
-    // Replace utm_source parameter in href attributes
-    return html
-      .replace(/href="([^"]+)\?utm_source=chatgpt\.com"/g, (_match, url) => `href="${url}"`)
-      .replace(/href="([^"]+)&utm_source=chatgpt\.com"/g, (_match, url) => `href="${url}"`);
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    doc.querySelectorAll('a[href]').forEach(el => {
+      const anchor = el as HTMLAnchorElement;
+      try {
+        const url = new URL(anchor.href);
+        if (url.searchParams.get('utm_source') === 'chatgpt.com') {
+          url.searchParams.delete('utm_source');
+          anchor.href = url.toString();
+        }
+      } catch {
+        // malformed href — leave for DOMPurify to handle
+      }
+    });
+    return doc.body.innerHTML;
   }
 }

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -311,17 +311,6 @@ export class ClaudeExtractor extends BaseExtractor {
     });
   }
 
-  /**
-   * Extract markdown content from a grid section (.row-start-1 or .row-start-2)
-   */
-  private extractMarkdownFromSection(section: Element): string {
-    const markdownEl = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, section);
-    if (markdownEl) {
-      return sanitizeHtml(markdownEl.innerHTML);
-    }
-    return sanitizeHtml(section.innerHTML);
-  }
-
   // ========== Deep Research Extraction ==========
 
   /**

--- a/src/content/markdown-deep-research.ts
+++ b/src/content/markdown-deep-research.ts
@@ -17,13 +17,15 @@ import { htmlToMarkdown } from './markdown-rules';
 import { buildSourceMap } from '../lib/source-map';
 import type { DeepResearchLinks, DeepResearchSource } from '../lib/types';
 
-/** Pre-compiled regex for source-footnote wrapped citations */
-const CITATION_PATTERN_WRAPPED =
-  /<source-footnote[^>]*>[\s\S]*?<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>[\s\S]*?<\/source-footnote>/gi;
+/** Create a fresh regex for source-footnote wrapped citations */
+function createWrappedCitationPattern(): RegExp {
+  return /<source-footnote[^>]*>[\s\S]*?<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>[\s\S]*?<\/source-footnote>/gi;
+}
 
-/** Pre-compiled regex for standalone sup citations (fallback) */
-const CITATION_PATTERN_STANDALONE =
-  /<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>/gi;
+/** Create a fresh regex for standalone sup citations (fallback) */
+function createStandaloneCitationPattern(): RegExp {
+  return /<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>/gi;
+}
 
 /**
  * Escape Markdown link metacharacters in text
@@ -92,12 +94,10 @@ function convertInlineCitationsToFootnoteRefs(
   const replacer = createCitationReplacer(sourceMap);
 
   // Pattern 1: source-footnote wrapped
-  CITATION_PATTERN_WRAPPED.lastIndex = 0;
-  let result = html.replace(CITATION_PATTERN_WRAPPED, replacer);
+  let result = html.replace(createWrappedCitationPattern(), replacer);
 
   // Pattern 2: standalone sup element (fallback)
-  CITATION_PATTERN_STANDALONE.lastIndex = 0;
-  result = result.replace(CITATION_PATTERN_STANDALONE, replacer);
+  result = result.replace(createStandaloneCitationPattern(), replacer);
 
   return result;
 }

--- a/src/content/markdown-formatting.ts
+++ b/src/content/markdown-formatting.ts
@@ -7,13 +7,13 @@
 
 import { htmlToMarkdown, escapeAngleBrackets } from './markdown-rules';
 import { PLATFORM_LABELS } from '../lib/constants';
-import type { TemplateOptions } from '../lib/types';
+import type { AIPlatform, TemplateOptions } from '../lib/types';
 
 /**
  * Get display label for AI assistant based on source platform
  */
-function getAssistantLabel(source: string): string {
-  return PLATFORM_LABELS[source] ?? 'Assistant';
+function getAssistantLabel(source: AIPlatform): string {
+  return PLATFORM_LABELS[source];
 }
 
 /**
@@ -23,7 +23,7 @@ export function formatMessage(
   content: string,
   role: 'user' | 'assistant',
   options: TemplateOptions,
-  source: string
+  source: AIPlatform
 ): string {
   // Convert HTML to Markdown for assistant messages; escape angle brackets for user messages
   const markdown = role === 'assistant' ? htmlToMarkdown(content) : escapeAngleBrackets(content);

--- a/src/content/ui.ts
+++ b/src/content/ui.ts
@@ -262,7 +262,9 @@ export function showToast(
   closeBtn.textContent = '\u00d7';
   closeBtn.addEventListener('click', () => {
     toast.remove();
-    currentToast = null;
+    if (currentToast === toast) {
+      currentToast = null;
+    }
   });
 
   toast.appendChild(toastIcon);
@@ -274,10 +276,13 @@ export function showToast(
   // Auto-dismiss
   if (duration > 0) {
     setTimeout(() => {
+      if (currentToast !== toast) return;
       toast.style.animation = 'g2o-slideIn 0.3s ease reverse';
       setTimeout(() => {
         toast.remove();
-        currentToast = null;
+        if (currentToast === toast) {
+          currentToast = null;
+        }
       }, 300);
     }, duration);
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,6 +5,8 @@
  * and maintainability.
  */
 
+import type { AIPlatform } from './types';
+
 // ============================================================
 // String Length Limits
 // ============================================================
@@ -135,7 +137,7 @@ export const VALID_MESSAGE_FORMATS = ['callout', 'plain', 'blockquote'] as const
 /**
  * Human-readable display labels for AI platforms
  */
-export const PLATFORM_LABELS: Record<string, string> = {
+export const PLATFORM_LABELS: Record<AIPlatform, string> = {
   gemini: 'Gemini',
   claude: 'Claude',
   chatgpt: 'ChatGPT',

--- a/src/lib/message-counter.ts
+++ b/src/lib/message-counter.ts
@@ -106,13 +106,5 @@ export function extractTailMessages(fullBody: string, skipCount: number): string
 
   if (tailStartLine === -1) return '';
 
-  // Find the start of the tail, skipping leading empty lines separator
-  let start = tailStartLine;
-  // Look backwards to include the separator blank lines before the message
-  // but only the separator, not content from previous messages
-  while (start > 0 && lines[start - 1].trim() === '') {
-    start--;
-  }
-  // We want the new messages to start cleanly, so use tailStartLine
   return lines.slice(tailStartLine).join('\n');
 }

--- a/src/lib/obsidian-api.ts
+++ b/src/lib/obsidian-api.ts
@@ -246,7 +246,8 @@ export class ObsidianApiClient {
       }
 
       const data = (await response.json()) as Record<string, unknown>;
-      const files = Array.isArray(data?.files) ? (data.files as string[]) : [];
+      const rawFiles = Array.isArray(data?.files) ? data.files : [];
+      const files = rawFiles.filter((f): f is string => typeof f === 'string');
       // Filter out directories (entries ending with '/')
       return files.filter(f => !f.endsWith('/'));
     } catch (error) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,10 +26,6 @@
     "http://127.0.0.1/*",
     "https://127.0.0.1/*"
   ],
-  "optional_host_permissions": [
-    "http://*/*",
-    "https://*/*"
-  ],
   "content_security_policy": {
     "extension_pages": "default-src 'self'; script-src 'self'; connect-src 'self' http://127.0.0.1:* https://127.0.0.1:*; object-src 'none'; frame-src 'none'; style-src 'self'"
   },

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -54,8 +54,9 @@ chrome.runtime.onMessage.addListener(
     sender: chrome.runtime.MessageSender,
     sendResponse: (response: ClipboardWriteResponse) => void
   ) => {
-    // Security: Only accept messages from the same extension
-    if (sender.id !== chrome.runtime.id) {
+    // Security: Only accept messages from the background service worker
+    // sender.tab is undefined for background context, defined for content scripts
+    if (sender.id !== chrome.runtime.id || sender.tab !== undefined) {
       return false;
     }
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -258,13 +258,10 @@ function populateTimezoneOptions(): void {
   if (select.options.length > 1) return;
 
   // Intl.supportedValuesOf is available in Chrome 99+
-  // TypeScript ES2020 lib doesn't include it, so we use a type assertion
   // Falls back to UTC-only if unavailable (Chrome 96-98)
   let timezones: string[];
   try {
-    timezones = (Intl as unknown as { supportedValuesOf(key: string): string[] }).supportedValuesOf(
-      'timeZone'
-    );
+    timezones = Intl.supportedValuesOf('timeZone');
   } catch {
     // Chrome < 99: leave dropdown with just UTC
     return;

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -834,6 +834,30 @@ describe('background/index', () => {
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'Network timeout' });
     });
+
+    it('rejects assembled path with traversal (SEC-04)', async () => {
+      // vaultPath and fileName individually pass validation, but combined they could traverse
+      // This tests the defense-in-depth check on the assembled fullPath
+      mockGetSettings = vi.fn(() =>
+        Promise.resolve({
+          ...defaultSettings,
+          vaultPath: 'AI/../../../etc',
+        })
+      );
+
+      const sendResponse = vi.fn();
+      capturedListener(
+        { action: 'getExistingFile', fileName: 'passwd', vaultPath: 'AI/../../../etc' },
+        validSender as chrome.runtime.MessageSender,
+        sendResponse
+      );
+
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: expect.stringContaining('Invalid'),
+      });
+    });
   });
 
   describe('testConnection additional scenarios', () => {

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -599,34 +599,6 @@ describe('conversationToNote', () => {
     expect(note.body).toContain('`<span>`');
   });
 
-  // ========== Coverage Gap: getAssistantLabel default (DES-005 3.6) ==========
-  it('uses "Assistant" label for unknown source platform', () => {
-    // Covers: markdown.ts line 329 (default case in getAssistantLabel switch)
-    // NOTE: Uses type cast to bypass compile-time check. This is intentional
-    // to exercise the runtime default case.
-    const data: ConversationData = {
-      id: 'test-unknown',
-      title: 'Unknown Platform Test',
-      url: 'https://example.com/chat/123',
-      source: 'unknown_platform' as 'gemini',
-      messages: [
-        { id: 'u1', role: 'user', content: 'Hello', index: 0 },
-        { id: 'a1', role: 'assistant', content: '<p>Hi</p>', htmlContent: '<p>Hi</p>', index: 1 },
-      ],
-      extractedAt: new Date('2025-01-01T00:00:00.000Z'),
-      metadata: {
-        messageCount: 2,
-        userMessageCount: 1,
-        assistantMessageCount: 1,
-        hasCodeBlocks: false,
-      },
-    };
-
-    const note = conversationToNote(data, defaultOptions);
-
-    expect(note.body).toContain('[!NOTE] Assistant');
-  });
-
   // ========== Coverage Gap: empty sources in Deep Research (DES-005 3.6) ==========
   it('omits References section when links.sources is empty', () => {
     // Covers: markdown.ts line 176 branch (sources.length === 0)

--- a/test/lib/obsidian-api.test.ts
+++ b/test/lib/obsidian-api.test.ts
@@ -316,6 +316,18 @@ describe('ObsidianApiClient', () => {
         message: 'Request timed out. Please check your connection.',
       });
     });
+
+    it('filters out non-string elements from files array (Q1)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: ['note.md', 42, null, 'other.md', true] }),
+      });
+
+      const files = await client.listFiles('AI');
+
+      expect(files).toEqual(['note.md', 'other.md']);
+    });
   });
 
   describe('AbortSignal.timeout fallback', () => {

--- a/test/offscreen/offscreen.test.ts
+++ b/test/offscreen/offscreen.test.ts
@@ -79,7 +79,22 @@ describe('offscreen/offscreen', () => {
     expect(sendResponse).not.toHaveBeenCalled();
   });
 
-  it('accepts messages from same extension ID', () => {
+  it('rejects messages from content scripts (sender.tab defined) (SEC-03)', () => {
+    const sendResponse = vi.fn();
+    const result = capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
+      {
+        id: chrome.runtime.id,
+        tab: { id: 1, index: 0, highlighted: false, active: true, pinned: false } as chrome.tabs.Tab,
+      } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(result).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it('accepts messages from background service worker (no sender.tab) (SEC-03)', () => {
     const sendResponse = vi.fn();
     capturedListener(
       { action: 'clipboardWrite', target: 'offscreen', content: 'hello' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2022.Intl", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary

- **SEC-01**: Remove unused `optional_host_permissions` (`http://*/*`, `https://*/*`) from manifest — no functional justification for all-URL access
- **SEC-02**: Rewrite `cleanCitationUrls` in ChatGPT extractor to use `DOMParser` + `URL` API instead of fragile regex on raw HTML
- **SEC-03**: Add `sender.tab !== undefined` guard in offscreen document listener to reject messages from content scripts
- **SEC-04**: Add `containsPathTraversal` check on assembled `fullPath` after concatenation in `handleSave` and `handleGetFile`
- **Q1**: Add per-element string type guard on `data.files` in `listFiles` response — no longer blindly casts to `string[]`
- **Q3**: Remove dead private method `extractMarkdownFromSection` in Claude extractor
- **Q4**: Remove dead backward-scan `while` loop in `extractTailMessages` (computed `start` was never used)
- **Q8**: Type `PLATFORM_LABELS` as `Record<AIPlatform, string>` for compile-time exhaustiveness; narrow `formatMessage` source param
- **Q5**: Add `ES2022.Intl` to tsconfig lib, remove `as unknown as` type cast for `Intl.supportedValuesOf`
- **Q7**: Convert module-level g-flag regexes in deep-research to factory functions, eliminating `lastIndex` hazard
- **Q2**: Fix toast dismiss race condition with stale-reference guards in auto-dismiss callbacks

## Test plan

- [x] `npm run build` succeeds (tsc + vite)
- [x] `npm run lint` passes (eslint + platform lint)
- [x] `npm run test` passes (909 tests)
- [x] `npm run test:coverage` — 95.8% stmts / 89.2% branch / 96.9% funcs / 96.6% lines
- [x] Load extension in Chrome and verify all 4 platforms still work
- [x] Verify permissions page shows no unexpected "optional" access

🤖 Generated with [Claude Code](https://claude.com/claude-code)