### PR TITLE
refactor: DRY improvements for ObsidianApiClient and popup validation

### DIFF
--- a/src/lib/obsidian-api.ts
+++ b/src/lib/obsidian-api.ts
@@ -107,6 +107,27 @@ export class ObsidianApiClient {
   }
 
   /**
+   * Fetch with timeout and unified network error handling.
+   * Wraps fetch() with AbortSignal.timeout and converts network errors
+   * to ObsidianApiError. Used by getFile, putFile, listFiles.
+   *
+   * Not used by testConnection (which returns a result object instead of throwing).
+   */
+  private async fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+    try {
+      return await fetch(url, {
+        ...options,
+        signal: createTimeoutSignal(DEFAULT_API_TIMEOUT),
+      });
+    } catch (error) {
+      if (isNetworkError(error)) {
+        throw this.createError(0, 'Request timed out. Please check your connection.');
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Test API connection with authentication verification
    *
    * Uses /vault/ endpoint which requires authentication.
@@ -163,29 +184,21 @@ export class ObsidianApiClient {
    * @returns File content as string, or null if file doesn't exist
    */
   async getFile(path: string): Promise<string | null> {
-    try {
-      const encodedPath = encodeURIComponent(path);
-      const response = await fetch(`${this.baseUrl}/vault/${encodedPath}`, {
-        method: 'GET',
-        headers: this.getHeaders(),
-        signal: createTimeoutSignal(DEFAULT_API_TIMEOUT),
-      });
+    const encodedPath = encodeURIComponent(path);
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/vault/${encodedPath}`, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
 
-      if (response.status === 404) {
-        return null;
-      }
-
-      if (!response.ok) {
-        throw this.createError(response.status, `Failed to get file: ${response.statusText}`);
-      }
-
-      return await response.text();
-    } catch (error) {
-      if (isNetworkError(error)) {
-        throw this.createError(0, 'Request timed out. Please check your connection.');
-      }
-      throw error;
+    if (response.status === 404) {
+      return null;
     }
+
+    if (!response.ok) {
+      throw this.createError(response.status, `Failed to get file: ${response.statusText}`);
+    }
+
+    return await response.text();
   }
 
   /**
@@ -194,26 +207,18 @@ export class ObsidianApiClient {
    * @param content - File content (markdown)
    */
   async putFile(path: string, content: string): Promise<void> {
-    try {
-      const encodedPath = encodeURIComponent(path);
-      const response = await fetch(`${this.baseUrl}/vault/${encodedPath}`, {
-        method: 'PUT',
-        headers: {
-          ...this.getHeaders(),
-          'Content-Type': 'text/markdown',
-        },
-        body: content,
-        signal: createTimeoutSignal(DEFAULT_API_TIMEOUT),
-      });
+    const encodedPath = encodeURIComponent(path);
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/vault/${encodedPath}`, {
+      method: 'PUT',
+      headers: {
+        ...this.getHeaders(),
+        'Content-Type': 'text/markdown',
+      },
+      body: content,
+    });
 
-      if (!response.ok) {
-        throw this.createError(response.status, `Failed to save file: ${response.statusText}`);
-      }
-    } catch (error) {
-      if (isNetworkError(error)) {
-        throw this.createError(0, 'Request timed out. Please check your connection.');
-      }
-      throw error;
+    if (!response.ok) {
+      throw this.createError(response.status, `Failed to save file: ${response.statusText}`);
     }
   }
 
@@ -226,36 +231,28 @@ export class ObsidianApiClient {
    * @returns Array of filenames (directories filtered out)
    */
   async listFiles(directory: string): Promise<string[]> {
-    try {
-      const encodedDir = encodeURIComponent(directory);
-      const response = await fetch(`${this.baseUrl}/vault/${encodedDir}/`, {
-        method: 'GET',
-        headers: {
-          ...this.getHeaders(),
-          Accept: 'application/json',
-        },
-        signal: createTimeoutSignal(DEFAULT_API_TIMEOUT),
-      });
+    const encodedDir = encodeURIComponent(directory);
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/vault/${encodedDir}/`, {
+      method: 'GET',
+      headers: {
+        ...this.getHeaders(),
+        Accept: 'application/json',
+      },
+    });
 
-      if (response.status === 404) {
-        return [];
-      }
-
-      if (!response.ok) {
-        throw this.createError(response.status, `Failed to list files: ${response.statusText}`);
-      }
-
-      const data = (await response.json()) as Record<string, unknown>;
-      const rawFiles = Array.isArray(data?.files) ? data.files : [];
-      const files = rawFiles.filter((f): f is string => typeof f === 'string');
-      // Filter out directories (entries ending with '/')
-      return files.filter(f => !f.endsWith('/'));
-    } catch (error) {
-      if (isNetworkError(error)) {
-        throw this.createError(0, 'Request timed out. Please check your connection.');
-      }
-      throw error;
+    if (response.status === 404) {
+      return [];
     }
+
+    if (!response.ok) {
+      throw this.createError(response.status, `Failed to list files: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+    const rawFiles = Array.isArray(data?.files) ? data.files : [];
+    const files = rawFiles.filter((f): f is string => typeof f === 'string');
+    // Filter out directories (entries ending with '/')
+    return files.filter(f => !f.endsWith('/'));
   }
 
   /**

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -393,15 +393,22 @@ function validateObsidianSettings(settings: ExtensionSettings): ObsidianValidati
   const url = tryValidate(() => validateObsidianUrl(settings.obsidianUrl), 'Invalid URL');
   if (!url.ok) return { error: url.error, ...defaults, normalizedApiKey: apiKey.value };
 
-  const vaultPath = tryValidate(
-    () => validateVaultPath(settings.vaultPath),
-    'Invalid vault path'
-  );
+  const vaultPath = tryValidate(() => validateVaultPath(settings.vaultPath), 'Invalid vault path');
   if (!vaultPath.ok) {
-    return { error: vaultPath.error, ...defaults, normalizedApiKey: apiKey.value, normalizedUrl: url.value };
+    return {
+      error: vaultPath.error,
+      ...defaults,
+      normalizedApiKey: apiKey.value,
+      normalizedUrl: url.value,
+    };
   }
 
-  return { error: null, normalizedApiKey: apiKey.value, normalizedUrl: url.value, normalizedVaultPath: vaultPath.value };
+  return {
+    error: null,
+    normalizedApiKey: apiKey.value,
+    normalizedUrl: url.value,
+    normalizedVaultPath: vaultPath.value,
+  };
 }
 
 /**

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -363,47 +363,45 @@ interface ObsidianValidationResult {
 }
 
 /**
+ * Run a throwing validator and return the result or error message.
+ */
+function tryValidate(
+  fn: () => string,
+  fallbackMessage: string
+): { ok: true; value: string } | { ok: false; error: string } {
+  try {
+    return { ok: true, value: fn() };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : fallbackMessage };
+  }
+}
+
+/**
  * Validate Obsidian-specific settings (API key, URL, vault path)
  * Returns normalized values without mutating the input (DES-014 H-4)
  */
 function validateObsidianSettings(settings: ExtensionSettings): ObsidianValidationResult {
-  let normalizedApiKey: string;
-  try {
-    normalizedApiKey = validateApiKey(settings.obsidianApiKey);
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : 'Invalid API key',
-      normalizedApiKey: settings.obsidianApiKey,
-      normalizedUrl: settings.obsidianUrl,
-      normalizedVaultPath: settings.vaultPath,
-    };
+  const defaults = {
+    normalizedApiKey: settings.obsidianApiKey,
+    normalizedUrl: settings.obsidianUrl,
+    normalizedVaultPath: settings.vaultPath,
+  };
+
+  const apiKey = tryValidate(() => validateApiKey(settings.obsidianApiKey), 'Invalid API key');
+  if (!apiKey.ok) return { error: apiKey.error, ...defaults };
+
+  const url = tryValidate(() => validateObsidianUrl(settings.obsidianUrl), 'Invalid URL');
+  if (!url.ok) return { error: url.error, ...defaults, normalizedApiKey: apiKey.value };
+
+  const vaultPath = tryValidate(
+    () => validateVaultPath(settings.vaultPath),
+    'Invalid vault path'
+  );
+  if (!vaultPath.ok) {
+    return { error: vaultPath.error, ...defaults, normalizedApiKey: apiKey.value, normalizedUrl: url.value };
   }
 
-  let normalizedUrl: string;
-  try {
-    normalizedUrl = validateObsidianUrl(settings.obsidianUrl);
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : 'Invalid URL',
-      normalizedApiKey,
-      normalizedUrl: settings.obsidianUrl,
-      normalizedVaultPath: settings.vaultPath,
-    };
-  }
-
-  let normalizedVaultPath: string;
-  try {
-    normalizedVaultPath = validateVaultPath(settings.vaultPath);
-  } catch (error) {
-    return {
-      error: error instanceof Error ? error.message : 'Invalid vault path',
-      normalizedApiKey,
-      normalizedUrl,
-      normalizedVaultPath: settings.vaultPath,
-    };
-  }
-
-  return { error: null, normalizedApiKey, normalizedUrl, normalizedVaultPath };
+  return { error: null, normalizedApiKey: apiKey.value, normalizedUrl: url.value, normalizedVaultPath: vaultPath.value };
 }
 
 /**

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -405,6 +405,28 @@ function validateObsidianSettings(settings: ExtensionSettings): ObsidianValidati
 }
 
 /**
+ * Validate and normalize Obsidian settings (API key, URL, vault path).
+ * Returns normalized settings or an error message.
+ */
+function normalizeObsidianSettings(
+  settings: ExtensionSettings
+): { ok: true; settings: ExtensionSettings } | { ok: false; error: string } {
+  const validation = validateObsidianSettings(settings);
+  if (validation.error) {
+    return { ok: false, error: validation.error };
+  }
+  return {
+    ok: true,
+    settings: {
+      ...settings,
+      obsidianApiKey: validation.normalizedApiKey,
+      obsidianUrl: validation.normalizedUrl,
+      vaultPath: validation.normalizedVaultPath,
+    },
+  };
+}
+
+/**
  * Handle save button click
  * Input validation using security utilities (NEW-03)
  */
@@ -424,17 +446,12 @@ async function handleSave(): Promise<void> {
     // Validate Obsidian-specific settings only if Obsidian output is enabled
     let settingsToSave = settings;
     if (settings.outputOptions.obsidian) {
-      const validation = validateObsidianSettings(settings);
-      if (validation.error) {
-        showStatus(validation.error, 'error');
+      const result = normalizeObsidianSettings(settings);
+      if (!result.ok) {
+        showStatus(result.error, 'error');
         return;
       }
-      settingsToSave = {
-        ...settings,
-        obsidianApiKey: validation.normalizedApiKey,
-        obsidianUrl: validation.normalizedUrl,
-        vaultPath: validation.normalizedVaultPath,
-      };
+      settingsToSave = result.settings;
     }
 
     await saveSettings(settingsToSave);
@@ -466,20 +483,15 @@ async function handleTest(): Promise<void> {
     }
 
     // Validate Obsidian settings before saving (same as handleSave)
-    const validation = validateObsidianSettings(settings);
-    if (validation.error) {
-      showStatus(validation.error, 'error');
+    const result = normalizeObsidianSettings(settings);
+    if (!result.ok) {
+      showStatus(result.error, 'error');
       elements.testBtn.disabled = false;
       return;
     }
 
     // Save validated and normalized settings for the test
-    await saveSettings({
-      ...settings,
-      obsidianApiKey: validation.normalizedApiKey,
-      obsidianUrl: validation.normalizedUrl,
-      vaultPath: validation.normalizedVaultPath,
-    });
+    await saveSettings(result.settings);
 
     // Send test connection message to background script
     const response = await sendMessage({ action: 'testConnection' });

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -135,10 +135,6 @@ body {
   flex: 1;
 }
 
-.form-row .form-group.flex-grow {
-  flex: 2;
-}
-
 label {
   display: block;
   font-size: 13px;


### PR DESCRIPTION
## Summary

- Extract `fetchWithTimeout` in `ObsidianApiClient` to eliminate 3 identical try/catch + isNetworkError blocks across `getFile`, `putFile`, `listFiles`
- Add `tryValidate` helper with discriminated union return type to simplify `validateObsidianSettings` (3 try/catch blocks → 3 concise calls)
- Extract `normalizeObsidianSettings` to DRY shared validate → normalize → spread logic in `handleSave` and `handleTest`
- Remove unused `.form-group.flex-grow` CSS rule

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] All 909 tests pass (`npx vitest run`)
- [x] No behavior changes — pure refactoring verified after each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)