### PR TITLE
chore(devenv): bump nixpkgs flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777014176,
-        "narHash": "sha256-OzisFv/K6SRIKNOUsR+9Xij/HnS+UqXWhrheEHPJJ3E=",
+        "lastModified": 1777721675,
+        "narHash": "sha256-i9ceHh6k8DUa9Rb0Yab3+TDuqu2gWg9AdndP1f3DCtQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f05c8657c7016fb8cfec9ca06dac066cdeddb91",
+        "rev": "8d9115013055db4f9507d49a3a148ed82c718983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Updates `nixpkgs-25.11-darwin` pin: rev `3f05c86…` → `8d91150…` (lastModified 2026-04-22 → 2026-04-30).
- Same channel; this is a routine patch advance, not a Node major bump.
- `pkgs.nodejs_24` resolves to **24.15.0** (unchanged).
- Produced by `nix flake update nixpkgs`. No edits to `flake.nix`.

## Test plan

- [x] `nix flake check` — all checks pass
- [x] `nix run .#test` — 1000/1000 tests pass
- [x] `nix run .#build` — vite build succeeds
- [x] `nix develop --command node --version` → `v24.15.0` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)