### PR TITLE
chore: update nixpkgs flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778504458,
-        "narHash": "sha256-w6+HEdP1PoLAoqaFB/jTyXrFuqxuArJ6Lw1bOkecwP0=",
+        "lastModified": 1779975975,
+        "narHash": "sha256-gvG59uDld9KrCg6rD9eQtGGGUbKNf51dngL5SPB/xng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c424a96762240034e0bcda0e1a50dd48e60ab9b",
+        "rev": "4d66785aca79f0b08eb560a82672f55859af59ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Update the `nixpkgs` flake input to a newer revision (`6c424a9…` → `4d66785…`). Lockfile-only change; no source, config, or task-surface changes.

## Test plan

- [x] `nix run .#build` succeeds on the updated nixpkgs
- [x] `nix run .#test` passes
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)