### PR TITLE
refactor: improve code quality for v1.0.0 readiness

### DIFF
--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -200,9 +200,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
    * Sort elements by DOM position (document order).
    * Returns a new sorted array without mutating the input (DES-014 L-4).
    */
-  protected sortByDomPosition(
-    elements: Array<{ element: Element; type: 'user' | 'assistant' }>
-  ): Array<{ element: Element; type: 'user' | 'assistant' }> {
+  protected sortByDomPosition<T extends { element: Element }>(elements: T[]): T[] {
     return [...elements].sort((a, b) => {
       const position = a.element.compareDocumentPosition(b.element);
       if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -88,19 +88,14 @@ export class PerplexityExtractor extends BaseExtractor {
     }
 
     // Sort by DOM position to preserve visual ordering
-    tagged.sort((a, b) => {
-      const pos = a.element.compareDocumentPosition(b.element);
-      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
-      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
-      return 0;
-    });
+    const sorted = this.sortByDomPosition(tagged);
 
     const messages: ConversationMessage[] = [];
     let userIdx = 0;
     let responseIdx = 0;
     let reportIdx = 0;
 
-    for (const item of tagged) {
+    for (const item of sorted) {
       if (item.type === 'user') {
         const content = this.extractUserContent(item.element);
         if (content) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,6 +24,7 @@ import {
   AUTO_SAVE_CHECK_INTERVAL,
   EVENT_THROTTLE_DELAY,
   INFO_TOAST_DURATION,
+  MUTATION_DEBOUNCE_DELAY,
 } from '../lib/constants';
 import type {
   ContentScriptSettings,
@@ -33,9 +34,6 @@ import type {
   MultiOutputResponse,
 } from '../lib/types';
 import { throttle } from '../lib/throttle';
-
-/** Debounce delay for MutationObserver callback (milliseconds) */
-const MUTATION_DEBOUNCE_DELAY = 100;
 
 /** Platform-specific main content container selectors for optimized observation */
 const PLATFORM_ROOT_SELECTORS: Record<string, string[]> = {

--- a/src/content/markdown-formatting.ts
+++ b/src/content/markdown-formatting.ts
@@ -28,6 +28,7 @@ function getAssistantLabel(source: AIPlatform): string {
  *
  * Removes: backticks, asterisks, underscores, tildes, square brackets.
  * These are harmless to remove from a TOC header label.
+ * @internal Exported for testing
  */
 export function stripMarkdownChars(text: string): string {
   return text.replace(/[`*_~[\]]/g, '');
@@ -43,7 +44,7 @@ export function stripMarkdownChars(text: string): string {
  * - Returns an empty string for empty/whitespace-only content so callers can
  *   fall back to the unheaded format.
  *
- * Exported for unit testing.
+ * @internal Exported for testing
  */
 export function buildQuestionHeader(content: string): string {
   const normalized = content.replace(/\s+/g, ' ').trim();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -92,6 +92,9 @@ export const AUTO_SAVE_CHECK_INTERVAL = 10000;
 /** Event throttle delay (milliseconds) */
 export const EVENT_THROTTLE_DELAY = 1000;
 
+/** Debounce delay for MutationObserver callback (milliseconds) */
+export const MUTATION_DEBOUNCE_DELAY = 100;
+
 // ============================================================
 // Security Constants
 // ============================================================

--- a/src/lib/obsidian-api.ts
+++ b/src/lib/obsidian-api.ts
@@ -39,16 +39,6 @@ export function classifyNetworkError(error: unknown): NetworkErrorType {
 }
 
 /**
- * Check if an error is a network-related error
- *
- * @param error - The caught error
- * @returns True if the error is network-related
- */
-function isNetworkError(error: unknown): boolean {
-  return classifyNetworkError(error) !== 'unknown';
-}
-
-/**
  * Create an AbortSignal with timeout
  * Polyfill for AbortSignal.timeout() (Chrome < 103 support)
  *
@@ -120,8 +110,15 @@ export class ObsidianApiClient {
         signal: createTimeoutSignal(DEFAULT_API_TIMEOUT),
       });
     } catch (error) {
-      if (isNetworkError(error)) {
-        throw this.createError(0, 'Request timed out. Please check your connection.');
+      const errorType = classifyNetworkError(error);
+      if (errorType !== 'unknown') {
+        const message =
+          errorType === 'timeout'
+            ? 'Request timed out. Please check your connection.'
+            : errorType === 'connection'
+              ? 'Cannot reach Obsidian. Is it running?'
+              : 'Request was cancelled.';
+        throw this.createError(0, message);
       }
       throw error;
     }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -37,6 +37,7 @@ function extractLatexFromKatex(element: Element): string | null {
  * Gemini coexistence: Elements already inside a [data-math] ancestor
  * (Gemini's native format) are skipped.
  *
+ * @internal Exported for testing
  * @param html Raw HTML string from extractor innerHTML
  * @returns HTML with standard KaTeX converted to data-math format
  */

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -8,6 +8,7 @@ import { MIN_PORT, MAX_PORT, MAX_VAULT_PATH_LENGTH, MIN_API_KEY_LENGTH } from '.
 
 /**
  * Allowed callout types
+ * @internal Exported for testing
  */
 export const ALLOWED_CALLOUT_TYPES = [
   'NOTE',
@@ -118,17 +119,6 @@ export function validateApiKey(key: string): string {
   // Empty check
   if (!trimmed) {
     throw new Error('API key is required');
-  }
-
-  // Obsidian REST API generates SHA-256 hashes (64 hex chars),
-  // but we allow flexibility for manually configured keys
-  if (trimmed.length !== 64) {
-    console.warn(`[G2O] API key length is ${trimmed.length}, expected 64 (SHA-256 hex)`);
-  }
-
-  // Hex format validation (warning only, non-blocking)
-  if (!/^[0-9a-fA-F]+$/.test(trimmed)) {
-    console.warn('[G2O] API key contains non-hexadecimal characters');
   }
 
   // Minimum length check (for security)

--- a/test/extractors/base.test.ts
+++ b/test/extractors/base.test.ts
@@ -57,9 +57,7 @@ class TestExtractor extends BaseExtractor {
     return this.getPageTitle();
   }
 
-  public testSortByDomPosition(
-    elements: Array<{ element: Element; type: 'user' | 'assistant' }>
-  ): Array<{ element: Element; type: 'user' | 'assistant' }> {
+  public testSortByDomPosition<T extends { element: Element }>(elements: T[]): T[] {
     return this.sortByDomPosition(elements);
   }
 

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -645,6 +645,27 @@ describe('ClaudeExtractor', () => {
         // Tests fallback chain
         expect(true).toBe(true);
       });
+
+      it('falls back to textContent when innerHTML produces no markdown', () => {
+        setClaudeLocation('test-123');
+        loadFixture(`
+          <div data-testid="user-message">Fallback text</div>
+          <div class="font-claude-response">
+            <div class="standard-markdown"><p>Response</p></div>
+          </div>
+        `);
+        // Override innerHTML to return empty so the textContent fallback triggers
+        const userEl = document.querySelector('[data-testid="user-message"]')!;
+        Object.defineProperty(userEl, 'innerHTML', {
+          get: () => '',
+          configurable: true,
+        });
+
+        const messages = extractor.extractMessages();
+        const userMsg = messages.find(m => m.role === 'user');
+        expect(userMsg).toBeDefined();
+        expect(userMsg?.content).toBe('Fallback text');
+      });
     });
 
     describe('assistantResponse selectors', () => {

--- a/test/extractors/notebooklm.test.ts
+++ b/test/extractors/notebooklm.test.ts
@@ -148,7 +148,9 @@ describe('NotebookLMExtractor', () => {
 
     it('handles empty conversation', async () => {
       setNotebookLMLocation('test-id');
-      loadFixture('<section class="chat-panel"><chat-panel><div class="chat-panel-content"></div></chat-panel></section>');
+      loadFixture(
+        '<section class="chat-panel"><chat-panel><div class="chat-panel-content"></div></chat-panel></section>'
+      );
       const result = await extractor.extract();
       // May succeed with warnings or fail — either is acceptable
       expect(result).toBeDefined();
@@ -264,6 +266,117 @@ describe('NotebookLMExtractor', () => {
       const result = await extractor.extract();
       expect(result.success).toBe(true);
       expect(result.data?.messages.some(m => m.role === 'user')).toBe(true);
+    });
+  });
+
+  // ========== Branch Coverage: extractUserContent / extractAssistantContent ==========
+  describe('Content extraction fallback paths', () => {
+    it('skips user message when textContent is empty', async () => {
+      setNotebookLMLocation('test-123');
+      loadFixture(`
+        <section class="chat-panel"><chat-panel><div class="chat-panel-content">
+          <div class="chat-message-pair is-rich-chat-ui">
+            <chat-message class="individual-message">
+              <div class="from-user-container">
+                <mat-card class="mat-mdc-card mdc-card from-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content from-user-message-inner-content message-content">
+                    <div class="message-text-content mat-body-medium"></div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+            <chat-message class="individual-message">
+              <div class="to-user-container">
+                <mat-card class="mat-mdc-card mdc-card to-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content message-content to-user-message-inner-content">
+                    <div class="message-text-content mat-body-medium">
+                      <div><element-list-renderer><p>Response</p></element-list-renderer></div>
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+          </div>
+        </div></chat-panel></section>
+      `);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      // No user message should be extracted (empty textContent)
+      expect(result.data?.messages.every(m => m.role === 'assistant')).toBe(true);
+    });
+
+    it('falls back to innerHTML when no element-list-renderer found', async () => {
+      setNotebookLMLocation('test-123');
+      loadFixture(`
+        <section class="chat-panel"><chat-panel><div class="chat-panel-content">
+          <div class="chat-message-pair is-rich-chat-ui">
+            <chat-message class="individual-message">
+              <div class="from-user-container">
+                <mat-card class="mat-mdc-card mdc-card from-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content from-user-message-inner-content message-content">
+                    <div class="message-text-content mat-body-medium">
+                      <div class="is-rich-chat-ui" role="heading" aria-level="3"><p>Question</p></div>
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+            <chat-message class="individual-message">
+              <div class="to-user-container">
+                <mat-card class="mat-mdc-card mdc-card to-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content message-content to-user-message-inner-content">
+                    <div class="message-text-content mat-body-medium">
+                      <div><p>Direct content without renderer</p></div>
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+          </div>
+        </div></chat-panel></section>
+      `);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg?.content).toContain('Direct content without renderer');
+    });
+
+    it('skips assistant message when both renderer and innerHTML are empty', async () => {
+      setNotebookLMLocation('test-123');
+      loadFixture(`
+        <section class="chat-panel"><chat-panel><div class="chat-panel-content">
+          <div class="chat-message-pair is-rich-chat-ui">
+            <chat-message class="individual-message">
+              <div class="from-user-container">
+                <mat-card class="mat-mdc-card mdc-card from-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content from-user-message-inner-content message-content">
+                    <div class="message-text-content mat-body-medium">
+                      <div class="is-rich-chat-ui" role="heading" aria-level="3"><p>Question</p></div>
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+            <chat-message class="individual-message">
+              <div class="to-user-container">
+                <mat-card class="mat-mdc-card mdc-card to-user-message-card-content">
+                  <mat-card-content class="mat-mdc-card-content message-content to-user-message-inner-content">
+                    <div class="message-text-content mat-body-medium"></div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </chat-message>
+          </div>
+        </div></chat-panel></section>
+      `);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      // Only user message, no assistant (empty content skipped)
+      expect(result.data?.messages.every(m => m.role === 'user')).toBe(true);
     });
   });
 

--- a/test/lib/obsidian-api.test.ts
+++ b/test/lib/obsidian-api.test.ts
@@ -166,22 +166,22 @@ describe('ObsidianApiClient', () => {
       });
     });
 
-    it('throws timeout error for network errors', async () => {
+    it('throws connection error for TypeError (connection refused)', async () => {
       mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
 
       await expect(client.getFile('path/to/file.md')).rejects.toMatchObject({
         status: 0,
-        message: 'Request timed out. Please check your connection.',
+        message: 'Cannot reach Obsidian. Is it running?',
       });
     });
 
-    it('throws timeout error for AbortError', async () => {
+    it('throws abort error for AbortError', async () => {
       const abortError = new DOMException('The operation was aborted', 'AbortError');
       mockFetch.mockRejectedValue(abortError);
 
       await expect(client.getFile('path/to/file.md')).rejects.toMatchObject({
         status: 0,
-        message: 'Request timed out. Please check your connection.',
+        message: 'Request was cancelled.',
       });
     });
 
@@ -233,12 +233,12 @@ describe('ObsidianApiClient', () => {
       });
     });
 
-    it('throws timeout error for network errors', async () => {
+    it('throws connection error for TypeError (connection refused)', async () => {
       mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
 
       await expect(client.putFile('path/to/file.md', 'content')).rejects.toMatchObject({
         status: 0,
-        message: 'Request timed out. Please check your connection.',
+        message: 'Cannot reach Obsidian. Is it running?',
       });
     });
 
@@ -308,12 +308,12 @@ describe('ObsidianApiClient', () => {
       });
     });
 
-    it('throws timeout error for network errors', async () => {
+    it('throws connection error for TypeError (connection refused)', async () => {
       mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
 
       await expect(client.listFiles('AI')).rejects.toMatchObject({
         status: 0,
-        message: 'Request timed out. Please check your connection.',
+        message: 'Cannot reach Obsidian. Is it running?',
       });
     });
 

--- a/test/lib/validation.test.ts
+++ b/test/lib/validation.test.ts
@@ -95,28 +95,19 @@ describe('validateApiKey', () => {
     expect(validateApiKey(minKey)).toBe(minKey);
   });
 
-  it('warns on non-standard length', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('accepts non-standard length key silently', () => {
     const nonStandardKey = 'a'.repeat(32);
     expect(validateApiKey(nonStandardKey)).toBe(nonStandardKey);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('length is 32'));
-    consoleSpy.mockRestore();
   });
 
-  it('warns on non-hex characters', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('accepts non-hex characters key silently', () => {
     const nonHexKey = 'g'.repeat(64);
     expect(validateApiKey(nonHexKey)).toBe(nonHexKey);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('non-hexadecimal'));
-    consoleSpy.mockRestore();
   });
 
-  it('accepts valid hex key without warnings', () => {
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('accepts valid hex key', () => {
     const validHexKey = 'abcdef0123456789'.repeat(4);
     expect(validateApiKey(validHexKey)).toBe(validHexKey);
-    expect(consoleSpy).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix misleading `fetchWithTimeout` error messages — now correctly distinguishes connection refused, timeout, and abort errors
- Remove `console.warn` from `validateApiKey` that leaked API key format information to DevTools
- Eliminate DOM sort duplication in `PerplexityExtractor` by widening `BaseExtractor.sortByDomPosition` to a generic type parameter
- Centralize `MUTATION_DEBOUNCE_DELAY` constant in `constants.ts`
- Add `@internal` JSDoc to 4 symbols exported only for testing
- Add 4 new tests covering previously untested fallback paths (NotebookLM branch 60% → 90%, Claude branch 78% → 81%)

## Analysis Background

Five specialist agents (code-reviewer, security-reviewer, architect, coverage-analyzer, refactor-cleaner) analyzed the full codebase in parallel. Result: **0 CRITICAL, 0 HIGH** findings. This PR addresses all MEDIUM findings and improves branch coverage.

## Changes

| Item | Category | File(s) |
|------|----------|---------|
| `fetchWithTimeout` error message fix | Bug | `obsidian-api.ts` |
| Remove `console.warn` from `validateApiKey` | Security | `validation.ts` |
| Generify `sortByDomPosition` + remove duplication | DRY | `base.ts`, `perplexity.ts` |
| Move `MUTATION_DEBOUNCE_DELAY` | Clean | `constants.ts`, `content/index.ts` |
| `@internal` JSDoc annotations | Docs | `validation.ts`, `markdown-formatting.ts`, `sanitize.ts` |
| NotebookLM fallback path tests (×3) | Test | `notebooklm.test.ts` |
| Claude textContent fallback test (×1) | Test | `claude.test.ts` |

## Test plan

- [x] 978 tests passing (974 → 978, +4 new)
- [x] ESLint: 0 errors, 0 warnings
- [x] TypeScript strict: 0 errors
- [x] Build: clean
- [x] Overall coverage: stmt 91.83%, branch 87.28%
- [x] NotebookLM branch coverage: 60% → 90%

## Note

This commit includes `Release-As: 1.0.0` footer. After merge, release-please will generate a v1.0.0 release PR.