### PR TITLE
refactor: drop unused export on SelectorList type

### DIFF
--- a/src/content/extractors/selectors/types.ts
+++ b/src/content/extractors/selectors/types.ts
@@ -11,7 +11,7 @@
  * CSS selector fallback chain: selectors ordered by stability (HIGH → LOW).
  * queryWithFallback() tries each selector in order until one matches.
  */
-export type SelectorList = readonly string[];
+type SelectorList = readonly string[];
 
 /**
  * Named group of selector fallback chains for a platform.


### PR DESCRIPTION
## Summary

- Drop `export` keyword from `SelectorList` type alias in `src/content/extractors/selectors/types.ts`
- Type remains used internally by `SelectorGroup` in the same file; `SelectorGroup` is still exported and consumed by the e2e smoke test
- Pure compile-time change — no runtime impact, no behavior change

## Test plan

- [x] `npm run test` — 1025/1025 pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run build` — verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)