### PR TITLE
feat(template): add optional `## ` question headers for TOC navigation

### DIFF
--- a/docs/adr/008-image-sync-strategy.md
+++ b/docs/adr/008-image-sync-strategy.md
@@ -1,0 +1,72 @@
+# ADR-008: Image Sync Strategy
+
+## Status
+
+Proposed
+
+## Context
+
+Issue #186 requests image sync support: when exporting AI conversations to Obsidian, images (user-uploaded, AI-generated, inline) should be saved alongside the text.
+
+Currently, images are **completely stripped** during HTML sanitization (DOMPurify `USE_PROFILES: { html: true }` removes `<img>` tags). No image-related types, extraction logic, or storage methods exist.
+
+### Constraints
+
+- AI platform image URLs are **authentication-gated and ephemeral** (signed URLs with expiration)
+- Chrome Extension Manifest V3 restricts background service worker capabilities
+- Content scripts cannot directly fetch cross-origin images; background SW must proxy
+- Obsidian Local REST API `PUT /vault/{path}` supports `*/*` Content-Type (binary upload confirmed via `bodyParser.raw()` → `vault.adapter.writeBinary()`)
+- Users configure Obsidian attachment folders differently (vault root, centralized folder, co-located, subfolder)
+
+## Decision
+
+**Use Method A: Save images as binary files to the Obsidian vault via the Local REST API.**
+
+Images are fetched as binary data in the background service worker, uploaded to the vault via `PUT /vault/{path}` with `Content-Type: application/octet-stream`, and referenced in markdown using standard `![alt](relative/path)` syntax.
+
+### Alternatives Considered
+
+| Method | Approach | Rejected Because |
+|--------|----------|-----------------|
+| B - External URL reference | `![alt](https://platform.com/image/xxx)` | URLs are auth-gated and expire; notes become broken after session ends |
+| C - Base64 Data URI | `![alt](data:image/png;base64,...)` | Bloats markdown files (100KB+ per image); poor Git/sync performance; Obsidian preview issues |
+| D - External object storage | Upload to S3/GCS, reference public URL | Requires user to configure cloud credentials; adds external dependency; complex UX |
+
+### Key Design Decisions
+
+1. **Standard Markdown links** (`![alt](path)`) over Obsidian wiki-links (`![[file]]`) for portability
+2. **Relative paths** from the note file for maximum compatibility
+3. **Configurable attachment subfolder** (default: `assets/`) under the note's directory
+4. **Opt-in setting** (`enableImageSync: false` by default) to avoid unexpected bandwidth/storage usage
+5. **Background SW fetches images** to bypass CORS restrictions in content scripts
+6. **Preserve original format** (PNG, JPG, WebP, GIF) without conversion
+7. **Size limit** (configurable, default 10MB per image) as a safety guard
+
+## Consequences
+
+### Positive
+
+- Images persist in the vault indefinitely; no link rot
+- Works offline after initial sync
+- Integrates naturally with Obsidian's image preview
+- No external service dependencies
+- Respects existing Obsidian attachment conventions
+
+### Negative
+
+- Increases vault disk usage (mitigated by opt-in + size limit)
+- Adds network overhead during export (mitigated by parallel fetching with concurrency limit)
+- Background SW must handle binary data and upload failures
+- Image fetch may fail for expired/auth-gated URLs if user delays export
+
+### Risks
+
+- **Image URL expiration**: If a user opens a conversation but delays export, image URLs may expire. Mitigation: extract image data at extraction time, not save time.
+- **Large conversations with many images**: Could cause timeout or memory pressure. Mitigation: concurrency limit + per-image size cap.
+- **CORS/CSP blocking image fetch**: Some platforms may restrict image downloads. Mitigation: fetch from background SW using host_permissions.
+
+## References
+
+- GitHub Issue: #186
+- Obsidian Local REST API: [coddingtonbear/obsidian-local-rest-api](https://github.com/coddingtonbear/obsidian-local-rest-api)
+- Obsidian attachment docs: [help.obsidian.md/attachments](https://help.obsidian.md/attachments)

--- a/docs/design/DES-017-image-sync.md
+++ b/docs/design/DES-017-image-sync.md
@@ -1,0 +1,565 @@
+# DES-017: Image Sync
+
+**Issue:** #186-1
+**ADR:** [008-image-sync-strategy.md](../adr/008-image-sync-strategy.md)
+**Status:** Draft
+
+---
+
+## 1. Overview
+
+Add opt-in image sync to the export pipeline. When enabled, images in AI conversations are extracted, downloaded as binary, saved to the Obsidian vault, and referenced in the markdown note with relative paths.
+
+### Data Flow
+
+```
+Content Script                    Background Service Worker              Obsidian Vault
+─────────────                    ───────────────────────                ──────────────
+DOM <img> elements
+    │
+    ▼
+extractImages()
+  - collect src, alt, index
+  - filter: skip data URIs,
+    skip tiny icons (<24px)
+    │
+    ▼
+ConversationMessage.images[]
+  (ImageReference[])
+    │
+    ▼
+chrome.runtime.sendMessage
+  { action: 'saveToObsidian',
+    data: { ...conversation,
+            images: ImageReference[] }}
+                                     │
+                                     ▼
+                                 fetchImageBinary(src)
+                                   - fetch() with credentials
+                                   - validate Content-Type
+                                   - enforce size limit
+                                   - returns ArrayBuffer + mime
+                                     │
+                                     ▼
+                                 putBinaryFile(path, data)          ──▶  /vault/AI/gemini/assets/
+                                   - PUT /vault/{path}                    img_001.png
+                                   - Content-Type: application/           img_002.jpg
+                                     octet-stream
+                                   - body: ArrayBuffer
+                                     │
+                                     ▼
+                                 rewriteImagePaths(markdown)
+                                   - replace placeholder refs
+                                     with relative paths
+                                     │
+                                     ▼
+                                 putFile(notePath, markdown)        ──▶  /vault/AI/gemini/
+                                   - existing text save                   My-Conversation.md
+```
+
+---
+
+## 2. Type Definitions
+
+### New Types (`src/lib/types.ts`)
+
+```typescript
+/** Reference to an image found in a conversation message */
+export interface ImageReference {
+  /** Unique ID within the conversation: `img_{messageIndex}_{imageIndex}` */
+  readonly id: string;
+  /** Original image URL from the DOM */
+  readonly src: string;
+  /** Alt text from the DOM (sanitized) */
+  readonly alt: string;
+  /** Zero-based index of the parent message */
+  readonly messageIndex: number;
+  /** Zero-based index within the message's images */
+  readonly imageIndex: number;
+}
+
+/** Downloaded image ready for upload */
+export interface ImageData {
+  /** Corresponding ImageReference */
+  readonly ref: ImageReference;
+  /** Binary content */
+  readonly data: ArrayBuffer;
+  /** MIME type from response Content-Type header */
+  readonly mimeType: string;
+  /** File extension derived from mimeType (e.g., 'png', 'jpg') */
+  readonly extension: string;
+  /** File size in bytes */
+  readonly size: number;
+}
+
+/** Result of uploading a single image */
+export interface ImageUploadResult {
+  /** Corresponding ImageReference.id */
+  readonly id: string;
+  /** Whether upload succeeded */
+  readonly success: boolean;
+  /** Vault-relative path where the image was saved */
+  readonly vaultPath?: string;
+  /** Relative path from the note file (for markdown reference) */
+  readonly relativePath?: string;
+  /** Error message if failed */
+  readonly error?: string;
+}
+```
+
+### Extended Existing Types
+
+```typescript
+// ConversationMessage — add optional images field
+export interface ConversationMessage {
+  // ... existing fields ...
+  /** Image references extracted from this message */
+  readonly images?: readonly ImageReference[];
+}
+
+// ConversationMetadata — add image count
+export interface ConversationMetadata {
+  // ... existing fields ...
+  /** Total number of images across all messages */
+  readonly imageCount: number;
+}
+
+// SyncSettings — add image sync options
+export interface SyncSettings {
+  // ... existing fields ...
+  /** Enable image download and vault upload (default: false) */
+  readonly enableImageSync: boolean;
+  /** Subfolder name for images relative to note (default: 'assets') */
+  readonly imageSubfolder: string;
+  /** Max image file size in bytes (default: 10485760 = 10MB) */
+  readonly maxImageSize: number;
+}
+
+// SaveResponse — add image results
+export interface SaveResponse {
+  // ... existing fields ...
+  /** Per-image upload results (only when enableImageSync) */
+  readonly imageResults?: readonly ImageUploadResult[];
+}
+```
+
+---
+
+## 3. Component Design
+
+### 3.1 Image Extraction (Content Script)
+
+**File:** `src/content/extractors/base.ts` — add shared `extractImages()` method
+
+```typescript
+// BaseExtractor additions
+
+/** CSS selectors for image elements per platform */
+protected readonly IMAGE_SELECTORS: readonly string[] = ['img'];
+
+/** Minimum image dimension (px) to filter out icons/spacers */
+private static readonly MIN_IMAGE_DIMENSION = 24;
+
+/**
+ * Extract image references from a container element.
+ * Filters out: data URIs, tiny icons (<24px), duplicate srcs.
+ */
+protected extractImages(
+  container: Element,
+  messageIndex: number
+): readonly ImageReference[] {
+  const imgs = container.querySelectorAll<HTMLImageElement>(
+    this.IMAGE_SELECTORS.join(', ')
+  );
+  const seen = new Set<string>();
+  const result: ImageReference[] = [];
+
+  for (const img of imgs) {
+    const src = img.src || img.getAttribute('data-src') || '';
+
+    // Skip: no src, data URIs, blob URIs, already seen
+    if (!src || src.startsWith('data:') || src.startsWith('blob:') || seen.has(src)) {
+      continue;
+    }
+    // Skip: tiny images (icons, spacers)
+    if (img.naturalWidth > 0 && img.naturalWidth < BaseExtractor.MIN_IMAGE_DIMENSION &&
+        img.naturalHeight > 0 && img.naturalHeight < BaseExtractor.MIN_IMAGE_DIMENSION) {
+      continue;
+    }
+
+    seen.add(src);
+    result.push({
+      id: `img_${messageIndex}_${result.length}`,
+      src,
+      alt: this.sanitizeText(img.alt || ''),
+      messageIndex,
+      imageIndex: result.length,
+    });
+  }
+
+  return result;
+}
+```
+
+**Platform-specific overrides:**
+- **Gemini:** Override `IMAGE_SELECTORS` to target `model-response img`
+- **Claude:** Filter out `img[alt="favicon"]` (tool-use icons)
+- **ChatGPT:** Standard `img` within markdown content
+- **Perplexity:** Standard `img` within `.prose` content
+
+### 3.2 DOMPurify Configuration Change
+
+**File:** `src/lib/sanitize.ts`
+
+Allow `<img>` tags with safe attributes only:
+
+```typescript
+DOMPurify.sanitize(preprocessed, {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: ['style'],
+  ADD_TAGS: ['img'],                    // NEW: allow <img>
+  ADD_ATTR: ['src', 'alt', 'data-src'], // NEW: safe img attributes
+});
+```
+
+Security note: DOMPurify's `USE_PROFILES: { html: true }` already strips event handlers (`onerror`, `onload`, etc.) and `javascript:` URIs. Adding `<img>` with only `src`/`alt` is safe.
+
+### 3.3 Markdown Conversion — Image Placeholder Rule
+
+**File:** `src/content/markdown-rules.ts`
+
+```typescript
+// Image placeholder rule — converts <img> to a placeholder
+// that will be replaced with the final vault path after upload
+{
+  name: 'imagePlaceholder',
+  filter: 'img',
+  replacement: (_content: string, node: TurndownNode): string => {
+    const el = node as unknown as HTMLImageElement;
+    const src = el.getAttribute('src') || el.getAttribute('data-src') || '';
+    const alt = el.getAttribute('alt') || '';
+
+    if (!src || src.startsWith('data:')) return '';
+
+    // Placeholder format: {{G2O_IMG:src|alt}}
+    // Background SW replaces these with ![alt](relative/path) after upload
+    return `{{G2O_IMG:${src}|${alt}}}`;
+  },
+}
+```
+
+### 3.4 ObsidianApiClient — Binary Upload
+
+**File:** `src/lib/obsidian-api.ts`
+
+```typescript
+/**
+ * Upload a binary file to the vault.
+ * Uses Content-Type: application/octet-stream to trigger
+ * the REST API's writeBinary() path.
+ */
+async putBinaryFile(path: string, data: ArrayBuffer): Promise<void> {
+  const url = this.buildUrl(path);
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      ...this.getHeaders(),
+      'Content-Type': 'application/octet-stream',
+    },
+    body: data,
+    signal: AbortSignal.timeout(DEFAULT_API_TIMEOUT * 3), // 15s for large images
+  });
+
+  if (!response.ok) {
+    throw new ObsidianApiError(
+      `Failed to upload binary file: ${response.status} ${response.statusText}`,
+      response.status
+    );
+  }
+}
+```
+
+### 3.5 Image Download Service
+
+**File:** `src/background/image-service.ts` (NEW)
+
+```typescript
+import type { ImageReference, ImageData, ImageUploadResult } from '../lib/types';
+
+/** MIME type → file extension mapping */
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/avif': 'avif',
+  'image/bmp': 'bmp',
+};
+
+/** Max concurrent image downloads */
+const MAX_CONCURRENCY = 3;
+
+/**
+ * Download a single image from its source URL.
+ * Runs in the background service worker (bypasses CORS).
+ */
+export async function fetchImageBinary(
+  ref: ImageReference,
+  maxSize: number
+): Promise<ImageData> {
+  const response = await fetch(ref.src, {
+    credentials: 'include',   // send cookies for auth-gated URLs
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${ref.src}`);
+  }
+
+  const contentType = response.headers.get('Content-Type') || '';
+  const mimeType = contentType.split(';')[0].trim().toLowerCase();
+  const extension = MIME_TO_EXT[mimeType];
+
+  if (!extension) {
+    throw new Error(`Unsupported image type: ${mimeType}`);
+  }
+
+  const data = await response.arrayBuffer();
+
+  if (data.byteLength > maxSize) {
+    throw new Error(
+      `Image too large: ${(data.byteLength / 1024 / 1024).toFixed(1)}MB ` +
+      `exceeds ${(maxSize / 1024 / 1024).toFixed(0)}MB limit`
+    );
+  }
+
+  return { ref, data, mimeType, extension, size: data.byteLength };
+}
+
+/**
+ * Download multiple images with concurrency control.
+ * Returns results for all images (success or failure per image).
+ */
+export async function fetchAllImages(
+  images: readonly ImageReference[],
+  maxSize: number
+): Promise<readonly ImageData[]> {
+  const results: ImageData[] = [];
+  const queue = [...images];
+
+  // Process in batches of MAX_CONCURRENCY
+  while (queue.length > 0) {
+    const batch = queue.splice(0, MAX_CONCURRENCY);
+    const batchResults = await Promise.allSettled(
+      batch.map(ref => fetchImageBinary(ref, maxSize))
+    );
+
+    for (const result of batchResults) {
+      if (result.status === 'fulfilled') {
+        results.push(result.value);
+      }
+      // Failed images are logged but don't block the save
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Generate the vault path for an image file.
+ *
+ * @param notePath - vault-relative path to the note (e.g., 'AI/gemini/My-Conv.md')
+ * @param imageSubfolder - subfolder name (e.g., 'assets')
+ * @param imageData - downloaded image data
+ * @returns vault-relative path (e.g., 'AI/gemini/assets/img_0_0.png')
+ */
+export function buildImageVaultPath(
+  notePath: string,
+  imageSubfolder: string,
+  imageData: ImageData
+): string {
+  const noteDir = notePath.substring(0, notePath.lastIndexOf('/'));
+  return `${noteDir}/${imageSubfolder}/${imageData.ref.id}.${imageData.extension}`;
+}
+
+/**
+ * Build the relative path from note to image (for markdown reference).
+ *
+ * @returns relative path (e.g., './assets/img_0_0.png')
+ */
+export function buildImageRelativePath(
+  imageSubfolder: string,
+  imageData: ImageData
+): string {
+  return `./${imageSubfolder}/${imageData.ref.id}.${imageData.extension}`;
+}
+
+/**
+ * Replace image placeholders in markdown with actual relative paths.
+ *
+ * Placeholder format: {{G2O_IMG:src|alt}}
+ * Output format:      ![alt](./assets/img_0_0.png)
+ */
+export function rewriteImagePlaceholders(
+  markdown: string,
+  uploadResults: readonly ImageUploadResult[],
+  images: readonly ImageReference[]
+): string {
+  let result = markdown;
+
+  for (const img of images) {
+    // Escape special regex chars in the src URL
+    const escapedSrc = img.src.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const placeholder = new RegExp(
+      `\\{\\{G2O_IMG:${escapedSrc}\\|[^}]*\\}\\}`,
+      'g'
+    );
+
+    const uploadResult = uploadResults.find(r => r.id === img.id);
+
+    if (uploadResult?.success && uploadResult.relativePath) {
+      result = result.replace(
+        placeholder,
+        `![${img.alt}](${uploadResult.relativePath})`
+      );
+    } else {
+      // Upload failed — remove placeholder, leave nothing
+      result = result.replace(placeholder, '');
+    }
+  }
+
+  return result;
+}
+```
+
+### 3.6 Save Pipeline Integration
+
+**File:** `src/background/obsidian-handlers.ts` — modify `handleSave()`
+
+```
+handleSave() flow with image sync:
+
+1. Receive ConversationData + ImageReference[] from content script
+2. Convert to markdown (with {{G2O_IMG:...}} placeholders)
+3. If enableImageSync AND images exist:
+   a. fetchAllImages() — download all images in parallel (max 3)
+   b. For each successful download:
+      - buildImageVaultPath() → compute vault path
+      - client.putBinaryFile() → upload to Obsidian
+      - Record ImageUploadResult (success/failure)
+   c. rewriteImagePlaceholders() — replace placeholders with relative paths
+4. putFile() — save the final markdown note
+5. Return SaveResponse with imageResults
+```
+
+### 3.7 Settings UI
+
+**File:** `src/popup/index.html` + `src/popup/index.ts`
+
+New settings under "Advanced" panel:
+
+```
+[toggle] Sync images
+         Download and save images from conversations to your vault.
+
+  [text]  Image subfolder: [assets          ]
+          Subfolder name relative to the note file.
+
+  [text]  Max image size:  [10   ] MB
+          Skip images larger than this.
+```
+
+**Storage keys added to `SyncSettings`:**
+- `enableImageSync: boolean` (default: `false`)
+- `imageSubfolder: string` (default: `'assets'`)
+- `maxImageSize: number` (default: `10485760`)
+
+---
+
+## 4. Security Considerations
+
+| Concern | Mitigation |
+|---------|-----------|
+| XSS via `<img onerror>` | DOMPurify strips all event handlers even with `ADD_TAGS: ['img']` |
+| SSRF via image fetch | Background SW only fetches from `host_permissions` origins |
+| Path traversal in image paths | `containsPathTraversal()` validates all generated paths |
+| Malicious image content | Images are opaque binary; Obsidian renders them safely |
+| Excessive disk usage | Opt-in + configurable size limit + per-image cap |
+| Memory pressure (large images) | Process images sequentially in batches of 3 |
+
+---
+
+## 5. Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Single image fetch fails | Log warning, skip image, continue with remaining |
+| All image fetches fail | Save note without images (placeholders removed) |
+| Obsidian binary upload fails | Log error per image, save note with broken references removed |
+| Image exceeds size limit | Skip with warning in imageResults |
+| Unsupported MIME type | Skip with warning in imageResults |
+| Network timeout | 15s per image; skip on timeout |
+| Note save succeeds but images fail | Note saved, partial imageResults returned |
+
+**Principle:** Image sync failure must never prevent the text note from being saved.
+
+---
+
+## 6. Implementation Phases
+
+### Phase 1: Core Infrastructure
+1. Add types (`ImageReference`, `ImageData`, `ImageUploadResult`)
+2. Add `putBinaryFile()` to `ObsidianApiClient`
+3. Add `enableImageSync` / `imageSubfolder` / `maxImageSize` to settings + storage
+4. Add settings UI controls in popup
+
+### Phase 2: Extraction Pipeline
+5. Modify DOMPurify config to allow `<img>` with `src`/`alt`
+6. Add `extractImages()` to `BaseExtractor`
+7. Add image placeholder Turndown rule
+8. Platform-specific image selector overrides (Gemini, Claude, ChatGPT, Perplexity)
+
+### Phase 3: Save Pipeline
+9. Create `image-service.ts` (fetch, path generation, placeholder rewrite)
+10. Integrate image download + upload into `handleSave()`
+11. Add `imageResults` to `SaveResponse`
+
+### Phase 4: Testing
+12. Unit tests for all new functions
+13. Integration tests for the full pipeline (mock fetch + mock Obsidian API)
+14. E2E selector tests for image elements per platform
+
+---
+
+## 7. File Change Summary
+
+| File | Change |
+|------|--------|
+| `src/lib/types.ts` | Add `ImageReference`, `ImageData`, `ImageUploadResult`; extend `ConversationMessage`, `ConversationMetadata`, `SyncSettings`, `SaveResponse` |
+| `src/lib/sanitize.ts` | Add `ADD_TAGS: ['img']`, `ADD_ATTR: ['src', 'alt', 'data-src']` |
+| `src/lib/obsidian-api.ts` | Add `putBinaryFile(path, data)` method |
+| `src/lib/storage.ts` | Add default values for image settings |
+| `src/content/extractors/base.ts` | Add `extractImages()` method |
+| `src/content/extractors/gemini.ts` | Override `IMAGE_SELECTORS` |
+| `src/content/extractors/claude.ts` | Override `IMAGE_SELECTORS`, filter favicons |
+| `src/content/extractors/chatgpt.ts` | Override `IMAGE_SELECTORS` if needed |
+| `src/content/extractors/perplexity.ts` | Override `IMAGE_SELECTORS` if needed |
+| `src/content/markdown-rules.ts` | Add `imagePlaceholder` rule |
+| `src/background/image-service.ts` | **NEW** — fetch, upload, path, rewrite logic |
+| `src/background/obsidian-handlers.ts` | Integrate image pipeline into `handleSave()` |
+| `src/popup/index.html` | Add image sync UI controls |
+| `src/popup/index.ts` | Add image sync settings handling |
+| `src/manifest.json` | No changes needed (existing permissions sufficient) |
+
+---
+
+## 8. Out of Scope
+
+- Image format conversion (WebP → PNG etc.)
+- Image compression/resizing
+- Inline data URI images (already embedded, no need to download)
+- SVG sanitization (complex; defer to Obsidian's renderer)
+- Auto-sync (Issue #186-2, separate feature)
+- Image deduplication across conversations

--- a/docs/investigation/gemini-image-dom-structure.md
+++ b/docs/investigation/gemini-image-dom-structure.md
@@ -1,0 +1,90 @@
+# Gemini Generated Image DOM Structure
+
+**Date:** 2026-04-03
+**Issue:** #186-1 (Image Sync)
+**Status:** Investigation — not yet actionable
+
+## Findings
+
+Gemini's AI-generated images use two different URL schemes:
+
+### 1. HTTPS URL (Google User Content CDN)
+
+Some generated images use a permanent-looking HTTPS URL:
+
+```html
+<img loading="lazy" class="image animate loaded"
+     alt="（AI 生成）"
+     src="https://lh3.googleusercontent.com/gg/AMW1TPp...=s1024-rj">
+```
+
+- Domain: `lh3.googleusercontent.com`
+- Path: `/gg/` prefix
+- Suffix: `=s1024-rj` (size/format parameter)
+- These URLs may be auth-gated or time-limited (needs verification)
+
+### 2. Blob URL (local browser object)
+
+Other generated images use a `blob:` URL:
+
+```html
+<img loading="lazy" class="image animate loaded"
+     alt="（AI 生成）"
+     src="blob:https://gemini.google.com/5aab58b3-704c-462c-a3d3-42cfbfbecb63">
+```
+
+- `blob:` URLs are page-specific and cannot be fetched from the background service worker
+- They are invalidated when the page is closed or navigated away
+- Cannot be used for image sync (not downloadable cross-context)
+
+### DOM Structure
+
+Generated images are wrapped in a custom Angular component hierarchy:
+
+```
+model-response
+  └── .markdown.markdown-main-panel
+      └── .attachment-container.generated-images
+          └── response-element
+              └── generated-image
+                  └── single-image
+                      └── .image-container
+                          └── .overlay-container
+                              └── button.image-button
+                                  └── <img src="..." alt="（AI 生成）">
+```
+
+Key selectors:
+- `generated-image img.image` — the actual image element
+- `single-image` — container with jslog metadata
+- `.generated-image-controls` — overlay with share/copy/download buttons
+- `download-generated-image-button` — download button (may provide HTTPS URL)
+
+### Download Button
+
+Each generated image has a download button that triggers a full-size download:
+
+```html
+<download-generated-image-button>
+  <button mat-button="" aria-label="フルサイズの画像をダウンロード"
+          data-test-id="download-generated-image-button"
+          jslog="185865;track:generic_click;BardVeMetadataKey:[[...]]">
+```
+
+This button likely fetches the image via a different mechanism (possibly an API call that returns the HTTPS URL). Investigating this could provide a reliable download path for blob-URL images.
+
+## Challenges for Image Sync
+
+1. **Blob URLs cannot be fetched from background SW** — The `blob:` scheme is page-specific; `fetch()` in the service worker cannot access it
+2. **Mixed URL schemes** — Same conversation can have both HTTPS and blob URLs for different images
+3. **Alt text is generic** — All generated images have `alt="（AI 生成）"`, no descriptive text
+4. **Auth/expiration unknown** — Whether HTTPS URLs expire or require authentication is not yet verified
+
+## Potential Solutions (Future)
+
+1. **Canvas-based extraction in content script**: Draw the image to a canvas element, export as blob/data URL, then send binary to background SW via message passing
+2. **Intercept download button URL**: The download button may use a different API endpoint; intercepting or replicating that call could provide stable HTTPS URLs
+3. **Use `chrome.tabs.captureVisibleTab`**: Screenshot-based approach (lossy, complex)
+4. **Content script fetch with credentials**: Fetch the HTTPS URLs from the content script (same origin) and convert to ArrayBuffer before sending to background SW
+
+Option 4 is the most promising for HTTPS-URL images. Option 1 is a fallback for blob-URL images.

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -81,6 +81,14 @@
     "message": "Assistant Callout Type",
     "description": "Label for assistant callout type"
   },
+  "settings_includeQuestionHeaders": {
+    "message": "Add `## ` headers before user messages",
+    "description": "Checkbox label for issue #187 question header option"
+  },
+  "settings_includeQuestionHeadersHelp": {
+    "message": "Prepend a level-2 heading (first 60 chars of the question) for TOC navigation in long conversations.",
+    "description": "Help text for question header option"
+  },
   "settings_frontmatter": {
     "message": "Frontmatter Options",
     "description": "Section title for frontmatter options"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -61,6 +61,12 @@
   "settings_assistantCallout": {
     "message": "アシスタントのコールアウト種類"
   },
+  "settings_includeQuestionHeaders": {
+    "message": "ユーザーメッセージの前に `## ` 見出しを追加"
+  },
+  "settings_includeQuestionHeadersHelp": {
+    "message": "長い会話で目次から飛べるように、質問の冒頭60文字を見出し2 (`## `) として各ユーザーメッセージの前に追加します。"
+  },
   "settings_frontmatter": {
     "message": "フロントマター設定"
   },

--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -8,13 +8,22 @@ import { extractErrorMessage } from '../lib/error-utils';
 import { generateNoteContent } from '../lib/note-generator';
 import { handleSave } from './obsidian-handlers';
 import type {
-  ClipboardWriteResponse,
   ExtensionSettings,
   ObsidianNote,
   OutputDestination,
   OutputResult,
   MultiOutputResponse,
 } from '../lib/types';
+
+/** Runtime type guard for offscreen clipboard response */
+function isClipboardWriteResponse(value: unknown): value is { success: boolean; error?: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'success' in value &&
+    typeof (value as Record<string, unknown>).success === 'boolean'
+  );
+}
 
 /** Offscreen document close timeout (milliseconds) */
 const OFFSCREEN_TIMEOUT_MS = 5000;
@@ -178,22 +187,21 @@ async function handleCopyToClipboard(
 
     await ensureOffscreenDocument();
 
-    const response = (await chrome.runtime.sendMessage({
+    const response: unknown = await chrome.runtime.sendMessage({
       action: 'clipboardWrite',
       target: 'offscreen',
       content,
-    })) as ClipboardWriteResponse | undefined;
+    });
 
     scheduleOffscreenClose();
 
-    if (response?.success) {
+    if (isClipboardWriteResponse(response) && response.success) {
       return { destination: 'clipboard', success: true };
     } else {
-      return {
-        destination: 'clipboard',
-        success: false,
-        error: response?.error ?? 'Clipboard write failed',
-      };
+      const error = isClipboardWriteResponse(response)
+        ? (response.error ?? 'Clipboard write failed')
+        : 'Clipboard write failed';
+      return { destination: 'clipboard', success: false, error };
     }
   } catch (error) {
     return {

--- a/src/content/markdown-formatting.ts
+++ b/src/content/markdown-formatting.ts
@@ -10,10 +10,43 @@ import { PLATFORM_LABELS } from '../lib/constants';
 import type { AIPlatform, TemplateOptions } from '../lib/types';
 
 /**
+ * Maximum visible length of an auto-generated question header (issue #187).
+ * Includes the trailing ellipsis when truncation occurs.
+ */
+const QUESTION_HEADER_MAX_LENGTH = 60;
+
+/**
  * Get display label for AI assistant based on source platform
  */
 function getAssistantLabel(source: AIPlatform): string {
   return PLATFORM_LABELS[source];
+}
+
+/**
+ * Build a `## ` header line from a user message for TOC navigation (issue #187).
+ *
+ * - Normalizes all whitespace (including newlines) to single spaces.
+ * - Truncates to {@link QUESTION_HEADER_MAX_LENGTH} characters total, preferring
+ *   word-boundary breaks past the halfway mark and appending an ellipsis.
+ * - Returns an empty string for empty/whitespace-only content so callers can
+ *   fall back to the unheaded format.
+ *
+ * Exported for unit testing.
+ */
+export function buildQuestionHeader(content: string): string {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+
+  if (normalized.length <= QUESTION_HEADER_MAX_LENGTH) {
+    return `## ${normalized}`;
+  }
+
+  // Reserve one character for the ellipsis so total visible length stays within budget.
+  const sliceEnd = QUESTION_HEADER_MAX_LENGTH - 1;
+  const slice = normalized.substring(0, sliceEnd);
+  const lastSpace = slice.lastIndexOf(' ');
+  const truncated = lastSpace > sliceEnd / 2 ? slice.substring(0, lastSpace) : slice;
+  return `## ${truncated}…`;
 }
 
 /**
@@ -29,6 +62,7 @@ export function formatMessage(
   const markdown = role === 'assistant' ? htmlToMarkdown(content) : escapeAngleBrackets(content);
   const assistantLabel = getAssistantLabel(source);
 
+  let formatted: string;
   switch (options.messageFormat) {
     case 'callout': {
       const calloutType = role === 'user' ? options.userCalloutType : options.assistantCalloutType;
@@ -38,21 +72,35 @@ export function formatMessage(
       const formattedLines = lines.map((line, i) =>
         i === 0 ? `> [!${calloutType}] ${label}\n> ${line}` : `> ${line}`
       );
-      return formattedLines.join('\n');
+      formatted = formattedLines.join('\n');
+      break;
     }
 
     case 'blockquote': {
       const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
       const lines = markdown.split('\n').map(line => `> ${line}`);
-      return `${label}\n${lines.join('\n')}`;
+      formatted = `${label}\n${lines.join('\n')}`;
+      break;
     }
 
     case 'plain':
     default: {
       const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
-      return `${label}\n\n${markdown}`;
+      formatted = `${label}\n\n${markdown}`;
+      break;
     }
   }
+
+  // Optional: prepend `##` question header for user messages (issue #187).
+  // Uses the raw (pre-escape) content for a more readable TOC entry.
+  if (role === 'user' && options.includeQuestionHeaders) {
+    const header = buildQuestionHeader(content);
+    if (header) {
+      formatted = `${header}\n\n${formatted}`;
+    }
+  }
+
+  return formatted;
 }
 
 /**

--- a/src/lib/message-counter.ts
+++ b/src/lib/message-counter.ts
@@ -73,6 +73,10 @@ export function countExistingMessages(body: string): number {
 /**
  * Extract messages after skipCount from a formatted note body.
  * Returns formatted markdown for only the tail (new) messages.
+ *
+ * When the matched message is preceded by a freshly generated `## ` question
+ * header (issue #187), the lookback also captures that header so append-mode
+ * output keeps the TOC entry intact.
  */
 export function extractTailMessages(fullBody: string, skipCount: number): string {
   if (skipCount <= 0) return fullBody;
@@ -98,6 +102,14 @@ export function extractTailMessages(fullBody: string, skipCount: number): string
     if (MESSAGE_START_PATTERN.test(line)) {
       if (messageIndex === skipCount) {
         tailStartLine = i;
+        // Look back across blank lines for an immediately preceding `## ` header
+        // (issue #187). fullBody is freshly generated so the only `## ` lines
+        // are auto-generated question headers.
+        let lookback = i - 1;
+        while (lookback >= 0 && lines[lookback].trim() === '') lookback--;
+        if (lookback >= 0 && /^## /.test(lines[lookback])) {
+          tailStartLine = lookback;
+        }
         break;
       }
       messageIndex++;

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -25,6 +25,7 @@ const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
   messageFormat: 'callout',
   userCalloutType: 'QUESTION',
   assistantCalloutType: 'NOTE',
+  includeQuestionHeaders: false,
 };
 
 const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -227,6 +227,12 @@ export interface TemplateOptions {
   userCalloutType: string;
   /** Callout type for assistant messages (e.g., 'NOTE') */
   assistantCalloutType: string;
+  /**
+   * Prepend an `##` header derived from the user message before each user
+   * callout/blockquote/plain block. Enables Obsidian TOC navigation in long
+   * conversations. Defaults to false (issue #187).
+   */
+  includeQuestionHeaders?: boolean;
   /** IANA timezone for created/modified dates (e.g., 'Asia/Tokyo'). Defaults to 'UTC'. */
   timezone?: string;
   /** Custom frontmatter fields (reserved for future use) */

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -203,6 +203,19 @@
                   <input type="text" id="assistantCallout" value="NOTE" />
                 </div>
               </div>
+
+              <div class="form-group">
+                <label class="checkbox-label">
+                  <input type="checkbox" id="includeQuestionHeaders" />
+                  <span data-i18n="settings_includeQuestionHeaders"
+                    >Add `## ` headers before user messages</span
+                  >
+                </label>
+                <p class="help" data-i18n="settings_includeQuestionHeadersHelp">
+                  Prepend a level-2 heading (first 60 chars of the question) for TOC navigation in
+                  long conversations.
+                </p>
+              </div>
             </section>
 
             <!-- Frontmatter -->

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -78,6 +78,7 @@ const elements = {
   messageFormat: getElement<HTMLSelectElement>('messageFormat'),
   userCallout: getElement<HTMLInputElement>('userCallout'),
   assistantCallout: getElement<HTMLInputElement>('assistantCallout'),
+  includeQuestionHeaders: getElement<HTMLInputElement>('includeQuestionHeaders'),
   includeId: getElement<HTMLInputElement>('includeId'),
   includeTitle: getElement<HTMLInputElement>('includeTitle'),
   includeTags: getElement<HTMLInputElement>('includeTags'),
@@ -137,6 +138,7 @@ function populateForm(settings: ExtensionSettings): void {
   elements.messageFormat.value = templateOptions.messageFormat || 'callout';
   elements.userCallout.value = templateOptions.userCalloutType || 'QUESTION';
   elements.assistantCallout.value = templateOptions.assistantCalloutType || 'NOTE';
+  elements.includeQuestionHeaders.checked = templateOptions.includeQuestionHeaders ?? false;
 
   elements.includeId.checked = templateOptions.includeId ?? true;
   elements.includeTitle.checked = templateOptions.includeTitle ?? true;
@@ -329,6 +331,7 @@ function collectSettings(): ExtensionSettings {
     messageFormat,
     userCalloutType: validateCalloutType(elements.userCallout.value || 'QUESTION', 'QUESTION'),
     assistantCalloutType: validateCalloutType(elements.assistantCallout.value || 'NOTE', 'NOTE'),
+    includeQuestionHeaders: elements.includeQuestionHeaders.checked,
     includeId: elements.includeId.checked,
     includeTitle: elements.includeTitle.checked,
     includeTags: elements.includeTags.checked,

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -631,6 +631,164 @@ describe('conversationToNote', () => {
 
     expect(note.body).not.toContain('## References');
   });
+
+  // ========== Issue #187: Question headers ==========
+  describe('includeQuestionHeaders option (issue #187)', () => {
+    const baseData: ConversationData = {
+      id: 'header-test',
+      title: 'Header Test',
+      url: 'https://gemini.google.com/app/header-test',
+      source: 'gemini',
+      messages: [
+        { id: 'm1', role: 'user', content: 'How does TLS work?', index: 0 },
+        { id: 'm2', role: 'assistant', content: '<p>It uses keys.</p>', index: 1 },
+        { id: 'm3', role: 'user', content: 'What about HTTP/3?', index: 2 },
+        { id: 'm4', role: 'assistant', content: '<p>It uses QUIC.</p>', index: 3 },
+      ],
+      extractedAt: new Date('2025-01-01T00:00:00Z'),
+      metadata: {
+        messageCount: 4,
+        userMessageCount: 2,
+        assistantMessageCount: 2,
+        hasCodeBlocks: false,
+      },
+    };
+
+    it('omits headers when option is false (default)', () => {
+      const note = conversationToNote(baseData, defaultOptions);
+      expect(note.body).not.toMatch(/^## How does TLS work\?$/m);
+      expect(note.body).not.toMatch(/^## What about HTTP\/3\?$/m);
+    });
+
+    it('prepends `## ` header before each user callout when enabled', () => {
+      const note = conversationToNote(baseData, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      expect(note.body).toMatch(
+        /^## How does TLS work\?\n\n> \[!QUESTION\] User\n> How does TLS work\?/m
+      );
+      expect(note.body).toMatch(
+        /^## What about HTTP\/3\?\n\n> \[!QUESTION\] User\n> What about HTTP\/3\?/m
+      );
+    });
+
+    it('does not prepend headers before assistant messages', () => {
+      const note = conversationToNote(baseData, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      // Assistant content should never appear as an H2 heading
+      expect(note.body).not.toMatch(/^## It uses keys\./m);
+      expect(note.body).not.toMatch(/^## It uses QUIC\./m);
+    });
+
+    it('truncates long questions to 60 characters with ellipsis', () => {
+      const longText =
+        'Please explain quantum mechanics in simple terms that a ten year old child would easily understand';
+      const data: ConversationData = {
+        ...baseData,
+        messages: [{ id: 'm1', role: 'user', content: longText, index: 0 }],
+      };
+
+      const note = conversationToNote(data, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      const headerLine = note.body.split('\n').find(l => l.startsWith('## '));
+      expect(headerLine).toBeDefined();
+      expect(headerLine!.endsWith('…')).toBe(true);
+      // Visible length (excluding the leading "## ") must stay within budget
+      const visible = headerLine!.slice(3);
+      expect(visible.length).toBeLessThanOrEqual(60);
+      // Truncated text must be a complete word-prefix of the original (i.e. break
+      // happened on a space, not mid-word)
+      const textWithoutEllipsis = visible.slice(0, -1);
+      expect(longText.startsWith(textWithoutEllipsis + ' ')).toBe(true);
+    });
+
+    it('hard-truncates a single very long word', () => {
+      const longWord = 'A' + 'a'.repeat(100);
+      const data: ConversationData = {
+        ...baseData,
+        messages: [{ id: 'm1', role: 'user', content: longWord, index: 0 }],
+      };
+
+      const note = conversationToNote(data, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      const headerLine = note.body.split('\n').find(l => l.startsWith('## '));
+      expect(headerLine).toBeDefined();
+      expect(headerLine!.endsWith('…')).toBe(true);
+      const visible = headerLine!.slice(3);
+      // Total visible length stays within the 60-char budget
+      expect(visible.length).toBeLessThanOrEqual(60);
+    });
+
+    it('normalizes multi-line user content into a single header line', () => {
+      const data: ConversationData = {
+        ...baseData,
+        messages: [
+          {
+            id: 'm1',
+            role: 'user',
+            content: 'First line\n\n  Second   line\twith tabs',
+            index: 0,
+          },
+        ],
+      };
+
+      const note = conversationToNote(data, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      expect(note.body).toMatch(/^## First line Second line with tabs$/m);
+    });
+
+    it('skips header for empty user content', () => {
+      const data: ConversationData = {
+        ...baseData,
+        messages: [
+          { id: 'm1', role: 'user', content: '   \n\t  ', index: 0 },
+          { id: 'm2', role: 'assistant', content: '<p>Hi</p>', index: 1 },
+        ],
+      };
+
+      const note = conversationToNote(data, {
+        ...defaultOptions,
+        includeQuestionHeaders: true,
+      });
+
+      // No leading H2 line
+      expect(note.body).not.toMatch(/^## /m);
+    });
+
+    it('works with blockquote message format', () => {
+      const note = conversationToNote(baseData, {
+        ...defaultOptions,
+        messageFormat: 'blockquote',
+        includeQuestionHeaders: true,
+      });
+
+      expect(note.body).toMatch(/^## How does TLS work\?\n\n\*\*User:\*\*/m);
+    });
+
+    it('works with plain message format', () => {
+      const note = conversationToNote(baseData, {
+        ...defaultOptions,
+        messageFormat: 'plain',
+        includeQuestionHeaders: true,
+      });
+
+      expect(note.body).toMatch(/^## How does TLS work\?\n\n\*\*User:\*\*/m);
+    });
+  });
 });
 
 // ============================================================

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -417,38 +417,46 @@ describe('PerplexityExtractor', () => {
     });
   });
 
-  // ========== Issue #96: Math equations in code blocks ==========
+  // ========== Issue #96: Math equations rendering ==========
+  // Issue #96 was originally reported against v0.12.0 when Perplexity emitted
+  // raw LaTeX inside <pre><code>/<code> blocks. Perplexity has since switched to
+  // standard KaTeX (<span class="katex"> with <annotation encoding="application/x-tex">),
+  // which preprocessKatex() in src/lib/sanitize.ts converts to data-math attributes
+  // before DOMPurify strips MathML. The Turndown rules in markdown-rules.ts then
+  // emit $..$ for inline math and $$..$$ for display math, which Obsidian renders
+  // natively. These tests pin the current end-to-end behavior so future regressions
+  // surface immediately.
   describe('Math equations rendering (issue #96)', () => {
-    it('reproduces: LaTeX in fenced code blocks instead of $$ (display math)', () => {
-      // Issue #96: Perplexity outputs LaTeX inside <pre><code> instead of KaTeX
-      // Markdown conversion happens in conversationToNote(), not extractMessages()
-      // So we test via htmlToMarkdown() which is the actual conversion path
+    it('converts inline KaTeX to $..$ delimiters', () => {
       const html = `
-        <p>Then the unconditional expected prize is</p>
-        <pre><code>E[\\text{prize}] = 0.21 \\times 0.66</code></pre>
-        <p>and the EV of the ticket is</p>
-        <pre><code>EV = E[\\text{prize}] - 1
-= 0.21 \\times 0.66 - 1</code></pre>
+        <p>The quadratic formula is
+          <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><annotation encoding="application/x-tex">x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}</annotation></semantics></math></span></span>
+          which solves
+          <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><annotation encoding="application/x-tex">ax^2 + bx + c = 0</annotation></semantics></math></span></span>.
+        </p>
       `;
 
       const markdown = htmlToMarkdown(sanitizeHtml(html));
 
-      // CURRENT BEHAVIOR (bug): LaTeX ends up inside ``` code blocks
-      expect(markdown).toContain('```');
-      expect(markdown).toContain('E[\\text{prize}]');
-      expect(markdown).not.toContain('$$');
+      expect(markdown).toContain('$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$');
+      expect(markdown).toContain('$ax^2 + bx + c = 0$');
+      // Must NOT regress to inline code or fenced blocks
+      expect(markdown).not.toMatch(/`x = \\frac/);
+      expect(markdown).not.toMatch(/```[\s\S]*x = \\frac/);
     });
 
-    it('reproduces: LaTeX in inline code instead of $ (inline math)', () => {
-      // Issue #96: Perplexity outputs inline LaTeX inside <code> tags
-      const html = `<p>Let <code>P(\\text{win}) = 0.21</code> and <code>P(\\text{lose}) = 0.79</code></p>`;
+    it('converts display KaTeX to $$..$$ blocks', () => {
+      const html = `
+        <p>Integrating gives</p>
+        <span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><annotation encoding="application/x-tex">\\int_{0}^{1} x^2\\,dx = \\frac{1}{3}</annotation></semantics></math></span></span></span>
+      `;
 
       const markdown = htmlToMarkdown(sanitizeHtml(html));
 
-      // CURRENT BEHAVIOR (bug): LaTeX ends up inside ` backticks
-      expect(markdown).toContain('`');
-      expect(markdown).toContain('P(\\text{win})');
-      expect(markdown).not.toContain('$P(\\text{win})');
+      expect(markdown).toContain('$$');
+      expect(markdown).toContain('\\int_{0}^{1} x^2\\,dx = \\frac{1}{3}');
+      // Must NOT regress to fenced code blocks
+      expect(markdown).not.toMatch(/```[\s\S]*\\int_/);
     });
   });
 

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -296,6 +296,69 @@ describe('buildAppendContent', () => {
     expect(result!.content).toMatch(/modified: .*\+09:00/);
   });
 
+  // ========== Issue #187: Question headers in append mode ==========
+  it('preserves `## ` question headers when appending new messages', () => {
+    const settingsWithHeaders: ExtensionSettings = {
+      ...testSettings,
+      templateOptions: {
+        ...testSettings.templateOptions,
+        includeQuestionHeaders: true,
+      },
+    };
+
+    // Existing file: 2 messages with their `##` header from a prior sync
+    const existing = [
+      '---',
+      'id: claude_test-id',
+      'message_count: 2',
+      'modified: "2026-01-01"',
+      '---',
+      '## Hello',
+      '',
+      '> [!QUESTION] User',
+      '> Hello',
+      '',
+      '> [!NOTE] Claude',
+      '> Hi there!',
+    ].join('\n');
+
+    // New note has 4 messages; rebuilt body should also include headers
+    const noteWithHeaders: ObsidianNote = {
+      ...testNote,
+      body: [
+        '## Hello',
+        '',
+        '> [!QUESTION] User',
+        '> Hello',
+        '',
+        '> [!NOTE] Claude',
+        '> Hi there!',
+        '',
+        '## New question',
+        '',
+        '> [!QUESTION] User',
+        '> New question',
+        '',
+        '> [!NOTE] Claude',
+        '> New answer',
+      ].join('\n'),
+    };
+
+    const result = buildAppendContent(existing, noteWithHeaders, settingsWithHeaders);
+
+    expect(result).not.toBeNull();
+    expect(result!.messagesAppended).toBe(2);
+    // Header for the new question must be carried into the appended tail
+    expect(result!.content).toContain('## New question');
+    // Existing header should not be duplicated
+    const headerCount = (result!.content.match(/^## Hello$/gm) ?? []).length;
+    expect(headerCount).toBe(1);
+    // Existing content preserved
+    expect(result!.content).toContain('> Hello');
+    expect(result!.content).toContain('> Hi there!');
+    expect(result!.content).toContain('New answer');
+  });
+
   it('preserves user-added notes in existing body', () => {
     const existing = [
       '---',


### PR DESCRIPTION
## Summary

This branch bundles four related changes from a single improvement loop session:

- **feat #187** — Add an Advanced Settings → Message Format toggle (`includeQuestionHeaders`) that prepends a level-2 heading derived from each user message before its callout/blockquote/plain block, enabling Obsidian outline navigation in long conversations. Default OFF for backward compatibility. `extractTailMessages` learns to carry the `## ` line across the append boundary so append-mode keeps headers intact.
- **test #96** — Replace the bug-reproduction tests for Perplexity math equations with positive end-to-end checks that pin the current KaTeX → `$..$` / `$$..$$` conversion. Verified live on v0.19.8 — the original bug no longer reproduces because Perplexity now emits standard KaTeX. Closes #96.
- **docs #186** — Add image sync investigation notes, DES-017 design doc, and ADR-008 strategy decision. Implementation remains gated on per-platform DOM verification.
- **refactor** — Replace the unchecked `ClipboardWriteResponse` cast in `output-handlers.ts` with a runtime type guard, removing the dead import and narrowing the offscreen response defensively.

Header generation rules (`buildQuestionHeader` in `markdown-formatting.ts`):

- Normalize all whitespace (including newlines) to single spaces
- Truncate to 60 visible characters total, breaking at the last space past the halfway mark and appending an ellipsis
- Hard-truncate single very long words at the budget
- Skip the header entirely for empty/whitespace-only content

i18n entries (en/ja) added for the new toggle and its help text.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors / 0 warnings)
- [x] `npm run test` passes (919/919, +10 new cases)
- [x] `npm run format:check` clean
- [x] `npx tsc --noEmit` clean
- [x] Manual smoke test: enable the toggle in popup, sync a Perplexity/Gemini conversation with multiple questions, verify `## ` headers appear in Obsidian outline view
- [x] Manual smoke test: with toggle ON and append mode ON, sync a conversation, ask another question, sync again, verify the new question's header is appended without duplicating the existing one

🤖 Generated with [Claude Code](https://claude.com/claude-code)