### PR TITLE
test: add architecture fitness functions for layering, cycles, and platform SSOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 24 to match flake.nix (nodejs_24) and the arch-test dependency
+          # @nielspeter/ts-archunit, which requires Node >=24 (see ADR-012).
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/docs/adr/012-fitness-functions.md
+++ b/docs/adr/012-fitness-functions.md
@@ -1,0 +1,53 @@
+# ADR-012: Architecture Fitness Functions
+
+## Status
+
+Accepted (2026-05-29).
+
+Informed by an internal research note on fitness functions and the design philosophy recorded in [CLAUDE.md](../../CLAUDE.md).
+
+## Context
+
+CLAUDE.md and the global coding-style rules state an explicit design philosophy for this codebase: a one-way layering (`Content → Background → Obsidian`), an extractor pattern, a platform Single Source of Truth (SSOT) anchored in `src/manifest.json`, and maintainability limits (small files, small functions, shallow nesting). Until now these were enforced by convention and review only — nothing failed CI when a layer was crossed, a cycle was introduced, or a platform fell out of sync on the code side.
+
+That research note reframes "is the code adapted to its design intent?" as a set of **machine-checkable rules with pass/fail thresholds** (Neal Ford / Rebecca Parsons, *Building Evolutionary Architectures*). The maintainer asked whether such fitness functions could be generated and used to verify (検収) this codebase.
+
+### Verified facts (2026-05-29)
+
+- The repo already runs an implicit fitness-function suite, wired into `ci.yml` on every PR: ESLint (`no-explicit-any`, `no-console`) **+ `scripts/lint-platforms.mjs`** (platform SSOT across docs/locales/manifest), `prettier --check`, `tsc --noEmit`, Vitest coverage thresholds (85/75/85/85), commitlint, and the Playwright/CDP **selector-validation** harness (a continual/temporal DOM-drift detector).
+- The dependency direction is currently clean: `src/lib` does not import `content`/`background`/`popup`/`offscreen`; `content` reaches `background` only via the Chrome messaging API; extractors import only `base`, `selectors`, `lib`, and `content/markdown-rules`.
+- No automated check covered: (a) the layering direction, (b) import cycles, (c) the **code-side** of the platform SSOT (`AIPlatform` union, `ALLOWED_ORIGINS`, `getExtractor()` routing), (d) the maintainability limits.
+- `@nielspeter/ts-archunit@0.10.0` (Vitest-native, `ts-morph`-based) provides `project()`, `modules().that().resideInFolder().should().notImportFrom()`, and `slices().beFreeOfCycles()`. It requires **Node ≥ 24**. `flake.nix` already uses `nodejs_24` and local dev is on v24; only `.github/workflows/ci.yml` lagged at Node 20.
+
+Two tooling shapes were considered for the dependency-direction/cycle checks:
+
+- **Option A — `@nielspeter/ts-archunit`.** Vitest-native, actively maintained, `ts-morph` analysis, first-class `.warn()`/`.severity()`. Requires Node ≥ 24.
+- **Option B — `tsarch` (MaibornWolff).** The package literally cited in the research note; Node-20 compatible but less maintained, and Vitest 4 / TS 5.3 compatibility was unverifiable offline.
+
+## Decision
+
+Adopt **Option A**. Formalize the design philosophy as fitness functions that run inside the existing Vitest + ESLint gates (no new CI stage), per the research note's staged-adoption guidance.
+
+### Concrete settings
+
+| Decision | Value | Rationale |
+|---|---|---|
+| Arch-test library | `@nielspeter/ts-archunit` (devDependency) | Vitest-native, maintained, matches the research note's intent (layering + cycles). |
+| Layering tests | `test/arch/layering.test.ts` | Enforces `lib`/`content`/`background`/`popup`/`offscreen` import direction. |
+| Cycle test | `test/arch/cycles.test.ts` | `slices('src/*/').beFreeOfCycles()` over top-level subsystems. |
+| Code-side SSOT | `test/arch/platform-ssot.test.ts` | Manifest matches ↔ `AIPlatform` union, `ALLOWED_ORIGINS`, `getExtractor()` routing, `host_permissions`. Complements `lint-platforms.mjs` (docs side). |
+| Maintainability limits | ESLint `max-lines` 800, `max-lines-per-function` 50, `max-depth` 4, `complexity` 15 | Codifies CLAUDE.md / coding-style limits. |
+| Limit severity | **`warn` first** | Per the note's staged-threshold advice: surface drift without breaking CI on existing files (e.g. `popup/index.ts` 542 lines). Promote to `error` in a later PR once clean. |
+| CI Node version | `20` → `24` | Required by `@nielspeter/ts-archunit`; also aligns CI with the existing `flake.nix` `nodejs_24` and local toolchain, fixing pre-existing drift. |
+| Wiring | None beyond the above | Vitest auto-collects `test/**/*.test.ts`; ESLint runs under `npm run lint`; `ci.yml` already runs both. |
+
+## Consequences
+
+- **Positive.** Layer violations, import cycles, and code-side platform drift now fail `npm run test`. Maintainability regressions surface as ESLint warnings. The design philosophy is executable, not just documented — ADRs *record* decisions, fitness functions *assure* them.
+- **Negative / cost.** One new devDependency (transitively `ts-morph`, `picomatch`, and an optional `graphql` peer used only by an unused subpath). Arch tests add a `ts-morph` project load (~hundreds of ms) to the suite. The `PLATFORM_IDS` map in the SSOT test is a second place to update when adding a platform — intentional, mirroring `HOST_DISPLAY_NAMES` in `lint-platforms.mjs`.
+- **Follow-up.** Once the codebase is clean against the ESLint limits, promote them from `warn` to `error`. Candidate future fitness functions (deferred, see assessment doc): Chrome-API purity test, sanitization-path invariant, dependency-drift/vuln gate, content-script bundle-size budget.
+
+## Related
+
+- [docs/fitness-functions-assessment.md](../fitness-functions-assessment.md) — principle → fitness-function mapping (the 検収 report).
+- [ADR-005](005-shared-selector-modules.md), [ADR-011](011-nix-task-surface.md).

--- a/docs/fitness-functions-assessment.md
+++ b/docs/fitness-functions-assessment.md
@@ -1,0 +1,43 @@
+# Fitness-Function Assessment (検収)
+
+**Question:** Is this codebase adapted to its original design intent, and can that be verified objectively?
+
+**Answer:** Yes. Each documented design principle maps to a fitness function with a machine-checkable pass/fail. Most already existed (implicitly); [ADR-012](adr/012-fitness-functions.md) adds the missing layering, cycle, code-side SSOT, and maintainability checks. This document is the mapping. Terminology follows *Building Evolutionary Architectures* (Neal Ford / Rebecca Parsons).
+
+## Design principle → fitness function
+
+| # | Design principle (source) | Fitness function | Classification | Status |
+|---|---|---|---|---|
+| 1 | One-way layering: `Content → Background → Obsidian`; `lib` shared base; `popup`/`offscreen` leaves (CLAUDE.md › Architecture) | `test/arch/layering.test.ts` — `modules().resideInFolder().should().notImportFrom()` for each layer | atomic · triggered · static | **New (ADR-012)** |
+| 2 | No architecture erosion via circular coupling | `test/arch/cycles.test.ts` — `slices('src/*/').beFreeOfCycles()` | atomic · triggered · static | **New (ADR-012)** |
+| 3 | Platform SSOT = `manifest.json` matches; code must agree (CLAUDE.md › Adding New Platforms) | `test/arch/platform-ssot.test.ts` (code side: `AIPlatform` union, `ALLOWED_ORIGINS`, `getExtractor()`, `host_permissions`) + `scripts/lint-platforms.mjs` (docs/locales side) | holistic · triggered · static | **New + existing** |
+| 4 | No untyped escape hatches; clean console usage | ESLint `@typescript-eslint/no-explicit-any`, `no-console` | atomic · triggered · static | Existing |
+| 5 | Type safety (strict mode, no type errors) | `tsc --noEmit` (in `build`) | atomic · triggered · static | Existing |
+| 6 | Maintainability: files ≤ 800 lines, functions < 50, nesting ≤ 4, bounded complexity (CLAUDE.md / coding-style) | ESLint `max-lines`, `max-lines-per-function`, `max-depth`, `complexity` (warn-first) | atomic · triggered · dynamic→static | **New (ADR-012)** |
+| 7 | Test confidence | Vitest coverage thresholds 85/75/85/85 | atomic · triggered · static | Existing |
+| 8 | Consistent commit/release hygiene | commitlint (conventional commits) | atomic · triggered · static | Existing |
+| 9 | Consistent formatting | `prettier --check` | atomic · triggered · static | Existing |
+| 10 | DOM selectors keep working as target sites evolve | Playwright + CDP selector-validation harness (`e2e/selectors`) | holistic · continual/temporal · dynamic | Existing |
+
+All triggered functions run in `.github/workflows/ci.yml` on every PR (lint → format → coverage → build); the selector harness runs on demand against live sites.
+
+## What "verification (検収)" looks like
+
+- **Green on `main`** = the codebase currently conforms to principles 1–9.
+- **Plant-violation proof** (done during ADR-012 implementation): adding a `src/lib → src/content` import makes case 1 fail; dropping a platform from `ALLOWED_ORIGINS` makes case 3 fail. The gate demonstrably catches regressions, not just passes vacuously.
+- **Warn-first limits** (principle 6) report current drift without blocking; promotion to `error` is the next ratchet.
+
+## Deferred (candidate future fitness functions)
+
+Scoped out of ADR-012 to keep the change focused; recorded here so the backlog is explicit (the note warns against over-fitting to all `-ilities`):
+
+- **Chrome-API purity** — assert designated pure modules (e.g. `note-generator.ts`, `path-utils.ts`) never reference `chrome.*`, protecting testability. (`messaging`/`storage`/`i18n` legitimately use `chrome`.)
+- **Sanitization-path invariant** — assert extractor HTML always flows through `sanitizeHtml()` (DOMPurify).
+- **Immutability lint** — `no-param-reassign` and related, codifying the immutability rule.
+- **Dependency-drift / vulnerability gate** — `npm audit --audit-level=high` (or osv-scanner) as a temporal gate — the `failBuildOnCVSS` analog.
+- **Content-script bundle-size budget** — regression gate on the built bundle size.
+
+## References
+
+- *Building Evolutionary Architectures* (Ford, Parsons, Kua) — the fitness-functions concept this operationalizes.
+- [ADR-012](adr/012-fitness-functions.md) — the decision and concrete settings.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,13 @@ export default tseslint.config(
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error', 'info', 'debug'] }],
+      // Fitness functions for maintainability (CLAUDE.md / coding-style limits).
+      // Warn-first per ADR-012: surfaces drift without breaking CI on existing
+      // files; promote to 'error' in a later PR once the codebase is clean.
+      'max-lines': ['warn', { max: 800, skipBlankLines: true, skipComments: true }],
+      'max-lines-per-function': ['warn', { max: 50, skipBlankLines: true, skipComments: true }],
+      'max-depth': ['warn', 4],
+      complexity: ['warn', 15],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/config-conventional": "^20.3.1",
         "@crxjs/vite-plugin": "^2.0.0-beta.23",
         "@eslint/js": "^10.0.1",
+        "@nielspeter/ts-archunit": "^0.10.0",
         "@playwright/test": "^1.58.2",
         "@types/chrome": "^0.0.268",
         "@types/jsdom": "^27.0.0",
@@ -1413,6 +1414,44 @@
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/@nielspeter/ts-archunit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@nielspeter/ts-archunit/-/ts-archunit-0.10.0.tgz",
+      "integrity": "sha512-wVg7LvluQ5LjrzSNIuAn9u0kyOPHym4UaXeZAvjxmKdmThrmZN4HY5X+8NyyyHNYNooLjPvuvQMk9z1aR8N69w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4",
+        "ts-morph": "^27.0.2"
+      },
+      "bin": {
+        "ts-archunit": "dist/cli/bin.js"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nielspeter/ts-archunit/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1837,6 +1876,18 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2545,9 +2596,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2686,6 +2737,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4539,6 +4597,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5143,6 +5208,17 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/tslib": {
@@ -6156,9 +6232,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@commitlint/config-conventional": "^20.3.1",
     "@crxjs/vite-plugin": "^2.0.0-beta.23",
     "@eslint/js": "^10.0.1",
+    "@nielspeter/ts-archunit": "^0.10.0",
     "@playwright/test": "^1.58.2",
     "@types/chrome": "^0.0.268",
     "@types/jsdom": "^27.0.0",

--- a/test/arch/cycles.test.ts
+++ b/test/arch/cycles.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Fitness function: no circular dependencies between subsystems (ADR-012).
+ *
+ * Assigns every src file to its top-level subsystem and asserts there is no
+ * import cycle between those subsystems. Cyclic coupling is the classic
+ * "architecture erosion" signal the book's beFreeOfCycles() rule guards against.
+ *
+ * Uses assignedFrom() with globstar-prefixed folder globs (matched against
+ * absolute paths). A slice-prefix matching form was found to slice vacuously
+ * during ADR-012 verification, so explicit named slices are used instead.
+ */
+import path from 'node:path';
+import { describe, it } from 'vitest';
+import { project, slices } from '@nielspeter/ts-archunit';
+
+const tsconfigPath = path.resolve(import.meta.dirname, '../../tsconfig.json');
+const p = project(tsconfigPath);
+
+const subsystems = {
+  lib: '**/lib/**',
+  content: '**/content/**',
+  background: '**/background/**',
+  popup: '**/popup/**',
+  offscreen: '**/offscreen/**',
+};
+
+describe('architecture: cycles', () => {
+  it('src subsystems must be free of dependency cycles', () => {
+    slices(p)
+      .assignedFrom(subsystems)
+      .should()
+      .beFreeOfCycles()
+      .because('circular coupling between subsystems erodes the architecture')
+      .check();
+  });
+});

--- a/test/arch/layering.test.ts
+++ b/test/arch/layering.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Fitness function: one-way layering (ADR-012).
+ *
+ * Enforces the dependency direction documented in CLAUDE.md:
+ *
+ *     Content Script -> Background -> Obsidian REST API
+ *
+ * `lib/` is the shared base layer; `popup/` and `offscreen/` are leaves.
+ * Cross-layer talk between content and background happens via the Chrome
+ * messaging API at runtime, NOT via static imports, so importing across
+ * those folders is forbidden.
+ *
+ * Glob anchoring: ts-archunit matches resideInFolder()/notImportFrom() against
+ * ABSOLUTE file paths, so folders are matched with globstar-prefixed globs
+ * (a bare non-prefixed folder glob matches nothing — verified during ADR-012).
+ * Planting a `src/lib -> src/content` import makes the first case fail.
+ */
+import path from 'node:path';
+import { describe, it } from 'vitest';
+import { project, modules } from '@nielspeter/ts-archunit';
+
+const tsconfigPath = path.resolve(import.meta.dirname, '../../tsconfig.json');
+const p = project(tsconfigPath);
+
+describe('architecture: layering', () => {
+  it('lib must not import content / background / popup / offscreen', () => {
+    modules(p)
+      .that()
+      .resideInFolder('**/lib/**')
+      .should()
+      .notImportFrom('**/content/**', '**/background/**', '**/popup/**', '**/offscreen/**')
+      .because('lib is the shared base layer and must not depend upward')
+      .check();
+  });
+
+  it('content must not import background / popup / offscreen', () => {
+    modules(p)
+      .that()
+      .resideInFolder('**/content/**')
+      .should()
+      .notImportFrom('**/background/**', '**/popup/**', '**/offscreen/**')
+      .because('content talks to background via Chrome messaging, not imports')
+      .check();
+  });
+
+  it('background must not import content / popup / offscreen', () => {
+    modules(p)
+      .that()
+      .resideInFolder('**/background/**')
+      .should()
+      .notImportFrom('**/content/**', '**/popup/**', '**/offscreen/**')
+      .because('background depends only on lib and its own modules')
+      .check();
+  });
+
+  it('popup must not import content / background / offscreen', () => {
+    modules(p)
+      .that()
+      .resideInFolder('**/popup/**')
+      .should()
+      .notImportFrom('**/content/**', '**/background/**', '**/offscreen/**')
+      .because('popup is a leaf UI layer that depends only on lib')
+      .check();
+  });
+
+  it('extractors must not import background / popup / offscreen', () => {
+    modules(p)
+      .that()
+      .resideInFolder('**/content/extractors/**')
+      .should()
+      .notImportFrom('**/background/**', '**/popup/**', '**/offscreen/**')
+      .because('extractors depend only on base, selectors, and lib')
+      .check();
+  });
+});

--- a/test/arch/platform-ssot.test.ts
+++ b/test/arch/platform-ssot.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Fitness function: platform Single Source of Truth (ADR-012).
+ *
+ * `src/manifest.json` content_scripts[0].matches is the SSOT for supported
+ * platforms (per CLAUDE.md "Adding New Platforms"). This holistic check proves
+ * the CODE side stays in sync with it — complementing scripts/lint-platforms.mjs,
+ * which covers the DOCS side (README, privacy.html, locales).
+ *
+ * For every platform host in the manifest it asserts the host/id is present in:
+ *   - manifest host_permissions
+ *   - ALLOWED_ORIGINS         (src/lib/constants.ts)
+ *   - getExtractor() routing  (src/content/index.ts)
+ *   - the AIPlatform union     (src/lib/types.ts)
+ *
+ * The PLATFORM_IDS map below is the one place a human updates when adding a
+ * platform; a manifest host with no mapping fails fast, mirroring the
+ * HOST_DISPLAY_NAMES guard in lint-platforms.mjs.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (rel: string): string => fs.readFileSync(path.join(root, rel), 'utf-8');
+
+// hostname -> AIPlatform id. Brand ids are not derivable from hostnames.
+const PLATFORM_IDS: Record<string, string> = {
+  'gemini.google.com': 'gemini',
+  'claude.ai': 'claude',
+  'chatgpt.com': 'chatgpt',
+  'www.perplexity.ai': 'perplexity',
+  'notebooklm.google.com': 'notebooklm',
+};
+
+interface Manifest {
+  content_scripts: { matches: string[] }[];
+  host_permissions: string[];
+}
+
+const manifest = JSON.parse(read('src/manifest.json')) as Manifest;
+
+// Derive platform hosts from the SSOT (skip infrastructure hosts like 127.0.0.1).
+const platformHosts = manifest.content_scripts[0].matches
+  .map((m) => m.replace('https://', '').replace('/*', ''))
+  .filter((h) => !h.startsWith('127.'));
+
+describe('architecture: platform SSOT (manifest <-> code)', () => {
+  it('every manifest platform host has a known AIPlatform id', () => {
+    for (const host of platformHosts) {
+      expect(PLATFORM_IDS[host], `add "${host}" to PLATFORM_IDS`).toBeDefined();
+    }
+  });
+
+  it.each(platformHosts)('host %s is consistent across manifest + code', (host) => {
+    const id = PLATFORM_IDS[host];
+
+    // manifest host_permissions
+    expect(manifest.host_permissions).toContain(`https://${host}/*`);
+
+    // ALLOWED_ORIGINS (constants.ts)
+    expect(read('src/lib/constants.ts')).toContain(`'https://${host}'`);
+
+    // getExtractor() routing (content/index.ts)
+    expect(read('src/content/index.ts')).toContain(`hostname === '${host}'`);
+
+    // AIPlatform union (types.ts)
+    const types = read('src/lib/types.ts');
+    const union = /export type AIPlatform\s*=\s*([^;]+);/.exec(types);
+    expect(union, 'AIPlatform union not found in types.ts').not.toBeNull();
+    expect(union?.[1]).toContain(`'${id}'`);
+  });
+});


### PR DESCRIPTION
## Summary

- Add architecture **fitness functions** (per *Building Evolutionary Architectures*) that make the documented design philosophy machine-checkable, wired into the existing Vitest + ESLint gates (no new CI stage).
- `test/arch/layering.test.ts` — enforces the one-way layering (`content → background → Obsidian`; `lib` shared base; `popup`/`offscreen` leaves) via `@nielspeter/ts-archunit`.
- `test/arch/cycles.test.ts` — asserts no import cycles between `src` subsystems.
- `test/arch/platform-ssot.test.ts` — proves the **code side** stays in sync with `manifest.json` (the platform SSOT): `AIPlatform` union, `ALLOWED_ORIGINS`, `getExtractor()` routing, `host_permissions`. Complements `scripts/lint-platforms.mjs` (docs side). Pure `fs`, no extra dep.
- `eslint.config.js` — add `max-lines` (800), `max-lines-per-function` (50), `max-depth` (4), `complexity` (15) as **warnings** (warn-first; promote to error later). Surfaces 9 existing drift points, 0 errors.
- `.github/workflows/ci.yml` — Node `20 → 24` (required by `@nielspeter/ts-archunit`; also aligns CI with `flake.nix`'s existing `nodejs_24`).
- `docs/adr/012-fitness-functions.md` + `docs/fitness-functions-assessment.md` — decision record and the principle → fitness-function mapping (検収 report).

## Verification

- **Red/green proof:** planting a `lib → content` import turns the layering **and** cycle gates red; reverting returns green — confirming they are non-vacuous (this caught and fixed two would-be vacuous gates around ts-archunit's absolute-path glob anchoring).

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors; 9 warnings expected, warn-first)
- [x] `npm run test` passes (1023 tests incl. 12 new arch tests)
- [x] `npm run format:check` passes
- [x] CI green on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)