### PR TITLE
docs: add Perplexity Deep Research, timezone, remove stale CWS note

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,8 +12,9 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 - **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity からエクスポート
 - **ワンクリック保存**: 対応 AI ページに表示される「Sync」ボタンで即座に保存
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
-- **Deep Research 対応**: Gemini Deep Research と Claude Extended Thinking レポートを保存
+- **Deep Research 対応**: Gemini Deep Research、Claude Extended Thinking、Perplexity Deep Research レポートを保存
 - **Artifact 対応**: Claude Artifacts をインライン引用とソース付きで抽出
+- **タイムゾーン設定**: フロントマターの日時（created/modified）にタイムゾーンを指定可能
 - **ツールコンテンツ対応**: Claude の Web 検索結果やツール活動を折りたたみ可能な `[!ABSTRACT]` コールアウトとして保存（オプション）
 - **追記モード**: 既存ノートには新しいメッセージのみを追加
 - **Obsidian コールアウト**: `[!QUESTION]` と `[!NOTE]` による見やすいフォーマット
@@ -32,8 +33,6 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 ## インストール
 
 ### Chrome ウェブストアから
-
-> **注意**: 現在審査中です。承認後にリンクが有効になります。
 
 [Chrome ウェブストアからインストール](https://chromewebstore.google.com/detail/obsidian-ai-exporter/edemgeigfbodiehkjhjflleipabgbdeh)
 
@@ -110,6 +109,11 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 1. Artifact を含む会話を開く
 2. 「Sync」ボタンをクリック
 3. インライン引用とソース付きで Artifact の内容が抽出されます
+
+**Perplexity Deep Research:**
+1. Deep Research レポートを含む Perplexity の会話を開く
+2. 「Sync」ボタンをクリック
+3. レポート内容が通常の会話メッセージとともに抽出されます
 
 ## 出力フォーマット
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 - **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, and Perplexity
 - **One-click export**: Floating "Sync" button on supported AI pages
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
-- **Deep Research support**: Export Gemini Deep Research and Claude Extended Thinking reports
+- **Deep Research support**: Export Gemini Deep Research, Claude Extended Thinking, and Perplexity Deep Research reports
 - **Artifact support**: Extract Claude Artifacts with inline citations and sources
+- **Configurable timezone**: Set timezone for frontmatter dates (created/modified)
 - **Tool content support**: Optionally include Claude's web search results and tool activity as collapsible `[!ABSTRACT]` callouts
 - **Append mode**: Only new messages are added to existing notes
 - **Obsidian callouts**: Formatted output with `[!QUESTION]` and `[!NOTE]` callouts
@@ -32,8 +33,6 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 ## Installation
 
 ### From Chrome Web Store
-
-> **Note**: Currently under review. The link will be active once approved.
 
 [Install from Chrome Web Store](https://chromewebstore.google.com/detail/obsidian-ai-exporter/edemgeigfbodiehkjhjflleipabgbdeh)
 
@@ -110,6 +109,11 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 1. Open a conversation with an Artifact
 2. Click the "Sync" button
 3. The Artifact content with inline citations and sources will be extracted
+
+**Perplexity Deep Research:**
+1. Open a Perplexity conversation containing a Deep Research report
+2. Click the "Sync" button
+3. The report content will be extracted alongside normal conversation messages
 
 ## Output Format
 

--- a/docs/store/description_en.md
+++ b/docs/store/description_en.md
@@ -12,7 +12,8 @@ This extension extracts conversations from Google Gemini (gemini.google.com), Cl
 • One-click export from Gemini, Claude, ChatGPT, and Perplexity conversations
 • Clean Markdown formatting with YAML frontmatter
 • Obsidian callout syntax for Q&A blocks (shows correct AI name)
-• Deep Research support (Gemini) and Extended Thinking/Artifacts (Claude)
+• Deep Research support (Gemini, Perplexity) and Extended Thinking/Artifacts (Claude)
+• Configurable timezone for frontmatter dates
 • LaTeX math formula preservation ($$...$$ and $...$) across all platforms
 • Web search results saved as collapsible callouts (Claude)
 • Append mode - only new messages are added to existing notes

--- a/docs/store/description_ja.md
+++ b/docs/store/description_ja.md
@@ -12,7 +12,8 @@ Google Gemini（gemini.google.com）、Claude AI（claude.ai）、ChatGPT（chat
 • Gemini、Claude、ChatGPT、Perplexity の会話をワンクリックでエクスポート
 • YAML フロントマター付きの整形された Markdown
 • Q&A ブロックに Obsidian コールアウト構文（正しい AI 名を表示）
-• Deep Research（Gemini）と Extended Thinking / Artifacts（Claude）に対応
+• Deep Research（Gemini、Perplexity）と Extended Thinking / Artifacts（Claude）に対応
+• フロントマター日時のタイムゾーン設定
 • LaTeX 数式の保存（$$...$$・$...$）- 全プラットフォーム対応
 • Web 検索結果を折りたたみ可能なコールアウトとして保存（Claude）
 • 追記モード - 既存ノートに新しいメッセージのみ追加


### PR DESCRIPTION
## Summary

- Add Perplexity Deep Research to feature lists and usage sections (EN/JA READMEs + store descriptions)
- Add configurable timezone feature to feature lists (EN/JA READMEs + store descriptions)
- Remove outdated "currently under review" Chrome Web Store note from both READMEs

## Test plan

- [x] No code changes — docs only
- [x] Verify Markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)