### PR TITLE
fix(notebooklm): convert inline citations to Obsidian footnote refs

### DIFF
--- a/src/content/extractors/notebooklm-citations.ts
+++ b/src/content/extractors/notebooklm-citations.ts
@@ -1,0 +1,106 @@
+/**
+ * NotebookLM citation-to-footnote transformation
+ *
+ * NotebookLM renders inline source citations as buttons:
+ *   <button class="citation-marker">
+ *     <span aria-label="N: Source Title">N</span>
+ *   </button>
+ *
+ * Without transformation, DOMPurify strips the <button> wrapper but keeps the
+ * inner number as a text node, producing output like "big claim359" where
+ * "359" is three citations glued to the prose. This module rewrites each
+ * marker into a placeholder span carrying a per-message footnote label,
+ * which the existing `footnoteRef` Turndown rule (markdown-rules.ts) converts
+ * to Obsidian footnote syntax `[^label]`. The footnote definitions are
+ * returned alongside so the extractor can append them to the assistant
+ * message body.
+ */
+
+const FOOTNOTE_REF_ATTR = 'data-footnote-ref';
+
+const ARIA_LABEL_PATTERN = /^\s*(\d+)\s*[:.]\s*(.+?)\s*$/;
+
+export interface CitationTransformResult {
+  /** HTML with citation buttons replaced by footnote-ref placeholder spans. */
+  html: string;
+  /** Per-message footnote definition lines (`[^label]: title`), deduped. */
+  footnotes: string[];
+}
+
+interface ParsedCitation {
+  number: string;
+  title: string;
+}
+
+function parseCitation(button: Element): ParsedCitation | null {
+  const labelEl = button.querySelector('[aria-label]');
+  const ariaLabel = labelEl?.getAttribute('aria-label')?.trim() ?? '';
+  const visible = (button.textContent ?? '').trim();
+
+  const match = ariaLabel.match(ARIA_LABEL_PATTERN);
+  if (match) {
+    const [, number, title] = match;
+    return { number, title };
+  }
+
+  if (ariaLabel.length > 0 && visible.length > 0) {
+    return { number: visible, title: ariaLabel };
+  }
+
+  if (visible.length > 0) {
+    return { number: visible, title: visible };
+  }
+
+  return null;
+}
+
+function isMoreCitationsButton(button: Element): boolean {
+  return button.querySelector('mat-icon') !== null;
+}
+
+export function transformCitationsToFootnotes(
+  html: string,
+  messageIndex: number
+): CitationTransformResult {
+  if (!html) {
+    return { html: '', footnotes: [] };
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const buttons = Array.from(doc.querySelectorAll('button.citation-marker'));
+
+  if (buttons.length === 0) {
+    return { html, footnotes: [] };
+  }
+
+  const footnoteByNumber = new Map<string, string>();
+  const order: string[] = [];
+
+  for (const button of buttons) {
+    if (isMoreCitationsButton(button)) {
+      button.remove();
+      continue;
+    }
+
+    const parsed = parseCitation(button);
+    if (!parsed) {
+      button.remove();
+      continue;
+    }
+
+    const label = `m${messageIndex}-${parsed.number}`;
+    const placeholder = doc.createElement('span');
+    placeholder.setAttribute(FOOTNOTE_REF_ATTR, label);
+    placeholder.textContent = 'REF';
+    button.replaceWith(placeholder);
+
+    if (!footnoteByNumber.has(parsed.number)) {
+      footnoteByNumber.set(parsed.number, parsed.title);
+      order.push(parsed.number);
+    }
+  }
+
+  const footnotes = order.map(num => `[^m${messageIndex}-${num}]: ${footnoteByNumber.get(num)}`);
+
+  return { html: doc.body.innerHTML, footnotes };
+}

--- a/src/content/extractors/notebooklm.ts
+++ b/src/content/extractors/notebooklm.ts
@@ -17,6 +17,19 @@ import { sanitizeHtml } from '../../lib/sanitize';
 import type { ConversationMessage } from '../../lib/types';
 
 import { SELECTORS } from './selectors/notebooklm';
+import { transformCitationsToFootnotes } from './notebooklm-citations';
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch] ?? ch);
+}
 
 /**
  * NotebookLM chat conversation extractor
@@ -102,7 +115,7 @@ export class NotebookLMExtractor extends BaseExtractor {
       // Extract assistant response from this turn
       const assistantEl = this.queryWithFallback<HTMLElement>(SELECTORS.assistantResponse, turn);
       if (assistantEl) {
-        const content = this.extractAssistantContent(assistantEl);
+        const content = this.extractAssistantContent(assistantEl, index);
         if (content) {
           messages.push({
             id: `assistant-${index}`,
@@ -132,20 +145,30 @@ export class NotebookLMExtractor extends BaseExtractor {
    * Extract assistant response content (HTML for markdown conversion)
    *
    * Looks for element-list-renderer within the response container.
+   * Inline citation buttons are rewritten to footnote-ref placeholder spans
+   * BEFORE sanitization so the per-message footnote labels survive into
+   * the markdown pipeline. Footnote definitions are appended as
+   * `<p data-footnote-def>` paragraphs that the Turndown rule emits as
+   * literal `[^label]: title` lines.
+   *
    * All HTML is sanitized via DOMPurify to prevent XSS.
    */
-  private extractAssistantContent(element: HTMLElement): string {
-    // Find the structured content renderer
+  private extractAssistantContent(element: HTMLElement, messageIndex: number): string {
     const renderer = this.queryWithFallback<HTMLElement>(SELECTORS.markdownContent, element);
-    if (renderer) {
-      return sanitizeHtml(renderer.innerHTML);
+    const rawHtml = renderer?.innerHTML ?? element.innerHTML;
+    if (!rawHtml) {
+      return '';
     }
 
-    // Fallback: use the element's innerHTML
-    if (element.innerHTML) {
-      return sanitizeHtml(element.innerHTML);
-    }
+    const { html: transformedHtml, footnotes } = transformCitationsToFootnotes(
+      rawHtml,
+      messageIndex
+    );
 
-    return '';
+    const footnoteDefsHtml = footnotes
+      .map(line => `<p data-footnote-def="">${escapeHtml(line)}</p>`)
+      .join('');
+
+    return sanitizeHtml(transformedHtml + footnoteDefsHtml);
   }
 }

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -174,6 +174,20 @@ turndown.addRule('footnoteRef', {
   },
 });
 
+// Custom rule for footnote definitions (NotebookLM citations)
+// Converts <p data-footnote-def>[^label]: title</p> to a literal footnote
+// definition line. Bypasses Turndown's default text-escaping so the
+// `[^label]:` syntax survives intact.
+turndown.addRule('footnoteDef', {
+  filter: node => {
+    return node.nodeName === 'P' && (node as HTMLElement).hasAttribute('data-footnote-def');
+  },
+  replacement: (_content, node) => {
+    const text = (node.textContent ?? '').trim();
+    return text ? `\n\n${text}` : '';
+  },
+});
+
 // Custom rule for display math blocks (Gemini KaTeX: <div data-math="...">)
 turndown.addRule('mathBlock', {
   filter: node => {

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -96,6 +96,8 @@ export function preprocessKatex(html: string): string {
  * The uponSanitizeAttribute hook selectively allows:
  * - data-turn-source-index (Deep Research inline citations, 1-based index into source list)
  * - data-math (KaTeX math expressions — Gemini native or standard KaTeX via preprocessKatex)
+ * - data-footnote-ref (NotebookLM citation placeholder spans → Turndown rule)
+ * - data-footnote-def (NotebookLM footnote definition paragraphs → Turndown rule)
  * while blocking all other data-* attributes.
  *
  * Note: The hook is added/removed per call to avoid cross-contamination
@@ -107,7 +109,12 @@ export function sanitizeHtml(html: string): string {
   const preprocessed = preprocessKatex(html);
 
   DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
-    if (data.attrName === 'data-turn-source-index' || data.attrName === 'data-math') {
+    if (
+      data.attrName === 'data-turn-source-index' ||
+      data.attrName === 'data-math' ||
+      data.attrName === 'data-footnote-ref' ||
+      data.attrName === 'data-footnote-def'
+    ) {
       data.forceKeepAttr = true;
     } else if (data.attrName.startsWith('data-')) {
       data.keepAttr = false;

--- a/test/extractors/notebooklm-citations.test.ts
+++ b/test/extractors/notebooklm-citations.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { transformCitationsToFootnotes } from '../../src/content/extractors/notebooklm-citations';
+
+describe('transformCitationsToFootnotes', () => {
+  describe('basic transformation', () => {
+    it('returns input unchanged when no citations are present', () => {
+      const html = '<p>Plain prose with no citations.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toBe(html);
+      expect(result.footnotes).toEqual([]);
+    });
+
+    it('returns empty result for empty input', () => {
+      const result = transformCitationsToFootnotes('', 0);
+
+      expect(result.html).toBe('');
+      expect(result.footnotes).toEqual([]);
+    });
+
+    it('replaces a single citation with a footnote-ref placeholder span', () => {
+      const html =
+        '<p>A claim<button class="xap-inline-dialog citation-marker">' +
+        '<span aria-label="1: Source Title">1</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-1"');
+      expect(result.html).not.toContain('citation-marker');
+      expect(result.html).not.toContain('<button');
+      expect(result.footnotes).toEqual(['[^m0-1]: Source Title']);
+    });
+
+    it('preserves surrounding prose around the citation', () => {
+      const html =
+        '<p>A claim<button class="citation-marker">' +
+        '<span aria-label="1: Title">1</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('A claim');
+      expect(result.html).toContain('.</p>');
+    });
+  });
+
+  describe('multiple citations', () => {
+    it('handles multiple distinct citations in the same message', () => {
+      const html =
+        '<p>First<button class="citation-marker">' +
+        '<span aria-label="1: Source A">1</span></button> ' +
+        'and second<button class="citation-marker">' +
+        '<span aria-label="2: Source B">2</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-1"');
+      expect(result.html).toContain('data-footnote-ref="m0-2"');
+      expect(result.footnotes).toEqual(['[^m0-1]: Source A', '[^m0-2]: Source B']);
+    });
+
+    it('deduplicates footnote definitions when the same N is cited twice', () => {
+      const html =
+        '<p>Same<button class="citation-marker">' +
+        '<span aria-label="3: Repeat Source">3</span></button> ' +
+        'twice<button class="citation-marker">' +
+        '<span aria-label="3: Repeat Source">3</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 1);
+
+      const matches = result.html.match(/data-footnote-ref="m1-3"/g) ?? [];
+      expect(matches).toHaveLength(2);
+      expect(result.footnotes).toEqual(['[^m1-3]: Repeat Source']);
+    });
+  });
+
+  describe('per-message scoping', () => {
+    it('scopes labels by messageIndex to avoid cross-message collisions', () => {
+      const html =
+        '<p>Cite<button class="citation-marker">' +
+        '<span aria-label="1: First">1</span></button>.</p>';
+
+      const r0 = transformCitationsToFootnotes(html, 0);
+      const r1 = transformCitationsToFootnotes(html, 1);
+
+      expect(r0.html).toContain('data-footnote-ref="m0-1"');
+      expect(r1.html).toContain('data-footnote-ref="m1-1"');
+      expect(r0.footnotes[0]).toBe('[^m0-1]: First');
+      expect(r1.footnotes[0]).toBe('[^m1-1]: First');
+    });
+  });
+
+  describe('"more citations" mat-icon button is excluded', () => {
+    it('skips citation-marker buttons containing a mat-icon', () => {
+      const html =
+        '<p>A claim<button class="citation-marker">' +
+        '<span aria-label="1: Source Title">1</span></button>' +
+        '<button class="citation-marker">' +
+        '<mat-icon>more_horiz</mat-icon></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-1"');
+      expect(result.html).not.toContain('mat-icon');
+      expect(result.html).not.toContain('<button');
+      expect(result.footnotes).toEqual(['[^m0-1]: Source Title']);
+    });
+  });
+
+  describe('aria-label fallbacks', () => {
+    it('falls back to the visible number when aria-label is missing', () => {
+      const html =
+        '<p>Cite<button class="citation-marker"><span>5</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-5"');
+      expect(result.footnotes).toEqual(['[^m0-5]: 5']);
+    });
+
+    it('uses entire aria-label as title when no "N: title" separator is present', () => {
+      const html =
+        '<p>Cite<button class="citation-marker">' +
+        '<span aria-label="Just some label">7</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-7"');
+      expect(result.footnotes).toEqual(['[^m0-7]: Just some label']);
+    });
+
+    it('skips a citation that has neither aria-label nor visible number', () => {
+      const html =
+        '<p>Bad<button class="citation-marker"><span></span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).not.toContain('data-footnote-ref');
+      expect(result.html).not.toContain('<button');
+      expect(result.footnotes).toEqual([]);
+    });
+  });
+
+  describe('selector variants', () => {
+    it('also matches the .xap-inline-dialog.citation-marker variant', () => {
+      const html =
+        '<p>Cite<button class="xap-inline-dialog citation-marker">' +
+        '<span aria-label="2: Variant Source">2</span></button>.</p>';
+      const result = transformCitationsToFootnotes(html, 0);
+
+      expect(result.html).toContain('data-footnote-ref="m0-2"');
+      expect(result.footnotes).toEqual(['[^m0-2]: Variant Source']);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input string', () => {
+      const html =
+        '<p>X<button class="citation-marker">' +
+        '<span aria-label="1: T">1</span></button>.</p>';
+      const original = html;
+      transformCitationsToFootnotes(html, 0);
+      expect(html).toBe(original);
+    });
+  });
+});

--- a/test/extractors/notebooklm.test.ts
+++ b/test/extractors/notebooklm.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NotebookLMExtractor } from '../../src/content/extractors/notebooklm';
+import { htmlToMarkdown } from '../../src/content/markdown';
 import {
   loadFixture,
   clearFixture,
@@ -158,8 +159,13 @@ describe('NotebookLMExtractor', () => {
   });
 
   // ========== Citation Handling ==========
+  // Issue #185: inline citations were rendered as bare numbers ("big claim359")
+  // because citation buttons were stripped by DOMPurify but their inner text
+  // survived. These tests pin the fix: citations become Obsidian footnote refs
+  // with per-message labels, and footnote definitions are appended after the
+  // assistant prose.
   describe('Citation extraction', () => {
-    it('strips citation marker buttons from extracted text', async () => {
+    it('converts inline citation buttons to Obsidian footnote refs and definitions', async () => {
       createNotebookLMPage('test-id', [
         { role: 'user', content: 'Question' },
         {
@@ -168,8 +174,8 @@ describe('NotebookLMExtractor', () => {
             <labs-tailwind-structural-element-view-v2>
               <paragraph-element-view>
                 <div class="paragraph is-rich-chat-ui normal">
-                  <span>Some text with a citation</span>
-                  <span><button class="xap-inline-dialog citation-marker"><span aria-label="1: Source Title">1</span></button></span>
+                  <span>A big claim</span>
+                  <span><button class="xap-inline-dialog citation-marker"><span aria-label="1: First Source">1</span></button></span>
                   <span>.</span>
                 </div>
               </paragraph-element-view>
@@ -178,12 +184,124 @@ describe('NotebookLMExtractor', () => {
       ]);
 
       const result = await extractor.extract();
-
       expect(result.success).toBe(true);
       const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
-      // Citation number should not appear as raw inline text
-      // (it should either be stripped or converted to footnote)
-      expect(assistantMsg?.content).toContain('Some text with a citation');
+      expect(assistantMsg).toBeDefined();
+
+      const markdown = htmlToMarkdown(assistantMsg!.content);
+
+      // Footnote ref appears in the prose
+      expect(markdown).toContain('[^m0-1]');
+      // Footnote definition is appended (with the source title from aria-label)
+      expect(markdown).toContain('[^m0-1]: First Source');
+      // Bug regression guard: bare digit no longer glued to the prose
+      expect(markdown).not.toMatch(/big claim\d/);
+      // No leftover citation button artifact
+      expect(markdown).not.toContain('citation-marker');
+    });
+
+    it('drops the "more citations" mat-icon button without producing a footnote', async () => {
+      createNotebookLMPage('test-id', [
+        { role: 'user', content: 'Question' },
+        {
+          role: 'assistant',
+          content: `
+            <labs-tailwind-structural-element-view-v2>
+              <paragraph-element-view>
+                <div class="paragraph is-rich-chat-ui normal">
+                  <span>Sourced fact</span>
+                  <span><button class="xap-inline-dialog citation-marker"><span aria-label="2: Real Source">2</span></button></span>
+                  <span><button class="xap-inline-dialog citation-marker"><mat-icon>more_horiz</mat-icon></button></span>
+                  <span>.</span>
+                </div>
+              </paragraph-element-view>
+            </labs-tailwind-structural-element-view-v2>`,
+        },
+      ]);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      const markdown = htmlToMarkdown(assistantMsg!.content);
+
+      expect(markdown).toContain('[^m0-2]: Real Source');
+      // Only one footnote ref; the mat-icon button is silently dropped
+      expect(markdown.match(/\[\^m0-/g) ?? []).toHaveLength(2); // 1 ref + 1 def line
+      expect(markdown).not.toContain('mat-icon');
+      expect(markdown).not.toContain('more_horiz');
+    });
+
+    it('keeps footnote labels unique across assistant turns', async () => {
+      createNotebookLMPage('test-id', [
+        { role: 'user', content: 'Q1' },
+        {
+          role: 'assistant',
+          content: `
+            <labs-tailwind-structural-element-view-v2>
+              <paragraph-element-view>
+                <div class="paragraph is-rich-chat-ui normal">
+                  <span>First</span>
+                  <span><button class="citation-marker"><span aria-label="1: Source A">1</span></button></span>
+                  <span>.</span>
+                </div>
+              </paragraph-element-view>
+            </labs-tailwind-structural-element-view-v2>`,
+        },
+        { role: 'user', content: 'Q2' },
+        {
+          role: 'assistant',
+          content: `
+            <labs-tailwind-structural-element-view-v2>
+              <paragraph-element-view>
+                <div class="paragraph is-rich-chat-ui normal">
+                  <span>Second</span>
+                  <span><button class="citation-marker"><span aria-label="1: Source B">1</span></button></span>
+                  <span>.</span>
+                </div>
+              </paragraph-element-view>
+            </labs-tailwind-structural-element-view-v2>`,
+        },
+      ]);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+
+      const assistants = result.data?.messages.filter(m => m.role === 'assistant') ?? [];
+      expect(assistants).toHaveLength(2);
+      const md0 = htmlToMarkdown(assistants[0].content);
+      const md1 = htmlToMarkdown(assistants[1].content);
+
+      // Per-turn labels prevent cross-message [^N] collisions
+      expect(md0).toContain('[^m0-1]: Source A');
+      expect(md1).toContain('[^m1-1]: Source B');
+      expect(md0).not.toContain('[^m1-1]');
+      expect(md1).not.toContain('[^m0-1]');
+    });
+
+    it('falls back to the visible number when aria-label is missing', async () => {
+      createNotebookLMPage('test-id', [
+        { role: 'user', content: 'Question' },
+        {
+          role: 'assistant',
+          content: `
+            <labs-tailwind-structural-element-view-v2>
+              <paragraph-element-view>
+                <div class="paragraph is-rich-chat-ui normal">
+                  <span>Cite</span>
+                  <span><button class="citation-marker"><span>5</span></button></span>
+                  <span>.</span>
+                </div>
+              </paragraph-element-view>
+            </labs-tailwind-structural-element-view-v2>`,
+        },
+      ]);
+
+      const result = await extractor.extract();
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      const markdown = htmlToMarkdown(assistantMsg!.content);
+
+      expect(markdown).toContain('[^m0-5]');
+      expect(markdown).toContain('[^m0-5]: 5');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #185.

NotebookLM inline citation buttons (`<button class="citation-marker">`) were stripped by DOMPurify but their inner number text survived, producing output like "big claim359" — three citations glued to the prose. The `citationMarker` selector existed in `selectors/notebooklm.ts` but was never consumed.

This PR rewrites each citation marker into a footnote-ref placeholder span before sanitization. Footnote definitions are appended as `<p data-footnote-def>` paragraphs handled by a new Turndown rule that preserves the `[^label]: title` syntax verbatim. Footnote labels are scoped per-message (`m{turn}-{N}`) to avoid cross-turn `[^1]` collisions.

Source titles are parsed from each marker's `aria-label="N: Title"` attribute; missing or malformed labels fall back to the visible number. The "more citations" mat-icon button is silently dropped.

### Before / After

Before:

> **... a big claim359.**

After:

> **... a big claim[^m0-3][^m0-5][^m0-9].**
>
> [^m0-3]: Source Title
> [^m0-5]: Source Title
> [^m0-9]: Source Title

### Scope

- ✅ Inline citation → `[^label]` footnote ref + footnote def with source title
- ✅ Per-message label scoping (no cross-turn collision)
- ✅ "More citations" button silently excluded
- ❌ URL linking to specific sources — out of scope (most NotebookLM sources are uploaded files without public URLs; citation→source mapping requires additional DOM reverse-engineering). Tracked as a separate follow-up.

### Existing notes

This fix only affects newly extracted conversations. Existing Obsidian notes saved before this fix retain the buggy "claim359" output — re-extracting the same conversation will produce corrected output.

## Test plan

- [x] `npm run test` — 1000/1000 pass (added 13 unit tests for the transform module + 4 strong integration tests replacing the previously weak citation test)
- [x] `npm run test:coverage` — 92% statements (well above 85% threshold); new `notebooklm-citations.ts` at 100%
- [x] `npm run lint && npm run lint:platforms` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds
- [x] `npm run e2e:selectors` — live NotebookLM selector validation passes (citation-marker still matches)
- [x] Manual: load `dist/` as unpacked extension, save a real NotebookLM conversation with citations, open in Obsidian, verify footnote refs render and click navigation works