### PR TITLE
feat(popup): add functionality to set font size and color for message captions ("User", "Assistant")

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -81,6 +81,22 @@
     "message": "Assistant Callout Type",
     "description": "Label for assistant callout type"
   },
+  "settings_userHeaderFontSize": {
+    "message": "User Font Size",
+    "description": "Label for user header font size input"
+  },
+  "settings_assistantHeaderFontSize": {
+    "message": "Assistant Font Size",
+    "description": "Label for assistant header font size input"
+  },
+  "settings_userHeaderFontColor": {
+    "message": "User Color",
+    "description": "Label for user header font color input"
+  },
+  "settings_assistantHeaderFontColor": {
+    "message": "Assistant Color",
+    "description": "Label for assistant header font color input"
+  },
   "settings_includeQuestionHeaders": {
     "message": "Add `## ` headers before user messages",
     "description": "Checkbox label for issue #187 question header option"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -61,6 +61,18 @@
   "settings_assistantCallout": {
     "message": "アシスタントのコールアウト種類"
   },
+  "settings_userHeaderFontSize": {
+    "message": "ユーザーのフォントサイズ"
+  },
+  "settings_assistantHeaderFontSize": {
+    "message": "アシスタントのフォントサイズ"
+  },
+  "settings_userHeaderFontColor": {
+    "message": "ユーザーのカラー"
+  },
+  "settings_assistantHeaderFontColor": {
+    "message": "アシスタントのカラー"
+  },
   "settings_includeQuestionHeaders": {
     "message": "ユーザーメッセージの前に `## ` 見出しを追加"
   },

--- a/src/content/markdown-formatting.ts
+++ b/src/content/markdown-formatting.ts
@@ -91,7 +91,16 @@ export function formatMessage(
     }
 
     case 'blockquote': {
-      const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
+      const rawLabel = role === 'user' ? 'User:' : `${assistantLabel}:`;
+      let label = `**${rawLabel}**`;
+      const fontSize = role === 'user' ? options.userHeaderFontSize : options.assistantHeaderFontSize;
+      const fontColor = role === 'user' ? options.userHeaderFontColor : options.assistantHeaderFontColor;
+
+      if (fontSize || fontColor) {
+        const sizeAttr = fontSize ? ` size="${fontSize}"` : '';
+        const colorAttr = fontColor ? ` color="${fontColor}"` : '';
+        label = `<font${sizeAttr}${colorAttr}><b>${rawLabel}</b></font>`;
+      }
       const lines = markdown.split('\n').map(line => `> ${line}`);
       formatted = `${label}\n${lines.join('\n')}`;
       break;
@@ -99,7 +108,16 @@ export function formatMessage(
 
     case 'plain':
     default: {
-      const label = role === 'user' ? '**User:**' : `**${assistantLabel}:**`;
+      const rawLabel = role === 'user' ? 'User:' : `${assistantLabel}:`;
+      let label = `**${rawLabel}**`;
+      const fontSize = role === 'user' ? options.userHeaderFontSize : options.assistantHeaderFontSize;
+      const fontColor = role === 'user' ? options.userHeaderFontColor : options.assistantHeaderFontColor;
+
+      if (fontSize || fontColor) {
+        const sizeAttr = fontSize ? ` size="${fontSize}"` : '';
+        const colorAttr = fontColor ? ` color="${fontColor}"` : '';
+        label = `<font${sizeAttr}${colorAttr}><b>${rawLabel}</b></font>`;
+      }
       formatted = `${label}\n\n${markdown}`;
       break;
     }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -26,6 +26,10 @@ const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
   userCalloutType: 'QUESTION',
   assistantCalloutType: 'NOTE',
   includeQuestionHeaders: false,
+  userHeaderFontSize: '',
+  assistantHeaderFontSize: '',
+  userHeaderFontColor: '',
+  assistantHeaderFontColor: '',
 };
 
 const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -233,6 +233,14 @@ export interface TemplateOptions {
   includeQuestionHeaders?: boolean;
   /** IANA timezone for created/modified dates (e.g., 'Asia/Tokyo'). Defaults to 'UTC'. */
   timezone?: string;
+  /** Font size for User message header. e.g., '3' or '14px' */
+  userHeaderFontSize?: string;
+  /** Font size for Assistant message header. e.g., '3' or '14px' */
+  assistantHeaderFontSize?: string;
+  /** Font color for User message header. e.g., '#FF0000' or 'red' */
+  userHeaderFontColor?: string;
+  /** Font color for Assistant message header. e.g., '#0000FF' or 'blue' */
+  assistantHeaderFontColor?: string;
   /** Custom frontmatter fields (reserved for future use) */
   customFrontmatter?: Record<string, string>;
 }

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -204,6 +204,71 @@
                 </div>
               </div>
 
+              <div id="headerFontSettingsGroup">
+                <div class="form-row">
+                  <div class="form-group">
+                    <label for="userHeaderFontSize" data-i18n="settings_userHeaderFontSize"
+                      >User Font Size</label
+                    >
+                    <div class="number-input-wrapper">
+                      <input type="number" id="userHeaderFontSize" min="1" max="7" step="1" />
+                      <div class="number-spinbuttons">
+                        <button type="button" class="spin-btn spin-up" id="userHeaderFontSizeUp" aria-label="Increase">
+                          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m1 5 4-4 4 4"/></svg>
+                        </button>
+                        <button type="button" class="spin-btn spin-down" id="userHeaderFontSizeDown" aria-label="Decrease">
+                          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m1 1 4 4 4-4"/></svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label for="userHeaderFontColor" data-i18n="settings_userHeaderFontColor"
+                      >User Color</label
+                    >
+                    <div class="color-input-wrapper">
+                      <div class="color-preview" id="userHeaderFontColorPreview"></div>
+                      <input type="text" id="userHeaderFontColor" disabled />
+                      <div class="color-input-overlay" id="userHeaderFontColorOverlay"></div>
+                      <input type="color" id="userHeaderFontColorPicker" />
+                      <button type="button" id="userHeaderFontColorReset" class="color-reset-btn" title="Reset">✕</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-group">
+                    <label for="assistantHeaderFontSize" data-i18n="settings_assistantHeaderFontSize"
+                      >Assistant Font Size</label
+                    >
+                    <div class="number-input-wrapper">
+                      <input type="number" id="assistantHeaderFontSize" min="1" max="7" step="1" />
+                      <div class="number-spinbuttons">
+                        <button type="button" class="spin-btn spin-up" id="assistantHeaderFontSizeUp" aria-label="Increase">
+                          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m1 5 4-4 4 4"/></svg>
+                        </button>
+                        <button type="button" class="spin-btn spin-down" id="assistantHeaderFontSizeDown" aria-label="Decrease">
+                          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m1 1 4 4 4-4"/></svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label
+                      for="assistantHeaderFontColor"
+                      data-i18n="settings_assistantHeaderFontColor"
+                      >Assistant Color</label
+                    >
+                    <div class="color-input-wrapper">
+                      <div class="color-preview" id="assistantHeaderFontColorPreview"></div>
+                      <input type="text" id="assistantHeaderFontColor" disabled />
+                      <div class="color-input-overlay" id="assistantHeaderFontColorOverlay"></div>
+                      <input type="color" id="assistantHeaderFontColorPicker" />
+                      <button type="button" id="assistantHeaderFontColorReset" class="color-reset-btn" title="Reset">✕</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <div class="form-group">
                 <label class="checkbox-label">
                   <input type="checkbox" id="includeQuestionHeaders" />

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -79,6 +79,17 @@ const elements = {
   calloutSettingsGroup: getElement<HTMLElement>('calloutSettingsGroup'),
   userCallout: getElement<HTMLInputElement>('userCallout'),
   assistantCallout: getElement<HTMLInputElement>('assistantCallout'),
+  headerFontSettingsGroup: getElement<HTMLElement>('headerFontSettingsGroup'),
+  userHeaderFontSize: getElement<HTMLInputElement>('userHeaderFontSize'),
+  assistantHeaderFontSize: getElement<HTMLInputElement>('assistantHeaderFontSize'),
+  userHeaderFontColor: getElement<HTMLInputElement>('userHeaderFontColor'),
+  userHeaderFontColorPicker: getElement<HTMLInputElement>('userHeaderFontColorPicker'),
+  userHeaderFontColorOverlay: getElement<HTMLDivElement>('userHeaderFontColorOverlay'),
+  userHeaderFontColorReset: getElement<HTMLButtonElement>('userHeaderFontColorReset'),
+  assistantHeaderFontColor: getElement<HTMLInputElement>('assistantHeaderFontColor'),
+  assistantHeaderFontColorPicker: getElement<HTMLInputElement>('assistantHeaderFontColorPicker'),
+  assistantHeaderFontColorOverlay: getElement<HTMLDivElement>('assistantHeaderFontColorOverlay'),
+  assistantHeaderFontColorReset: getElement<HTMLButtonElement>('assistantHeaderFontColorReset'),
   includeQuestionHeaders: getElement<HTMLInputElement>('includeQuestionHeaders'),
   includeId: getElement<HTMLInputElement>('includeId'),
   includeTitle: getElement<HTMLInputElement>('includeTitle'),
@@ -106,6 +117,8 @@ async function initialize(): Promise<void> {
     populateForm(settings);
     setupEventListeners();
     setupToggleSwitchAccessibility();
+    setupColorInputs();
+    setupNumberInputs();
   } catch (error) {
     showStatus(getMessage('toast_error_connectionFailed'), 'error');
     console.error('[G2O Popup] Init error:', error);
@@ -139,6 +152,10 @@ function populateForm(settings: ExtensionSettings): void {
   elements.messageFormat.value = templateOptions.messageFormat || 'callout';
   elements.userCallout.value = templateOptions.userCalloutType || 'QUESTION';
   elements.assistantCallout.value = templateOptions.assistantCalloutType || 'NOTE';
+  elements.userHeaderFontSize.value = templateOptions.userHeaderFontSize || '';
+  elements.assistantHeaderFontSize.value = templateOptions.assistantHeaderFontSize || '';
+  elements.userHeaderFontColor.value = templateOptions.userHeaderFontColor || '';
+  elements.assistantHeaderFontColor.value = templateOptions.assistantHeaderFontColor || '';
   updateCalloutSettingsVisibility();
   elements.includeQuestionHeaders.checked = templateOptions.includeQuestionHeaders ?? false;
 
@@ -249,6 +266,122 @@ function setupToggleSwitchAccessibility(): void {
 }
 
 /**
+ * Setup custom color inputs (text + hidden color picker overlay)
+ */
+function setupColorInputs(): void {
+  const setupPair = (
+    textInput: HTMLInputElement,
+    pickerInput: HTMLInputElement,
+    overlay: HTMLDivElement,
+    resetBtn: HTMLButtonElement
+  ) => {
+    const updatePreview = () => {
+      const wrapper = textInput.closest('.color-input-wrapper');
+      if (!wrapper) return;
+      const preview = wrapper.querySelector('.color-preview') as HTMLElement;
+      if (preview) {
+        if (textInput.value) {
+          preview.style.backgroundColor = textInput.value;
+          wrapper.classList.add('has-color');
+        } else {
+          wrapper.classList.remove('has-color');
+        }
+      }
+    };
+
+    // Run on initialize
+    updatePreview();
+
+    // When overlay is clicked, trigger color picker
+    overlay.addEventListener('click', () => {
+      pickerInput.value = textInput.value || '#000000';
+      if (typeof pickerInput.showPicker === 'function') {
+        try {
+          pickerInput.showPicker();
+        } catch {
+          pickerInput.click();
+        }
+      } else {
+        pickerInput.click();
+      }
+    });
+
+    // When color picker value changes, update text input
+    pickerInput.addEventListener('input', () => {
+      textInput.value = pickerInput.value;
+      updatePreview();
+    });
+
+    // Reset button clears the text input
+    resetBtn.addEventListener('click', () => {
+      textInput.value = '';
+      updatePreview();
+    });
+  };
+
+  setupPair(
+    elements.userHeaderFontColor,
+    elements.userHeaderFontColorPicker,
+    elements.userHeaderFontColorOverlay,
+    elements.userHeaderFontColorReset
+  );
+
+  setupPair(
+    elements.assistantHeaderFontColor,
+    elements.assistantHeaderFontColorPicker,
+    elements.assistantHeaderFontColorOverlay,
+    elements.assistantHeaderFontColorReset
+  );
+}
+
+/**
+ * Setup custom spinner buttons for number inputs
+ */
+function setupNumberInputs(): void {
+  const setupSpinner = (inputId: string) => {
+    const input = document.getElementById(inputId) as HTMLInputElement;
+    const btnUp = document.getElementById(`${inputId}Up`) as HTMLButtonElement;
+    const btnDown = document.getElementById(`${inputId}Down`) as HTMLButtonElement;
+    
+    if (!input || !btnUp || !btnDown) return;
+
+    btnUp.addEventListener('click', () => {
+      input.stepUp();
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    btnDown.addEventListener('click', () => {
+      input.stepDown();
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const enforceConstraints = () => {
+      if (input.value === '') return;
+      
+      const val = parseInt(input.value, 10);
+      const min = parseInt(input.min || '1', 10);
+      const max = parseInt(input.max || '7', 10);
+
+      if (isNaN(val)) {
+        input.value = '';
+      } else if (val < min) {
+        input.value = min.toString();
+      } else if (val > max) {
+        input.value = max.toString();
+      }
+    };
+
+    input.addEventListener('input', enforceConstraints);
+    input.addEventListener('change', enforceConstraints);
+  };
+
+  setupSpinner('userHeaderFontSize');
+  setupSpinner('assistantHeaderFontSize');
+}
+
+/**
  * Populate timezone select with IANA timezone names
  * Groups by region for easier navigation
  */
@@ -296,12 +429,9 @@ function updateTimezoneVisibility(): void {
 }
 
 function updateCalloutSettingsVisibility(): void {
-  const group = elements.calloutSettingsGroup;
-  if (elements.messageFormat.value === 'callout') {
-    group.style.display = '';
-  } else {
-    group.style.display = 'none';
-  }
+  const isCallout = elements.messageFormat.value === 'callout';
+  elements.calloutSettingsGroup.style.display = isCallout ? '' : 'none';
+  elements.headerFontSettingsGroup.style.display = isCallout ? 'none' : '';
 }
 
 /**
@@ -338,6 +468,10 @@ function collectSettings(): ExtensionSettings {
     messageFormat,
     userCalloutType: validateCalloutType(elements.userCallout.value || 'QUESTION', 'QUESTION'),
     assistantCalloutType: validateCalloutType(elements.assistantCallout.value || 'NOTE', 'NOTE'),
+    userHeaderFontSize: elements.userHeaderFontSize.value.trim() || undefined,
+    assistantHeaderFontSize: elements.assistantHeaderFontSize.value.trim() || undefined,
+    userHeaderFontColor: elements.userHeaderFontColor.value.trim() || undefined,
+    assistantHeaderFontColor: elements.assistantHeaderFontColor.value.trim() || undefined,
     includeQuestionHeaders: elements.includeQuestionHeaders.checked,
     includeId: elements.includeId.checked,
     includeTitle: elements.includeTitle.checked,

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -535,3 +535,148 @@ select {
 .advanced-content {
   padding-top: 12px;
 }
+
+/* Color Picker Input Wrapper */
+.color-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.color-preview {
+  position: absolute;
+  left: 8px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid var(--border, rgba(128, 128, 128, 0.4));
+  pointer-events: none;
+  z-index: 2;
+  display: none;
+}
+
+.color-input-wrapper.has-color .color-preview {
+  display: block;
+}
+
+.color-input-wrapper.has-color input[type='text'] {
+  padding-left: 28px;
+}
+
+.color-input-wrapper input[type='text'] {
+  flex: 1;
+  padding-right: 28px;
+  cursor: pointer;
+  background-color: var(--bg-secondary);
+}
+
+.color-input-wrapper input[type='text']:disabled {
+  opacity: 1;
+  color: var(--text-primary);
+  -webkit-text-fill-color: var(--text-primary);
+}
+
+.color-input-wrapper input[type='color'] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  padding: 0;
+  margin: 0;
+  border: none;
+  pointer-events: none;
+}
+
+.color-reset-btn {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  z-index: 2;
+}
+
+.color-reset-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.color-input-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 32px;
+  bottom: 0;
+  cursor: pointer;
+  z-index: 1;
+}
+
+/* Number Input Custom Spinners */
+.number-input-wrapper {
+  position: relative;
+  display: flex;
+}
+
+.number-input-wrapper input[type='number'] {
+  padding-right: 28px;
+  -moz-appearance: textfield;
+}
+
+.number-input-wrapper input[type='number']::-webkit-inner-spin-button,
+.number-input-wrapper input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.number-spinbuttons {
+  position: absolute;
+  right: 1px;
+  top: 1px;
+  bottom: 1px;
+  width: 24px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--bg-secondary);
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
+  overflow: hidden;
+}
+
+.spin-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.1s, color 0.1s;
+  padding: 0;
+}
+
+.spin-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.spin-btn:active {
+  background: var(--border);
+}
+
+.spin-btn.spin-up {
+  border-bottom: 1px solid var(--border);
+}
+
+.spin-btn svg {
+  width: 10px;
+  height: 6px;
+}

--- a/test/content/markdown-formatting.test.ts
+++ b/test/content/markdown-formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildQuestionHeader, stripMarkdownChars } from '../../src/content/markdown-formatting';
+import { buildQuestionHeader, stripMarkdownChars, formatMessage } from '../../src/content/markdown-formatting';
 
 /**
  * Unit tests for buildQuestionHeader (issue #187).
@@ -147,5 +147,50 @@ describe('stripMarkdownChars', () => {
 
   it('returns empty string for input of only markdown chars', () => {
     expect(stripMarkdownChars('`*_~[]')).toBe('');
+  });
+});
+
+describe('formatMessage', () => {
+  const baseOptions = {
+    messageFormat: 'plain' as const,
+    userCalloutType: 'QUESTION',
+    assistantCalloutType: 'NOTE',
+    includeQuestionHeaders: false,
+    includeId: false,
+    includeTitle: false,
+    includeTags: false,
+    includeSource: false,
+    includeDates: false,
+    includeMessageCount: false,
+  };
+
+  it('uses ** for labels when no font settings are applied in plain format', () => {
+    const result = formatMessage('Hello', 'user', baseOptions, 'chatgpt');
+    expect(result).toBe('**User:**\n\nHello');
+  });
+
+  it('uses ** for assistant labels when no font settings are applied in plain format', () => {
+    const result = formatMessage('Hello', 'assistant', baseOptions, 'claude');
+    expect(result).toBe('**Claude:**\n\nHello');
+  });
+
+  it('wraps label in <b> inside <font> when font settings are used', () => {
+    const options = {
+      ...baseOptions,
+      userHeaderFontSize: '5',
+      userHeaderFontColor: '#ff0000'
+    };
+    const result = formatMessage('Hello', 'user', options, 'chatgpt');
+    expect(result).toBe('<font size="5" color="#ff0000"><b>User:</b></font>\n\nHello');
+  });
+
+  it('applies assistant font settings similarly in blockquote format', () => {
+    const options = {
+      ...baseOptions,
+      messageFormat: 'blockquote' as const,
+      assistantHeaderFontSize: '6',
+    };
+    const result = formatMessage('Hello', 'assistant', options, 'gemini');
+    expect(result).toBe('<font size="6"><b>Gemini:</b></font>\n> Hello');
   });
 });

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -499,12 +499,38 @@ describe('conversationToNote', () => {
     expect(note.body).toContain('> ');
   });
 
+  it('formats with custom header font size and different colors for user and assistant', () => {
+    const options: TemplateOptions = {
+      ...defaultOptions,
+      messageFormat: 'blockquote',
+      userHeaderFontSize: '4',
+      assistantHeaderFontSize: '2',
+      userHeaderFontColor: 'red',
+      assistantHeaderFontColor: 'blue',
+    };
+    const note = conversationToNote(mockData, options);
+    expect(note.body).toContain('<font size="4" color="red"><b>User:</b></font>');
+    expect(note.body).toContain('<font size="2" color="blue"><b>Gemini:</b></font>');
+  });
+
   it('formats as plain when specified', () => {
     const options = { ...defaultOptions, messageFormat: 'plain' as const };
     const note = conversationToNote(mockData, options);
     expect(note.body).toContain('**User:**');
     expect(note.body).toContain('**Gemini:**');
     expect(note.body).not.toContain('[!');
+  });
+
+  it('formats with custom header font size only in plain format', () => {
+    const options: TemplateOptions = {
+      ...defaultOptions,
+      messageFormat: 'plain',
+      userHeaderFontSize: '14px',
+      assistantHeaderFontSize: '12px',
+    };
+    const note = conversationToNote(mockData, options);
+    expect(note.body).toContain('<font size="14px"><b>User:</b></font>');
+    expect(note.body).toContain('<font size="12px"><b>Gemini:</b></font>');
   });
 
   it('handles multiple messages', () => {

--- a/test/popup/index.test.ts
+++ b/test/popup/index.test.ts
@@ -119,6 +119,10 @@ describe('popup/index patterns', () => {
         </select>
         <input id="userCallout" type="text">
         <input id="assistantCallout" type="text">
+        <input id="userHeaderFontSize" type="number">
+        <input id="assistantHeaderFontSize" type="number">
+        <input id="userHeaderFontColor" type="text">
+        <input id="assistantHeaderFontColor" type="text">
         <input id="includeId" type="checkbox">
         <input id="includeTitle" type="checkbox">
         <input id="includeTags" type="checkbox">
@@ -175,6 +179,32 @@ describe('popup/index patterns', () => {
       expect(assistantCallout.value).toBe('NOTE');
     });
 
+    it('populates font settings inputs', () => {
+      const userSize = document.getElementById('userHeaderFontSize') as HTMLInputElement;
+      const userColor = document.getElementById('userHeaderFontColor') as HTMLInputElement;
+      const assistantSize = document.getElementById('assistantHeaderFontSize') as HTMLInputElement;
+      const assistantColor = document.getElementById('assistantHeaderFontColor') as HTMLInputElement;
+
+      const settings = {
+        templateOptions: {
+          userHeaderFontSize: '4',
+          userHeaderFontColor: '#ff0000',
+          assistantHeaderFontSize: '3',
+          assistantHeaderFontColor: '#00ff00',
+        },
+      };
+
+      userSize.value = settings.templateOptions.userHeaderFontSize || '';
+      userColor.value = settings.templateOptions.userHeaderFontColor || '';
+      assistantSize.value = settings.templateOptions.assistantHeaderFontSize || '';
+      assistantColor.value = settings.templateOptions.assistantHeaderFontColor || '';
+
+      expect(userSize.value).toBe('4');
+      expect(userColor.value).toBe('#ff0000');
+      expect(assistantSize.value).toBe('3');
+      expect(assistantColor.value).toBe('#00ff00');
+    });
+
     it('populates enableToolContent checkbox', () => {
       const enableToolContent = document.getElementById('enableToolContent') as HTMLInputElement;
       const settings = { enableToolContent: true };
@@ -210,6 +240,10 @@ describe('popup/index patterns', () => {
         </select>
         <input id="userCallout" type="text" value="QUESTION">
         <input id="assistantCallout" type="text" value="NOTE">
+        <input id="userHeaderFontSize" type="number" value="4">
+        <input id="userHeaderFontColor" type="text" value="#ff0000">
+        <input id="assistantHeaderFontSize" type="number" value="3">
+        <input id="assistantHeaderFontColor" type="text" value="#00ff00">
         <input id="includeId" type="checkbox" checked>
         <input id="includeTitle" type="checkbox" checked>
         <input id="includeTags" type="checkbox" checked>
@@ -228,6 +262,10 @@ describe('popup/index patterns', () => {
         messageFormat: document.getElementById('messageFormat') as HTMLSelectElement,
         userCallout: document.getElementById('userCallout') as HTMLInputElement,
         assistantCallout: document.getElementById('assistantCallout') as HTMLInputElement,
+        userHeaderFontSize: document.getElementById('userHeaderFontSize') as HTMLInputElement,
+        userHeaderFontColor: document.getElementById('userHeaderFontColor') as HTMLInputElement,
+        assistantHeaderFontSize: document.getElementById('assistantHeaderFontSize') as HTMLInputElement,
+        assistantHeaderFontColor: document.getElementById('assistantHeaderFontColor') as HTMLInputElement,
         includeId: document.getElementById('includeId') as HTMLInputElement,
         includeTitle: document.getElementById('includeTitle') as HTMLInputElement,
         includeTags: document.getElementById('includeTags') as HTMLInputElement,
@@ -240,6 +278,10 @@ describe('popup/index patterns', () => {
         messageFormat: elements.messageFormat.value as 'callout' | 'plain' | 'blockquote',
         userCalloutType: elements.userCallout.value || 'QUESTION',
         assistantCalloutType: elements.assistantCallout.value || 'NOTE',
+        userHeaderFontSize: elements.userHeaderFontSize.value.trim() || undefined,
+        userHeaderFontColor: elements.userHeaderFontColor.value.trim() || undefined,
+        assistantHeaderFontSize: elements.assistantHeaderFontSize.value.trim() || undefined,
+        assistantHeaderFontColor: elements.assistantHeaderFontColor.value.trim() || undefined,
         includeId: elements.includeId.checked,
         includeTitle: elements.includeTitle.checked,
         includeTags: elements.includeTags.checked,
@@ -259,6 +301,8 @@ describe('popup/index patterns', () => {
       expect(settings.obsidianUrl).toBe('http://127.0.0.1:27123');
       expect(settings.vaultPath).toBe('AI/Gemini');
       expect(settings.templateOptions.messageFormat).toBe('callout');
+      expect(settings.templateOptions.userHeaderFontSize).toBe('4');
+      expect(settings.templateOptions.userHeaderFontColor).toBe('#ff0000');
     });
 
     it('collectSettings includes enableToolContent', () => {
@@ -510,13 +554,12 @@ describe('popup/index patterns', () => {
     /** Replicates updateCalloutSettingsVisibility() from src/popup/index.ts */
     function updateCalloutSettingsVisibility(
       messageFormat: HTMLSelectElement,
-      calloutSettingsGroup: HTMLElement
+      calloutSettingsGroup: HTMLElement,
+      headerFontSettingsGroup: HTMLElement
     ): void {
-      if (messageFormat.value === 'callout') {
-        calloutSettingsGroup.style.display = '';
-      } else {
-        calloutSettingsGroup.style.display = 'none';
-      }
+      const isCallout = messageFormat.value === 'callout';
+      calloutSettingsGroup.style.display = isCallout ? '' : 'none';
+      headerFontSettingsGroup.style.display = isCallout ? 'none' : '';
     }
 
     beforeEach(() => {
@@ -530,73 +573,57 @@ describe('popup/index patterns', () => {
           <input id="userCallout" type="text">
           <input id="assistantCallout" type="text">
         </div>
+        <div id="headerFontSettingsGroup"></div>
       `;
     });
 
-    it('hides callout settings group when format is plain', () => {
+    it('hides callout settings and shows header settings when format is plain', () => {
       const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
       const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+      const headerGroup = document.getElementById('headerFontSettingsGroup') as HTMLElement;
 
       messageFormat.addEventListener('change', () =>
-        updateCalloutSettingsVisibility(messageFormat, group)
+        updateCalloutSettingsVisibility(messageFormat, group, headerGroup)
       );
 
       messageFormat.value = 'plain';
       messageFormat.dispatchEvent(new Event('change'));
 
       expect(group.style.display).toBe('none');
+      expect(headerGroup.style.display).toBe('');
     });
 
-    it('hides callout settings group when format is blockquote', () => {
+    it('shows callout settings and hides header settings when format is callout', () => {
       const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
       const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+      const headerGroup = document.getElementById('headerFontSettingsGroup') as HTMLElement;
 
-      messageFormat.addEventListener('change', () =>
-        updateCalloutSettingsVisibility(messageFormat, group)
-      );
-
-      messageFormat.value = 'blockquote';
-      messageFormat.dispatchEvent(new Event('change'));
-
-      expect(group.style.display).toBe('none');
-    });
-
-    it('shows callout settings group when format is callout', () => {
-      const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
-      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
-
-      // Start hidden
+      // Start reversed
       group.style.display = 'none';
+      headerGroup.style.display = '';
 
       messageFormat.addEventListener('change', () =>
-        updateCalloutSettingsVisibility(messageFormat, group)
+        updateCalloutSettingsVisibility(messageFormat, group, headerGroup)
       );
 
       messageFormat.value = 'callout';
       messageFormat.dispatchEvent(new Event('change'));
 
       expect(group.style.display).toBe('');
+      expect(headerGroup.style.display).toBe('none');
     });
 
-    it('syncs visibility on initial load when format is not callout', () => {
+    it('syncs visibility on initial load when format is plain', () => {
       const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
       const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
+      const headerGroup = document.getElementById('headerFontSettingsGroup') as HTMLElement;
 
       // Simulate restoring a non-callout format from settings
       messageFormat.value = 'plain';
-      updateCalloutSettingsVisibility(messageFormat, group);
+      updateCalloutSettingsVisibility(messageFormat, group, headerGroup);
 
       expect(group.style.display).toBe('none');
-    });
-
-    it('syncs visibility on initial load when format is callout', () => {
-      const messageFormat = document.getElementById('messageFormat') as HTMLSelectElement;
-      const group = document.getElementById('calloutSettingsGroup') as HTMLElement;
-
-      messageFormat.value = 'callout';
-      updateCalloutSettingsVisibility(messageFormat, group);
-
-      expect(group.style.display).toBe('');
+      expect(headerGroup.style.display).toBe('');
     });
   });
 
@@ -646,6 +673,96 @@ describe('popup/index patterns', () => {
       });
 
       expect(saveSettings).toHaveBeenCalled();
+    });
+  });
+
+  describe('number constraints pattern', () => {
+    it('enforces min and max values on input', () => {
+      document.body.innerHTML = '<input type="number" id="testNum" min="1" max="7" />';
+      const input = document.getElementById('testNum') as HTMLInputElement;
+      
+      const enforceConstraints = () => {
+        if (input.value === '') return;
+        
+        const val = parseInt(input.value, 10);
+        const min = parseInt(input.min || '1', 10);
+        const max = parseInt(input.max || '7', 10);
+
+        if (isNaN(val)) {
+          input.value = '';
+        } else if (val < min) {
+          input.value = min.toString();
+        } else if (val > max) {
+          input.value = max.toString();
+        }
+      };
+
+      input.addEventListener('input', enforceConstraints);
+
+      // Test value above max
+      input.value = '8';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('7');
+
+      // Test value below min
+      input.value = '0';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('1');
+
+      // Test valid value
+      input.value = '5';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('5');
+
+      // Test negative value
+      input.value = '-5';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('1');
+
+      // Test empty string bypass
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('');
+    });
+  });
+
+  describe('color interactions pattern', () => {
+    it('syncs color preview background and class based on text input value', () => {
+      document.body.innerHTML = `
+        <div class="color-input-wrapper">
+          <div class="color-preview"></div>
+          <input type="text" id="colorText" />
+        </div>
+      `;
+      const wrapper = document.querySelector('.color-input-wrapper') as HTMLElement;
+      const preview = document.querySelector('.color-preview') as HTMLElement;
+      const textInput = document.getElementById('colorText') as HTMLInputElement;
+
+      const updatePreview = () => {
+        if (textInput.value) {
+          preview.style.backgroundColor = textInput.value;
+          wrapper.classList.add('has-color');
+        } else {
+          preview.style.backgroundColor = '';
+          wrapper.classList.remove('has-color');
+        }
+      };
+
+      // Initially empty
+      updatePreview();
+      expect(wrapper.classList.contains('has-color')).toBe(false);
+
+      // Set color via input
+      textInput.value = '#ff0000';
+      updatePreview();
+      expect(wrapper.classList.contains('has-color')).toBe(true);
+      expect(preview.style.backgroundColor).toBe('rgb(255, 0, 0)'); // browser standardizes #ff0000 to rgb(255, 0, 0)
+
+      // Clear color
+      textInput.value = '';
+      updatePreview();
+      expect(wrapper.classList.contains('has-color')).toBe(false);
+      expect(preview.style.backgroundColor).toBe('');
     });
   });
 });


### PR DESCRIPTION
## The problem

When chat contains a lot of messages (for example: 20 or more) and each model response is long enough, it's hard to find where each message is started (when "Message Format" is "Plain" or "Blockquote").

## The idea

Add possibility to set custom font-size and font-color for message captions ("User", "Assistant"), and keep the current behavior for thoose users who don't need it (if these additional fields are empty - the current behavior is kept).

## In Extension

<img width="725" height="470" src="https://github.com/user-attachments/assets/875dfb9d-a5b5-4648-a65d-1ae10c54ee07" alt="Screenshot 1">

## In Obsidian

<img width="454" height="449" src="https://github.com/user-attachments/assets/285d8595-fd89-417b-b1be-06d9388418a5" alt="Screenshot 2">
