### PR TITLE
feat(popup): hide callout-settings for other message-formats

### DIFF
--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -191,7 +191,7 @@
                 </select>
               </div>
 
-              <div class="form-row">
+              <div class="form-row" id="calloutSettingsGroup">
                 <div class="form-group">
                   <label for="userCallout" data-i18n="settings_userCallout">User Callout</label>
                   <input type="text" id="userCallout" value="QUESTION" />

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -76,6 +76,7 @@ const elements = {
   obsidianUrl: getElement<HTMLInputElement>('obsidianUrl'),
   vaultPath: getElement<HTMLInputElement>('vaultPath'),
   messageFormat: getElement<HTMLSelectElement>('messageFormat'),
+  calloutSettingsGroup: getElement<HTMLDivElement>('calloutSettingsGroup'),
   userCallout: getElement<HTMLInputElement>('userCallout'),
   assistantCallout: getElement<HTMLInputElement>('assistantCallout'),
   includeQuestionHeaders: getElement<HTMLInputElement>('includeQuestionHeaders'),
@@ -190,8 +191,12 @@ function setupEventListeners(): void {
   // Enable/disable callout inputs based on message format
   elements.messageFormat.addEventListener('change', () => {
     const isCallout = elements.messageFormat.value === 'callout';
-    elements.userCallout.disabled = !isCallout;
-    elements.assistantCallout.disabled = !isCallout;
+
+    if (isCallout) {
+      elements.calloutSettingsGroup.classList.remove('hidden');
+    } else {
+      elements.calloutSettingsGroup.classList.add('hidden');
+    }
   });
 
   // Setup API key visibility toggle

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -2,6 +2,8 @@
 
 /* Light theme (default) */
 :root {
+  interpolate-size: allow-keywords;
+
   /* Background colors */
   --bg-primary: #ffffff;
   --bg-secondary: #f8f9fa;
@@ -129,6 +131,19 @@ body {
 .form-row {
   display: flex;
   gap: 12px;
+  overflow: hidden;
+  transition: height 0.5s, display 0.5s;
+  transition-behavior: allow-discrete;
+}
+
+@starting-style {
+  .form-row {
+    height: 0;
+  }
+}
+
+.form-row.hidden {
+  height: 0;
 }
 
 .form-row .form-group {
@@ -534,4 +549,8 @@ select {
 
 .advanced-content {
   padding-top: 12px;
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
Hide callout settings (fields: "User Callout Type" and "Assistant Callout Type") when selected "Message Format" is not "Callout (Recommended)"