### PR TITLE
chore(devenv): expose all npm scripts as nix apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,30 +68,34 @@ The following are **always required**. No shortcuts.
 
 ## Commands
 
+Nix is the canonical task surface (see [ADR-011](docs/adr/011-nix-task-surface.md)); `npm run` continues to work as a compatibility alias. Both invoke the same `node_modules/.bin/*` binaries.
+
 ```bash
-npm run build          # TypeScript check + Vite production build
-npm run build:zip      # Build + zip dist/ for Chrome Web Store
-npm run dev            # Vite dev server with HMR
-npm run lint           # ESLint on src/ + platform consistency check
-npm run lint:platforms # Platform consistency check only
-npm run format         # Prettier formatting (write)
-npm run format:check   # Prettier formatting (check only, for CI)
-npm run test           # Run test suite (vitest)
-npm run test:watch     # Run tests in watch mode
-npm run test:coverage  # Run tests with coverage report
+nix run .#build           # TypeScript check + Vite production build
+nix run .#build-zip       # Build + zip dist/ for Chrome Web Store
+nix run .#dev             # Vite dev server with HMR
+nix run .#lint            # ESLint on src/ + platform consistency check
+nix run .#lint-platforms  # Platform consistency check only
+nix run .#format          # Prettier formatting (write)
+nix run .#format-check    # Prettier formatting (check only, for CI)
+nix run .#test            # Run test suite (vitest)
+nix run .#test-watch      # Run tests in watch mode
+nix run .#test-coverage   # Run tests with coverage report
 ```
+
+Naming: Nix attribute names cannot contain `:`, so `npm run e2e:auth` maps to `nix run .#e2e-auth`. If `node_modules/` is missing, the wrapper exits with an instruction to run `npm ci` first (no auto-install per project rules).
 
 ### E2E Selector Validation
 
 ```bash
-npm run e2e:auth              # Manual login for all platforms
-npm run e2e:selectors         # Run selector validation
-npm run e2e:daemon start      # Start CDP daemon (headless Chrome + keep-alive)
-npm run e2e:daemon stop       # Stop CDP daemon
-npm run e2e:daemon status     # Check daemon health + open tabs
+nix run .#e2e-auth                 # Manual login for all platforms
+nix run .#e2e-selectors            # Run selector validation
+nix run .#e2e-daemon -- start      # Start CDP daemon (headless Chrome + keep-alive)
+nix run .#e2e-daemon -- stop       # Stop CDP daemon
+nix run .#e2e-daemon -- status     # Check daemon health + open tabs
 ```
 
-Re-authentication workflow: `e2e:daemon stop` → `e2e:auth` → `e2e:daemon start`
+Re-authentication workflow: `e2e-daemon -- stop` → `e2e-auth` → `e2e-daemon -- start`
 
 Load the extension in Chrome: `chrome://extensions` → Load unpacked → select `dist/` folder
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -198,25 +198,31 @@ message_count: 1
 
 ## 開発
 
-```bash
-# HMR 対応の開発サーバー
-npm run dev
+開発環境は Nix が管理します（[ADR-010](docs/adr/010-nix-only-dev-environment.md) 参照）。`direnv` + `nix-direnv` を入れていればディレクトリ移動時に自動で環境が読み込まれます。そうでない場合は `nix develop` を実行してください。
 
-# プロダクションビルド
-npm run build
+すべてのワークフローに Nix エントリポイント（正規）と `npm run` エイリアス（互換）があります。詳細は [ADR-011](docs/adr/011-nix-task-surface.md) を参照。
 
-# リント
-npm run lint
+| ワークフロー | Nix（正規） | npm（エイリアス） |
+|---|---|---|
+| 開発サーバー（HMR） | `nix run .#dev` | `npm run dev` |
+| プロダクションビルド | `nix run .#build` | `npm run build` |
+| ビルド + ストア用 zip | `nix run .#build-zip` | `npm run build:zip` |
+| リント | `nix run .#lint` | `npm run lint` |
+| プラットフォーム整合性チェック | `nix run .#lint-platforms` | `npm run lint:platforms` |
+| フォーマット（書き込み） | `nix run .#format` | `npm run format` |
+| フォーマット（チェック） | `nix run .#format-check` | `npm run format:check` |
+| テスト | `nix run .#test` | `npm test` |
+| テスト（watch） | `nix run .#test-watch` | `npm run test:watch` |
+| カバレッジ付きテスト | `nix run .#test-coverage` | `npm run test:coverage` |
+| E2E 認証セットアップ | `nix run .#e2e-auth` | `npm run e2e:auth` |
+| E2E セレクター検証 | `nix run .#e2e-selectors` | `npm run e2e:selectors` |
+| E2E セレクター（headed） | `nix run .#e2e-selectors-headed` | `npm run e2e:selectors:headed` |
+| CDP デーモン | `nix run .#e2e-daemon -- <start\|stop\|status>` | `npm run e2e:daemon:<sub>` |
 
-# フォーマット
-npm run format
+> [!NOTE]
+> Nix の属性名にはコロンが使えないため、`e2e:auth` のような名前は `e2e-auth` にマッピングされます。CDP デーモンはサブコマンドを引数で渡します: `nix run .#e2e-daemon -- start`。
 
-# テスト実行
-npm test
-
-# カバレッジ付きテスト
-npm run test:coverage
-```
+`node_modules/` が無い状態で Nix エントリポイントを起動するとエラーになり、`npm ci` を実行するよう案内されます。依存関係の自動インストールは意図的に行いません。
 
 ## アーキテクチャ
 

--- a/README.md
+++ b/README.md
@@ -198,25 +198,31 @@ Detailed analysis sections...
 
 ## Development
 
-```bash
-# Development server with HMR
-npm run dev
+The dev environment is provisioned by Nix (see [ADR-010](docs/adr/010-nix-only-dev-environment.md)). With `direnv` and `nix-direnv` installed, entering the directory loads the environment automatically; otherwise run `nix develop`.
 
-# Production build
-npm run build
+Every workflow has a Nix entry point (canonical) and an `npm run` alias (compatibility). See [ADR-011](docs/adr/011-nix-task-surface.md).
 
-# Lint code
-npm run lint
+| Workflow | Nix (canonical) | npm (alias) |
+|---|---|---|
+| Dev server (HMR) | `nix run .#dev` | `npm run dev` |
+| Production build | `nix run .#build` | `npm run build` |
+| Build + zip for store | `nix run .#build-zip` | `npm run build:zip` |
+| Lint | `nix run .#lint` | `npm run lint` |
+| Lint platform consistency | `nix run .#lint-platforms` | `npm run lint:platforms` |
+| Format (write) | `nix run .#format` | `npm run format` |
+| Format (check) | `nix run .#format-check` | `npm run format:check` |
+| Test | `nix run .#test` | `npm test` |
+| Test (watch) | `nix run .#test-watch` | `npm run test:watch` |
+| Test with coverage | `nix run .#test-coverage` | `npm run test:coverage` |
+| E2E auth setup | `nix run .#e2e-auth` | `npm run e2e:auth` |
+| E2E selector validation | `nix run .#e2e-selectors` | `npm run e2e:selectors` |
+| E2E selectors (headed) | `nix run .#e2e-selectors-headed` | `npm run e2e:selectors:headed` |
+| CDP daemon | `nix run .#e2e-daemon -- <start\|stop\|status>` | `npm run e2e:daemon:<sub>` |
 
-# Format code
-npm run format
+> [!NOTE]
+> Nix attribute names cannot contain `:`, so npm script names like `e2e:auth` map to `e2e-auth`. The CDP daemon takes its subcommand as an argument: `nix run .#e2e-daemon -- start`.
 
-# Run tests
-npm test
-
-# Run tests with coverage
-npm run test:coverage
-```
+If `node_modules/` is missing, the Nix wrapper exits with an instruction to run `npm ci` first. Dependency installation is intentionally not auto-run.
 
 ## Architecture
 

--- a/docs/adr/010-nix-only-dev-environment.md
+++ b/docs/adr/010-nix-only-dev-environment.md
@@ -4,7 +4,7 @@
 
 Accepted (2026-05-01).
 
-Supersedes [ADR-009](009-mise-nix-dev-environment.md).
+Supersedes [ADR-009](009-mise-nix-dev-environment.md). Extended by [ADR-011](011-nix-task-surface.md) (2026-05-02).
 
 ## Context
 

--- a/docs/adr/011-nix-task-surface.md
+++ b/docs/adr/011-nix-task-surface.md
@@ -1,0 +1,65 @@
+# ADR-011: Nix as Canonical Task Surface
+
+## Status
+
+Accepted (2026-05-02).
+
+Extends [ADR-010](010-nix-only-dev-environment.md).
+
+## Context
+
+[ADR-010](010-nix-only-dev-environment.md) made `flake.nix` the single source of truth for the **dev environment** (Node toolchain + system deps), replacing `mise`. It deliberately scoped the change to environment provisioning; the **task surface** remained `npm run …` (e.g. `npm run build`, `npm run test`, `npm run e2e:auth`).
+
+The maintainer subsequently asked whether TypeScript execution, transpile, and test workflows could also be expressed through Nix — i.e. whether `nix run .#test` should be a first-class equivalent to `npm run test`.
+
+Three architectural shapes were considered:
+
+- **Option A — Nix `apps` wrap `node_modules/.bin` binaries.** Each script in `package.json` is mirrored as a `pkgs.writeShellApplication` exposed under `apps.<system>.<name>`. Tool binaries (`vite`, `vitest`, `eslint`, `tsc`, `prettier`, `tsx`, `playwright`) continue to be installed by npm into `./node_modules/.bin/`; Nix supplies the runtime (`nodejs_24`, `zip`, `bash`, `coreutils`) and the invocation surface.
+- **Option B — `pkgs.buildNpmPackage` derivation owns `node_modules`.** A Nix derivation produces a hash-pinned `node_modules/` in the Nix store; build/zip become Nix derivations; apps consume the store-built tree. Hermetic, but introduces sandbox-only failure modes (Playwright browser download, Vite/Vitest cache writes, `@crxjs/vite-plugin@2.0.0-beta.23` resolution under sandbox) and an `npmDepsHash` maintenance burden that must be kept in sync with every `package-lock.json` change.
+- **Option C — Hybrid: pin standalone CLIs (typescript, prettier, tsx) at Nix level, leave plugin-coupled tools in npm.** Mixed sources of truth for tool versions; rejected as confusing without addressing the stated goal.
+
+### Verified facts (2026-05-02)
+
+- All 14 npm scripts in `package.json` (`dev`, `build`, `build:zip`, `lint`, `lint:platforms`, `format`, `format:check`, `test`, `test:watch`, `test:coverage`, `e2e:auth`, `e2e:selectors`, `e2e:selectors:headed`, `e2e:daemon`) reduce to invocations of binaries already present in `node_modules/.bin/` after `npm ci`.
+- `pkgs.writeShellApplication` (nixpkgs-25.11-darwin) provides the wrapper primitive needed for Option A with no additional inputs.
+- `package.json` `overrides` (`@crxjs/vite-plugin → rollup 2.80.0`, `undici >=7.24.0`) are resolved by npm at lockfile-generation time and are inert at runtime; they are unaffected by Option A.
+- Nix attribute names cannot contain `:`. Script names like `e2e:auth` map to attribute names like `e2e-auth`.
+
+## Decision
+
+Adopt **Option A**. The `flake.nix` `apps` outputs become the **canonical task surface**; `npm run …` continues to work unchanged as a compatibility alias.
+
+### Concrete settings
+
+| Decision | Value | Rationale |
+|---|---|---|
+| Task surface | `nix run .#<name>` for every npm script | Single canonical entry point; works from any directory containing the flake. |
+| Wrapper primitive | `pkgs.writeShellApplication` | Stdlib idiom in nixpkgs; gives `set -euo pipefail` and PATH composition for free. |
+| Script name mapping | `:` → `-` (`e2e:auth` → `e2e-auth`) | Nix attribute-name syntax requirement. Documented in README. |
+| `node_modules/` missing behaviour | Fail with a clear error pointing at `npm ci` | Project rule: "package.json / node_modules に触る操作は必ずユーザー承認を得る". Auto-install rejected for the same reason. |
+| `npm run …` retention | Keep all `package.json` scripts unchanged | Backwards compatibility for muscle memory, IDE integrations, and `husky`/`release-please`. |
+| Tool binary source | `./node_modules/.bin/` (npm-installed) | Plugin-coupled tools (Vite + `@crxjs/vite-plugin` + `vite-plugin-static-copy`, Vitest + `@vitest/coverage-v8`, ESLint + `typescript-eslint`) require Node module resolution from the project root; Nix-store binaries would either lose plugin discovery or require Option B's sandbox-aware setup. |
+| Argument forwarding | `"$@"` in every wrapper | Allows `nix run .#e2e-daemon -- start` and equivalent forms. |
+| CI migration | Deferred (unchanged from ADR-010) | Out of scope. |
+
+## Consequences
+
+### Positive
+
+- **Single canonical surface**: every workflow is invocable through `nix run .#<name>`, consistent with the nix-only philosophy of ADR-010.
+- **Zero risk of plugin-resolution regression**: Option A does not move tool binaries; Vite/Vitest/ESLint plugin discovery is byte-identical to the prior `npm run` path.
+- **Trivial reversibility**: removing `apps` from `flake.nix` reverts the change without touching `package.json` or `node_modules/`.
+- **`npm run` continues to work**, preserving editor integrations, `release-please`, and contributor muscle memory.
+- **No new flake inputs**: `flake.lock` does not change.
+
+### Negative / risks
+
+- **Two sources of truth for tool versions**: Node runtime is pinned by Nix (`nodejs_24` via `flake.lock`); every other tool is pinned by npm (`package.json` + `package-lock.json`). Acceptable trade-off: Option B's hermeticity is not worth the Playwright sandbox / `npmDepsHash` maintenance cost on a Chrome extension dev workflow.
+- **Onboarding edge case**: a contributor running `nix run .#test` before `npm ci` hits the missing-`node_modules` error. Mitigated by the wrapper's error message and README.
+- **Naming mismatch (`:` vs `-`)**: documented in README; both surfaces are first-class so contributors can use whichever they remember.
+
+### Out of scope (future work)
+
+- **Option B** (`buildNpmPackage`-based hermetic builds). Would warrant a separate ADR if pursued; revisit if the project's contributor base grows or CI moves to Nix.
+- **CI migration** to `cachix/install-nix-action` + `nix run .#<task>` (deferred per ADR-010).
+- **Auto-install** on missing `node_modules/` (rejected per project rules).

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "gemini2obsidian dev environment (Node toolchain + system deps)";
+  description = "gemini2obsidian dev environment + task surface (Node toolchain + system deps)";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
@@ -16,6 +16,67 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       pkgsFor = system: nixpkgs.legacyPackages.${system};
+
+      # Wrap an npm script as a writeShellApplication. The wrapper:
+      #   - asserts ./node_modules exists (fails with an instructive error if not)
+      #   - prepends node_modules/.bin to PATH
+      #   - execs the script body with all positional args forwarded as "$@"
+      # Tool binaries come from npm-managed node_modules; Nix supplies the
+      # Node runtime and the invocation surface. See ADR-011.
+      mkAppDrv =
+        pkgs: name: script:
+        pkgs.writeShellApplication {
+          inherit name;
+          runtimeInputs = [
+            pkgs.nodejs_24
+            pkgs.zip
+          ];
+          text = ''
+            if [ ! -d "$PWD/node_modules" ]; then
+              echo "error: node_modules/ not found in $PWD" >&2
+              echo "run 'npm ci' first to install dependencies" >&2
+              exit 1
+            fi
+            export PATH="$PWD/node_modules/.bin:$PATH"
+            ${script}
+          '';
+        };
+
+      mkApps =
+        pkgs:
+        let
+          app = name: script: {
+            type = "app";
+            program = "${mkAppDrv pkgs name script}/bin/${name}";
+          };
+        in
+        {
+          dev = app "dev" ''vite "$@"'';
+          build = app "build" ''
+            tsc --noEmit
+            vite build "$@"
+          '';
+          build-zip = app "build-zip" ''
+            tsc --noEmit
+            vite build
+            version=$(node -p "require('./package.json').version")
+            ( cd dist && zip -r "../gemini2obsidian-$version.zip" . -x '*.DS_Store' -x '.vite/*' )
+          '';
+          lint = app "lint" ''
+            eslint src/
+            node scripts/lint-platforms.mjs
+          '';
+          lint-platforms = app "lint-platforms" ''node scripts/lint-platforms.mjs "$@"'';
+          format = app "format" ''prettier --write "src/**/*.{ts,tsx,css,html}" "$@"'';
+          format-check = app "format-check" ''prettier --check "src/**/*.{ts,tsx,css,html}" "$@"'';
+          test = app "test" ''vitest run "$@"'';
+          test-watch = app "test-watch" ''vitest "$@"'';
+          test-coverage = app "test-coverage" ''vitest run --coverage "$@"'';
+          e2e-auth = app "e2e-auth" ''npx tsx e2e/auth/setup-profile.ts "$@"'';
+          e2e-selectors = app "e2e-selectors" ''npx playwright test --config e2e/playwright.config.ts "$@"'';
+          e2e-selectors-headed = app "e2e-selectors-headed" ''npx playwright test --config e2e/playwright.config.ts --headed "$@"'';
+          e2e-daemon = app "e2e-daemon" ''npx tsx e2e/daemon/daemon.ts "$@"'';
+        };
     in
     {
       devShells = forAllSystems (
@@ -35,5 +96,7 @@
           };
         }
       );
+
+      apps = forAllSystems (system: mkApps (pkgsFor system));
     };
 }


### PR DESCRIPTION
## Summary

- Adds 14 `apps.<system>.<name>` outputs to `flake.nix` wrapping every workflow in `package.json` (build, test, lint, format, dev, e2e variants) via `pkgs.writeShellApplication`.
- Tool binaries continue to come from npm-managed `node_modules/.bin/`; Nix supplies the runtime (`nodejs_24`, `zip`) and the canonical invocation surface.
- `npm run …` continues to work unchanged as a compatibility alias.
- Wrapper asserts `node_modules/` exists; otherwise exits with a clear instruction to run `npm ci` (auto-install intentionally rejected per project rules).
- Adds [ADR-011](docs/adr/011-nix-task-surface.md) extending [ADR-010](docs/adr/010-nix-only-dev-environment.md). Documents Option A (chosen), B (`buildNpmPackage`, deferred), C (hybrid, rejected).
- Updates `CLAUDE.md`, `README.md`, `README.ja.md` with a Nix↔npm task table.

Naming note: nix attribute names cannot contain `:`, so `e2e:auth` maps to `e2e-auth`. The CDP daemon takes its subcommand as a positional argument: `nix run .#e2e-daemon -- start`.

## Test plan

- [x] `nix flake check` — all checks pass (warnings about missing `meta` are informational)
- [x] `nix run .#lint-platforms` — passes
- [x] `nix run .#lint` — passes
- [x] `nix run .#format-check` — clean
- [x] `nix run .#test` — 1000/1000 tests pass
- [x] `nix run .#test-coverage` — runs
- [x] `nix run .#test-watch` — starts up
- [x] `nix run .#build` — vite build succeeds
- [x] `nix run .#build-zip` — produces `gemini2obsidian-1.1.6.zip`
- [x] `nix run .#e2e-daemon -- status` — runs (verified arg passthrough)
- [x] Missing `node_modules/` path — wrapper exits with the documented `npm ci` hint
- [x] `npm run …` aliases unchanged
- [x] `package.json` / `package-lock.json` byte-identical to `main`
- [x] CI continues to pass (CI not migrated; uses `actions/setup-node@v4` per ADR-010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)