### PR TITLE
fix(perplexity): extract all prose blocks in markdown-content containers

### DIFF
--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -174,14 +174,30 @@ export class PerplexityExtractor extends BaseExtractor {
   /**
    * Extract assistant response content (HTML for markdown conversion)
    *
-   * Finds the .prose child element and extracts its innerHTML.
+   * Perplexity uses two layouts for `#markdown-content-N`:
+   *   (1) Legacy: a single `.prose` child wraps the whole answer.
+   *   (2) New: multiple sibling `.has-inline-images > div > .prose` blocks,
+   *       one per section (observed around 2026-04). Using querySelector
+   *       here dropped every block after the first, truncating the answer.
+   *
+   * Strategy: collect all `.prose` descendants and concatenate their innerHTML
+   * in document order. querySelectorAll already returns DOM order, so a single
+   * matching selector covers both layouts.
+   *
+   * Citation URL caveat: the "pill" citations rendered as a hover trigger
+   * (span.group/trigger without an <a href>) do NOT carry their source URL
+   * in the static DOM — URLs are lazy-loaded into the Sources tab only after
+   * the user opens it. Those citations are preserved here as plain text.
+   * Citations that DO embed <a href> (typically video / featured sources) are
+   * converted to markdown links correctly via Turndown.
+   *
    * All HTML is sanitized via DOMPurify to prevent XSS.
    */
   private extractAssistantContent(contentElement: HTMLElement): string {
-    // Find .prose child within the markdown-content container
-    const proseEl = this.queryWithFallback<HTMLElement>(SELECTORS.proseContent, contentElement);
-    if (proseEl) {
-      return sanitizeHtml(proseEl.innerHTML);
+    const proseEls = this.queryAllWithFallback<HTMLElement>(SELECTORS.proseContent, contentElement);
+    if (proseEls.length > 0) {
+      const joined = proseEls.map(el => el.innerHTML).join('\n');
+      return sanitizeHtml(joined);
     }
 
     // Fallback: use the content element's innerHTML directly

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -415,6 +415,106 @@ describe('PerplexityExtractor', () => {
       expect(messages).toHaveLength(1);
       expect(messages[0].role).toBe('user');
     });
+
+    // Regression: Perplexity started rendering some responses as multiple sibling
+    // .prose blocks inside a single #markdown-content-N container (each section
+    // wrapped in its own .has-inline-images > div > .prose wrapper). The previous
+    // implementation used querySelector (first match), dropping every block after
+    // the first. Observed in the wild on 2026-04-23 (data/perplexity-fail.html,
+    // "Polaris とは何か" answer — truncated after one paragraph).
+    it('concatenates all sibling .prose blocks inside one markdown-content container', () => {
+      setPerplexityLocation('test-slug');
+      loadFixture(`
+        <div class="max-w-threadContentWidth">
+          <div class="group/query">
+            <div class="bg-offset rounded-2xl">
+              <span class="select-text">Polarisについて教えて</span>
+            </div>
+          </div>
+          <div id="markdown-content-0" class="markdown-content">
+            <div class="has-inline-images">
+              <div>
+                <div class="prose dark:prose-invert inline">
+                  <p>First intro paragraph.</p>
+                </div>
+              </div>
+            </div>
+            <div class="has-inline-images">
+              <div>
+                <div class="prose dark:prose-invert inline">
+                  <h2>Polaris とは何か</h2>
+                </div>
+              </div>
+            </div>
+            <div class="has-inline-images">
+              <div>
+                <div class="prose dark:prose-invert inline">
+                  <p>Body of the Polaris section.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `);
+
+      const messages = extractor.extractMessages();
+      const assistantMsg = messages.find(m => m.role === 'assistant');
+
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg?.content).toContain('First intro paragraph.');
+      expect(assistantMsg?.content).toContain('Polaris とは何か');
+      expect(assistantMsg?.content).toContain('Body of the Polaris section.');
+    });
+
+    it('preserves DOM order when concatenating sibling .prose blocks', () => {
+      setPerplexityLocation('test-slug');
+      loadFixture(`
+        <div class="max-w-threadContentWidth">
+          <div class="group/query">
+            <div class="bg-offset rounded-2xl">
+              <span class="select-text">ordering test</span>
+            </div>
+          </div>
+          <div id="markdown-content-0" class="markdown-content">
+            <div class="has-inline-images"><div><div class="prose dark:prose-invert inline"><p>ALPHA</p></div></div></div>
+            <div class="has-inline-images"><div><div class="prose dark:prose-invert inline"><p>BETA</p></div></div></div>
+            <div class="has-inline-images"><div><div class="prose dark:prose-invert inline"><p>GAMMA</p></div></div></div>
+          </div>
+        </div>
+      `);
+
+      const messages = extractor.extractMessages();
+      const content = messages.find(m => m.role === 'assistant')?.content ?? '';
+      const alphaIdx = content.indexOf('ALPHA');
+      const betaIdx = content.indexOf('BETA');
+      const gammaIdx = content.indexOf('GAMMA');
+
+      expect(alphaIdx).toBeGreaterThanOrEqual(0);
+      expect(betaIdx).toBeGreaterThan(alphaIdx);
+      expect(gammaIdx).toBeGreaterThan(betaIdx);
+    });
+
+    it('still works with the legacy single-.prose structure', () => {
+      setPerplexityLocation('test-slug');
+      loadFixture(`
+        <div class="max-w-threadContentWidth">
+          <div class="group/query">
+            <div class="bg-offset rounded-2xl">
+              <span class="select-text">legacy</span>
+            </div>
+          </div>
+          <div id="markdown-content-0" class="markdown-content">
+            <div class="prose dark:prose-invert">
+              <p>Only paragraph.</p>
+            </div>
+          </div>
+        </div>
+      `);
+
+      const messages = extractor.extractMessages();
+      const assistantMsg = messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).toContain('Only paragraph.');
+    });
   });
 
   // ========== Issue #96: Math equations rendering ==========


### PR DESCRIPTION
## Summary

- Perplexity now renders some answers as multiple sibling `.prose` blocks inside a single `#markdown-content-N` container (one block per section). The previous `querySelector` call took only the first block, truncating long answers (observed on 2026-04-23 with a "Polaris とは何か" response — only the first paragraph was captured).
- `extractAssistantContent()` now uses `queryAllWithFallback` and concatenates `innerHTML` of every `.prose` descendant in DOM order. Legacy single-`.prose` layouts continue to work unchanged.
- Added a code comment documenting the Pattern A citation URL caveat: hover-trigger pill citations (e.g. `zenn+1`) have no `<a href>` in the static DOM because Perplexity lazy-loads source URLs into the Sources tab. Citations that already embed `<a href>` keep working via Turndown.

## Test plan

- [x] `npm run test` — 984/984 pass, includes 3 new regression tests covering multi-prose concatenation, DOM ordering, and legacy single-prose compatibility
- [x] `npm run lint` passes
- [x] `tsc --noEmit` clean
- [x] Smoke-test against a live Perplexity conversation with long multi-section answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)