### PR TITLE
fix: strip markdown chars from question headers to prevent broken syntax (#203)

### DIFF
--- a/src/content/markdown-formatting.ts
+++ b/src/content/markdown-formatting.ts
@@ -23,9 +23,21 @@ function getAssistantLabel(source: AIPlatform): string {
 }
 
 /**
+ * Strip markdown-significant characters that could corrupt heading structure
+ * if left unclosed after truncation (issue #203).
+ *
+ * Removes: backticks, asterisks, underscores, tildes, square brackets.
+ * These are harmless to remove from a TOC header label.
+ */
+export function stripMarkdownChars(text: string): string {
+  return text.replace(/[`*_~[\]]/g, '');
+}
+
+/**
  * Build a `## ` header line from a user message for TOC navigation (issue #187).
  *
  * - Normalizes all whitespace (including newlines) to single spaces.
+ * - Strips markdown-significant characters to prevent unclosed syntax (issue #203).
  * - Truncates to {@link QUESTION_HEADER_MAX_LENGTH} characters total, preferring
  *   word-boundary breaks past the halfway mark and appending an ellipsis.
  * - Returns an empty string for empty/whitespace-only content so callers can
@@ -35,15 +47,16 @@ function getAssistantLabel(source: AIPlatform): string {
  */
 export function buildQuestionHeader(content: string): string {
   const normalized = content.replace(/\s+/g, ' ').trim();
-  if (!normalized) return '';
+  const cleaned = stripMarkdownChars(normalized).replace(/ {2,}/g, ' ').trim();
+  if (!cleaned) return '';
 
-  if (normalized.length <= QUESTION_HEADER_MAX_LENGTH) {
-    return `## ${normalized}`;
+  if (cleaned.length <= QUESTION_HEADER_MAX_LENGTH) {
+    return `## ${cleaned}`;
   }
 
   // Reserve one character for the ellipsis so total visible length stays within budget.
   const sliceEnd = QUESTION_HEADER_MAX_LENGTH - 1;
-  const slice = normalized.substring(0, sliceEnd);
+  const slice = cleaned.substring(0, sliceEnd);
   const lastSpace = slice.lastIndexOf(' ');
   const truncated = lastSpace > sliceEnd / 2 ? slice.substring(0, lastSpace) : slice;
   return `## ${truncated}…`;

--- a/test/content/markdown-formatting.test.ts
+++ b/test/content/markdown-formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildQuestionHeader } from '../../src/content/markdown-formatting';
+import { buildQuestionHeader, stripMarkdownChars } from '../../src/content/markdown-formatting';
 
 /**
  * Unit tests for buildQuestionHeader (issue #187).
@@ -68,5 +68,84 @@ describe('buildQuestionHeader', () => {
       const expectedSlice = `ab ${'c'.repeat(56)}`; // 3 + 56 = 59
       expect(buildQuestionHeader(input)).toBe(`## ${expectedSlice}…`);
     });
+  });
+
+  describe('markdown character stripping (issue #203)', () => {
+    it('strips backticks from short input', () => {
+      expect(buildQuestionHeader('How do I use `map` in JS?')).toBe('## How do I use map in JS?');
+    });
+
+    it('strips triple backticks', () => {
+      expect(buildQuestionHeader('```python code``` example')).toBe('## python code example');
+    });
+
+    it('strips bold and italic markers', () => {
+      expect(buildQuestionHeader('Use **bold** and _italic_ text')).toBe(
+        '## Use bold and italic text'
+      );
+    });
+
+    it('strips strikethrough tildes', () => {
+      expect(buildQuestionHeader('Remove ~~old~~ text')).toBe('## Remove old text');
+    });
+
+    it('strips square brackets from links', () => {
+      expect(buildQuestionHeader('See [React](https://react.dev) docs')).toBe(
+        '## See React(https://react.dev) docs'
+      );
+    });
+
+    it('strips all markdown chars from a mixed input', () => {
+      expect(buildQuestionHeader('Use `map` with **bold** and [link]')).toBe(
+        '## Use map with bold and link'
+      );
+    });
+
+    it('collapses double spaces left after stripping', () => {
+      expect(buildQuestionHeader('use ` map ` in code')).toBe('## use map in code');
+    });
+
+    it('returns empty string when input is only markdown chars', () => {
+      expect(buildQuestionHeader('```')).toBe('');
+    });
+
+    it('prevents unclosed backtick near truncation boundary', () => {
+      // Backtick at position ~55 in a 70+ char string — stripping removes it
+      // so the header never contains an unclosed backtick.
+      const input = `${'a'.repeat(50)} \`code that would be truncated in the middle\``;
+      const result = buildQuestionHeader(input);
+      expect(result).not.toContain('`');
+      expect(result.startsWith('## ')).toBe(true);
+    });
+  });
+});
+
+describe('stripMarkdownChars', () => {
+  it('returns unchanged text when no markdown chars present', () => {
+    expect(stripMarkdownChars('hello world')).toBe('hello world');
+  });
+
+  it('strips backticks', () => {
+    expect(stripMarkdownChars('`code`')).toBe('code');
+  });
+
+  it('strips asterisks and underscores', () => {
+    expect(stripMarkdownChars('**bold** and _italic_')).toBe('bold and italic');
+  });
+
+  it('strips tildes', () => {
+    expect(stripMarkdownChars('~~deleted~~')).toBe('deleted');
+  });
+
+  it('strips square brackets', () => {
+    expect(stripMarkdownChars('[link](url)')).toBe('link(url)');
+  });
+
+  it('handles mixed markdown characters', () => {
+    expect(stripMarkdownChars('`code` **bold** _em_ ~~del~~ [a]')).toBe('code bold em del a');
+  });
+
+  it('returns empty string for input of only markdown chars', () => {
+    expect(stripMarkdownChars('`*_~[]')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- Add `stripMarkdownChars()` helper that removes backticks, asterisks, underscores, tildes, and square brackets from text
- Integrate stripping into `buildQuestionHeader()` before truncation to prevent unclosed markdown syntax in `## ` headers
- Collapse double spaces left after character removal
- Add 16 new tests covering stripping behavior and edge cases (backtick near truncation boundary, mixed chars, empty-after-strip)

Closes #203

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (959 tests)
- [x] `npm run test:coverage` passes (91.54% stmts, 86.98% branch)
- [x] Manual: enable "Include Question Headers", export a conversation containing backticks in user messages, verify clean markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)