### PR TITLE
feat(popup): hide callout settings when message format is not callout

### DIFF
--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -191,7 +191,7 @@
                 </select>
               </div>
 
-              <div class="form-row">
+              <div class="form-row" id="calloutSettingsGroup">
                 <div class="form-group">
                   <label for="userCallout" data-i18n="settings_userCallout">User Callout</label>
                   <input type="text" id="userCallout" value="QUESTION" />

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -76,6 +76,7 @@ const elements = {
   obsidianUrl: getElement<HTMLInputElement>('obsidianUrl'),
   vaultPath: getElement<HTMLInputElement>('vaultPath'),
   messageFormat: getElement<HTMLSelectElement>('messageFormat'),
+  calloutSettingsGroup: getElement<HTMLElement>('calloutSettingsGroup'),
   userCallout: getElement<HTMLInputElement>('userCallout'),
   assistantCallout: getElement<HTMLInputElement>('assistantCallout'),
   includeQuestionHeaders: getElement<HTMLInputElement>('includeQuestionHeaders'),
@@ -138,6 +139,7 @@ function populateForm(settings: ExtensionSettings): void {
   elements.messageFormat.value = templateOptions.messageFormat || 'callout';
   elements.userCallout.value = templateOptions.userCalloutType || 'QUESTION';
   elements.assistantCallout.value = templateOptions.assistantCalloutType || 'NOTE';
+  updateCalloutSettingsVisibility();
   elements.includeQuestionHeaders.checked = templateOptions.includeQuestionHeaders ?? false;
 
   elements.includeId.checked = templateOptions.includeId ?? true;
@@ -187,12 +189,8 @@ function setupEventListeners(): void {
   // Show/hide timezone when includeDates changes
   elements.includeDates.addEventListener('change', updateTimezoneVisibility);
 
-  // Enable/disable callout inputs based on message format
-  elements.messageFormat.addEventListener('change', () => {
-    const isCallout = elements.messageFormat.value === 'callout';
-    elements.userCallout.disabled = !isCallout;
-    elements.assistantCallout.disabled = !isCallout;
-  });
+  // Show/hide callout settings based on message format
+  elements.messageFormat.addEventListener('change', updateCalloutSettingsVisibility);
 
   // Setup API key visibility toggle
   setupApiKeyToggle();
@@ -291,6 +289,15 @@ function populateTimezoneOptions(): void {
 function updateTimezoneVisibility(): void {
   const group = elements.timezoneGroup;
   if (elements.includeDates.checked) {
+    group.style.display = '';
+  } else {
+    group.style.display = 'none';
+  }
+}
+
+function updateCalloutSettingsVisibility(): void {
+  const group = elements.calloutSettingsGroup;
+  if (elements.messageFormat.value === 'callout') {
     group.style.display = '';
   } else {
     group.style.display = 'none';

--- a/test/popup/index.test.ts
+++ b/test/popup/index.test.ts
@@ -506,7 +506,19 @@ describe('popup/index patterns', () => {
     });
   });
 
-  describe('messageFormat change handler', () => {
+  describe('callout settings visibility', () => {
+    /** Replicates updateCalloutSettingsVisibility() from src/popup/index.ts */
+    function updateCalloutSettingsVisibility(
+      messageFormat: HTMLSelectElement,
+      calloutSettingsGroup: HTMLElement
+    ): void {
+      if (messageFormat.value === 'callout') {
+        calloutSettingsGroup.style.display = '';
+      } else {
+        calloutSettingsGroup.style.display = 'none';
+      }
+    }
+
     beforeEach(() => {
       document.body.innerHTML = `
         <select id="messageFormat">
@@ -514,51 +526,77 @@ describe('popup/index patterns', () => {
           <option value="plain">Plain</option>
           <option value="blockquote">Blockquote</option>
         </select>
-        <input id="userCallout" type="text">
-        <input id="assistantCallout" type="text">
+        <div class="form-row" id="calloutSettingsGroup">
+          <input id="userCallout" type="text">
+          <input id="assistantCallout" type="text">
+        </div>
       `;
     });
 
-    it('disables callout inputs when format is not callout', () => {
+    it('hides callout settings group when format is plain', () => {
       const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
-      const userCallout = document.getElementById('userCallout') as HTMLInputElement;
-      const assistantCallout = document.getElementById('assistantCallout') as HTMLInputElement;
+      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
 
-      messageFormat.addEventListener('change', () => {
-        const isCallout = messageFormat.value === 'callout';
-        userCallout.disabled = !isCallout;
-        assistantCallout.disabled = !isCallout;
-      });
+      messageFormat.addEventListener('change', () =>
+        updateCalloutSettingsVisibility(messageFormat, group)
+      );
 
-      // Change to plain
       messageFormat.value = 'plain';
       messageFormat.dispatchEvent(new Event('change'));
 
-      expect(userCallout.disabled).toBe(true);
-      expect(assistantCallout.disabled).toBe(true);
+      expect(group.style.display).toBe('none');
     });
 
-    it('enables callout inputs when format is callout', () => {
+    it('hides callout settings group when format is blockquote', () => {
       const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
-      const userCallout = document.getElementById('userCallout') as HTMLInputElement;
-      const assistantCallout = document.getElementById('assistantCallout') as HTMLInputElement;
+      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
 
-      // Start disabled
-      userCallout.disabled = true;
-      assistantCallout.disabled = true;
+      messageFormat.addEventListener('change', () =>
+        updateCalloutSettingsVisibility(messageFormat, group)
+      );
 
-      messageFormat.addEventListener('change', () => {
-        const isCallout = messageFormat.value === 'callout';
-        userCallout.disabled = !isCallout;
-        assistantCallout.disabled = !isCallout;
-      });
+      messageFormat.value = 'blockquote';
+      messageFormat.dispatchEvent(new Event('change'));
 
-      // Change to callout
+      expect(group.style.display).toBe('none');
+    });
+
+    it('shows callout settings group when format is callout', () => {
+      const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
+      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+
+      // Start hidden
+      group.style.display = 'none';
+
+      messageFormat.addEventListener('change', () =>
+        updateCalloutSettingsVisibility(messageFormat, group)
+      );
+
       messageFormat.value = 'callout';
       messageFormat.dispatchEvent(new Event('change'));
 
-      expect(userCallout.disabled).toBe(false);
-      expect(assistantCallout.disabled).toBe(false);
+      expect(group.style.display).toBe('');
+    });
+
+    it('syncs visibility on initial load when format is not callout', () => {
+      const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
+      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+
+      // Simulate restoring a non-callout format from settings
+      messageFormat.value = 'plain';
+      updateCalloutSettingsVisibility(messageFormat, group);
+
+      expect(group.style.display).toBe('none');
+    });
+
+    it('syncs visibility on initial load when format is callout', () => {
+      const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
+      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+
+      messageFormat.value = 'callout';
+      updateCalloutSettingsVisibility(messageFormat, group);
+
+      expect(group.style.display).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

- Hide callout type inputs (User Callout, Assistant Callout) when Message Format is not "Callout" instead of just disabling them
- Follow existing `updateTimezoneVisibility()` pattern using `style.display` toggle
- Add initial state sync on popup load so saved non-callout formats correctly hide the group
- Replace 2 disabled-state tests with 5 visibility tests (plain, blockquote, callout, initial sync x2)

Inspired by #212 — reimplemented with scoped changes and no global CSS side effects.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (981 tests)
- [x] Manual: open popup with "Callout" format → callout inputs visible
- [x] Manual: switch to "Plain" or "Blockquote" → callout inputs hidden
- [x] Manual: switch back to "Callout" → callout inputs reappear
- [x] Manual: save "Plain" format, reopen popup → callout inputs hidden on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)