### PR TITLE
refactor: deduplicate extractor hooks and remove wasted work on hot paths

### DIFF
--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -111,17 +111,22 @@ async function handleSaveToObsidian(
   }
 }
 
+/** Chunk size for base64 conversion — bounds String.fromCharCode argument count. */
+const BASE64_CHUNK_SIZE = 8192;
+
 /**
  * Convert string to base64 with proper Unicode handling
- * Service Worker doesn't support Blob/URL.createObjectURL
+ * Service Worker doesn't support Blob/URL.createObjectURL.
+ * Converts in chunks: per-byte concatenation is quadratic on MB-sized notes,
+ * while a single spread of the whole array would overflow the call stack.
  */
 function stringToBase64(str: string): string {
   const bytes = new TextEncoder().encode(str);
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+  const parts: string[] = [];
+  for (let i = 0; i < bytes.length; i += BASE64_CHUNK_SIZE) {
+    parts.push(String.fromCharCode(...bytes.subarray(i, i + BASE64_CHUNK_SIZE)));
   }
-  return btoa(binary);
+  return btoa(parts.join(''));
 }
 
 /**
@@ -248,12 +253,7 @@ export async function handleMultiOutput(
   });
 
   // Extract messagesAppended from obsidian result (append mode)
-  let messagesAppended: number | undefined;
-  settled.forEach((result, index) => {
-    if (result.status === 'fulfilled' && outputs[index] === 'obsidian') {
-      messagesAppended = result.value.messagesAppended;
-    }
-  });
+  const messagesAppended = results.find(r => r.destination === 'obsidian')?.messagesAppended;
 
   return {
     results,

--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -19,6 +19,7 @@ import {
 } from '../lib/constants';
 import type { ExtensionMessage, ObsidianNote } from '../lib/types';
 import { containsPathTraversal } from '../lib/path-utils';
+import { isHttpUrl } from '../lib/validation';
 
 /**
  * Validate message sender (M-02)
@@ -161,15 +162,8 @@ function validateNoteData(note: ObsidianNote): boolean {
   if (typeof note.frontmatter.url !== 'string') {
     return false;
   }
-  if (note.frontmatter.url.length > 0) {
-    try {
-      const parsed = new URL(note.frontmatter.url);
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return false;
-      }
-    } catch {
-      return false;
-    }
+  if (note.frontmatter.url.length > 0 && !isHttpUrl(note.frontmatter.url)) {
+    return false;
   }
 
   return true;

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -11,6 +11,7 @@ import type {
   ConversationMessage,
   ConversationMetadata,
   DeepResearchLinks,
+  DeepResearchSource,
 } from '../../lib/types';
 import { extractErrorMessage } from '../../lib/error-utils';
 import { generateHash } from '../../lib/hash';
@@ -84,11 +85,22 @@ export abstract class BaseExtractor implements IConversationExtractor {
 
   /**
    * Hook: attempt Deep Research extraction before normal extraction.
-   * Override in subclasses that support Deep Research.
+   * Driven by isDeepResearchVisible(); platforms without Deep Research
+   * keep the default false and skip straight to normal extraction.
    * @returns ExtractionResult if Deep Research detected, null otherwise
    */
   protected tryExtractDeepResearch(): ExtractionResult | null {
-    return null;
+    if (!this.isDeepResearchVisible()) return null;
+    console.info(`[G2O] ${this.platformLabel} Deep Research panel detected, extracting report`);
+    return this.buildDeepResearchResult();
+  }
+
+  /**
+   * Hook: whether the platform's Deep Research panel is currently visible.
+   * Override in subclasses that support Deep Research.
+   */
+  protected isDeepResearchVisible(): boolean {
+    return false;
   }
 
   // ========== Settings ==========
@@ -106,8 +118,8 @@ export abstract class BaseExtractor implements IConversationExtractor {
   /**
    * Build a Deep Research extraction result.
    * Shared logic for Claude and Gemini Deep Research modes.
-   * Subclasses override getDeepResearchTitle(), extractDeepResearchContent(),
-   * and extractDeepResearchLinks() for platform-specific DOM access.
+   * Subclasses override getDeepResearchSelectors() and extractSourceList()
+   * for platform-specific DOM access.
    */
   protected buildDeepResearchResult(): ExtractionResult {
     const title = this.getDeepResearchTitle();
@@ -121,7 +133,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
       };
     }
 
-    const titleHash = this.generateHashValue(title);
+    const titleHash = generateHash(title);
     const conversationId = `deep-research-${titleHash}`;
     const links = this.extractDeepResearchLinks();
 
@@ -189,11 +201,31 @@ export abstract class BaseExtractor implements IConversationExtractor {
 
   /**
    * Extract Deep Research link information.
-   * Default returns no sources; DR-supporting subclasses override with
-   * platform-specific source/citation extraction.
+   * Sources come from the extractSourceList() hook; platforms without
+   * Deep Research return no sources.
    */
-  protected extractDeepResearchLinks(): DeepResearchLinks {
-    return { sources: [] };
+  extractDeepResearchLinks(): DeepResearchLinks {
+    return { sources: this.extractSourceList() };
+  }
+
+  /**
+   * Hook: platform-specific Deep Research source/citation extraction.
+   * Override in subclasses that support Deep Research.
+   */
+  protected extractSourceList(): DeepResearchSource[] {
+    return [];
+  }
+
+  /**
+   * Hostname of a URL, or 'unknown' when the URL cannot be parsed.
+   * Shared fallback for Deep Research source domain extraction.
+   */
+  protected extractDomain(url: string): string {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return 'unknown';
+    }
   }
 
   // ========== DOM Sort & Message Build Utilities ==========
@@ -257,7 +289,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
       return { isValid: false, warnings, errors };
     }
 
-    const { messages, type } = result.data;
+    const { messages, type, metadata } = result.data;
     const isDeepResearch = type === 'deep-research';
 
     if (messages.length === 0) {
@@ -271,13 +303,11 @@ export abstract class BaseExtractor implements IConversationExtractor {
 
     // Check for balanced conversation (roughly equal user/assistant messages)
     // Skip for Deep Research which only has assistant content
-    if (!isDeepResearch) {
-      const userCount = messages.filter(m => m.role === 'user').length;
-      const assistantCount = messages.filter(m => m.role === 'assistant').length;
-
-      if (Math.abs(userCount - assistantCount) > 1) {
-        warnings.push('Unbalanced message count - some messages may not have been extracted');
-      }
+    if (
+      !isDeepResearch &&
+      Math.abs(metadata.userMessageCount - metadata.assistantMessageCount) > 1
+    ) {
+      warnings.push('Unbalanced message count - some messages may not have been extracted');
     }
 
     // Check for empty content
@@ -351,11 +381,23 @@ export abstract class BaseExtractor implements IConversationExtractor {
   }
 
   /**
-   * Known platform suffixes in document.title
+   * Known platform suffixes in document.title, derived from PLATFORM_LABELS
+   * so new platforms are picked up automatically.
    * Matches: " - Claude", " | Gemini", " - Google Gemini", " - ChatGPT", etc.
    */
-  private static readonly TITLE_SUFFIX_PATTERN =
-    /\s*[-|]\s*(?:Google\s+)?(?:Gemini|Claude|ChatGPT|Perplexity|NotebookLM)\s*$/i;
+  private static readonly TITLE_SUFFIX_PATTERN = new RegExp(
+    `\\s*[-|]\\s*(?:Google\\s+)?(?:${Object.values(PLATFORM_LABELS).join('|')})\\s*$`,
+    'i'
+  );
+
+  /**
+   * Titles that are nothing but a platform name (lowercased), derived from
+   * PLATFORM_LABELS plus known aliases.
+   */
+  private static readonly PLATFORM_ONLY_TITLES = new Set([
+    'google gemini',
+    ...Object.values(PLATFORM_LABELS).map(label => label.toLowerCase()),
+  ]);
 
   /**
    * Extract conversation title from document.title, stripping platform suffixes.
@@ -369,10 +411,7 @@ export abstract class BaseExtractor implements IConversationExtractor {
     const raw = document.title?.replace(BaseExtractor.TITLE_SUFFIX_PATTERN, '').trim();
     if (!raw) return null;
     // Skip if the remaining text is just the platform name
-    const lower = raw.toLowerCase();
-    if (
-      ['gemini', 'google gemini', 'claude', 'chatgpt', 'perplexity', 'notebooklm'].includes(lower)
-    ) {
+    if (BaseExtractor.PLATFORM_ONLY_TITLES.has(raw.toLowerCase())) {
       return null;
     }
     return raw.substring(0, MAX_CONVERSATION_TITLE_LENGTH);
@@ -391,13 +430,6 @@ export abstract class BaseExtractor implements IConversationExtractor {
       return this.sanitizeText(el.textContent).substring(0, MAX_CONVERSATION_TITLE_LENGTH);
     }
     return fallbackTitle;
-  }
-
-  /**
-   * Generate a hash from content for deduplication
-   */
-  protected generateHashValue(content: string): string {
-    return generateHash(content);
   }
 
   /**

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -10,13 +10,7 @@
 import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { htmlToMarkdownRaw } from '../markdown-rules';
-import type {
-  ConversationMessage,
-  DeepResearchSource,
-  DeepResearchLinks,
-  SyncSettings,
-  ExtractionResult,
-} from '../../lib/types';
+import type { ConversationMessage, DeepResearchSource, SyncSettings } from '../../lib/types';
 import { SELECTORS, DEEP_RESEARCH_SELECTORS, JOINED_SELECTORS } from './selectors/claude';
 
 /**
@@ -97,17 +91,6 @@ export class ClaudeExtractor extends BaseExtractor {
   /** Expose platform selectors to BaseExtractor's DR title/content helpers. */
   protected getDeepResearchSelectors() {
     return DEEP_RESEARCH_SELECTORS;
-  }
-
-  // ========== Deep Research Hook ==========
-
-  /**
-   * Intercept for Deep Research mode before normal extraction
-   */
-  protected tryExtractDeepResearch(): ExtractionResult | null {
-    if (!this.isDeepResearchVisible()) return null;
-    console.info('[G2O] Claude Deep Research panel detected, extracting report');
-    return this.buildDeepResearchResult();
   }
 
   // ========== Message Extraction ==========
@@ -354,13 +337,7 @@ export class ClaudeExtractor extends BaseExtractor {
         title = 'Unknown Title';
       }
 
-      // Extract domain
-      let domain: string;
-      try {
-        domain = new URL(url).hostname;
-      } catch {
-        domain = 'unknown';
-      }
+      const domain = this.extractDomain(url);
 
       const index = sources.length;
       seenUrls.set(url, index);
@@ -374,15 +351,5 @@ export class ClaudeExtractor extends BaseExtractor {
     });
 
     return sources;
-  }
-
-  /**
-   * Extract all Deep Research link information
-   *
-   * API compatibility with GeminiExtractor
-   */
-  extractDeepResearchLinks(): DeepResearchLinks {
-    const sources = this.extractSourceList();
-    return { sources };
   }
 }

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -13,7 +13,6 @@ import type {
   ExtractionResult,
   ConversationMessage,
   DeepResearchSource,
-  DeepResearchLinks,
 } from '../../lib/types';
 
 import { SELECTORS, DEEP_RESEARCH_SELECTORS, COMPUTED_SELECTORS } from './selectors/gemini';
@@ -47,15 +46,6 @@ export class GeminiExtractor extends BaseExtractor {
   }
 
   // ========== Extraction ==========
-
-  /**
-   * Intercept for Deep Research mode before normal extraction
-   */
-  protected tryExtractDeepResearch(): ExtractionResult | null {
-    if (!this.isDeepResearchVisible()) return null;
-    console.info('[G2O] Deep Research panel detected, extracting report');
-    return this.buildDeepResearchResult();
-  }
 
   /**
    * Override extract() so Gemini-specific auto-scroll runs before message
@@ -128,14 +118,7 @@ export class GeminiExtractor extends BaseExtractor {
 
       // Extract domain (fallback to URL parsing) using pre-computed selector
       const domainEl = anchor.querySelector(COMPUTED_SELECTORS.sourceDomain);
-      let domain = domainEl?.textContent?.trim() || '';
-      if (!domain) {
-        try {
-          domain = new URL(url).hostname;
-        } catch {
-          domain = 'unknown';
-        }
-      }
+      const domain = domainEl?.textContent?.trim() || this.extractDomain(url);
 
       sources.push({
         index, // 0-based array index
@@ -146,18 +129,6 @@ export class GeminiExtractor extends BaseExtractor {
     });
 
     return sources;
-  }
-
-  /**
-   * Extract all Deep Research link information
-   * Only extracts source list; inline citations are processed during Markdown conversion
-   */
-  extractDeepResearchLinks(): DeepResearchLinks {
-    const sources = this.extractSourceList();
-
-    return {
-      sources,
-    };
   }
 
   /**

--- a/src/content/extractors/notebooklm.ts
+++ b/src/content/extractors/notebooklm.ts
@@ -186,7 +186,7 @@ export class NotebookLMExtractor extends BaseExtractor {
       // Extract user query from this turn
       const userEl = this.queryWithFallback<HTMLElement>(SELECTORS.userQuery, turn);
       if (userEl) {
-        const content = this.extractUserContent(userEl);
+        const content = this.extractPlainText(userEl);
         if (content) {
           messages.push({
             id: `user-${index}`,
@@ -214,13 +214,6 @@ export class NotebookLMExtractor extends BaseExtractor {
     });
 
     return messages;
-  }
-
-  /**
-   * Extract user message content (plain text)
-   */
-  private extractUserContent(element: HTMLElement): string {
-    return this.extractPlainText(element);
   }
 
   /**

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -97,7 +97,7 @@ export class PerplexityExtractor extends BaseExtractor {
 
     for (const item of sorted) {
       if (item.type === 'user') {
-        const content = this.extractUserContent(item.element);
+        const content = this.extractPlainText(item.element);
         if (content) {
           messages.push({
             id: `user-${userIdx}`,
@@ -159,13 +159,6 @@ export class PerplexityExtractor extends BaseExtractor {
     }
 
     return tagged;
-  }
-
-  /**
-   * Extract user query content (plain text)
-   */
-  private extractUserContent(queryElement: HTMLElement): string {
-    return this.extractPlainText(queryElement);
   }
 
   /**

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -9,7 +9,6 @@ import type { ObsidianApiClient } from './obsidian-api';
 import type { ObsidianNote, ExtensionSettings } from './types';
 import { parseFrontmatter, updateFrontmatter } from './frontmatter-parser';
 import { countExistingMessages, extractTailMessages } from './message-counter';
-import { generateNoteContent } from './note-generator';
 import { formatDateWithTimezone } from './date-utils';
 
 /**
@@ -183,23 +182,19 @@ export function buildAppendContent(
   const newTotal = note.frontmatter.message_count;
   if (newTotal <= existingCount) return null; // No new messages
 
-  // 4. Generate full note content to get formatted new body
-  const fullContent = generateNoteContent(note, settings);
-  const fullParsed = parseFrontmatter(fullContent);
-  if (!fullParsed) return null;
-
-  // 5. Extract tail messages from the full new body
-  const newMessages = extractTailMessages(fullParsed.body, existingCount);
+  // 4. Extract tail messages from the new formatted body
+  // (note.body is exactly what generateNoteContent would embed after the frontmatter)
+  const newMessages = extractTailMessages(note.body, existingCount);
   if (!newMessages) return null;
 
-  // 6. Update frontmatter fields
+  // 5. Update frontmatter fields
   const timezone = settings.templateOptions.timezone ?? 'UTC';
   const updatedRaw = updateFrontmatter(parsed.raw, {
     modified: formatDateWithTimezone(new Date(), timezone),
     message_count: newTotal,
   });
 
-  // 7. Rebuild: updated frontmatter + existing body + separator + new messages
+  // 6. Rebuild: updated frontmatter + existing body + separator + new messages
   const content = updatedRaw + '\n' + parsed.body + '\n\n' + newMessages;
 
   return {

--- a/src/lib/frontmatter-parser.ts
+++ b/src/lib/frontmatter-parser.ts
@@ -102,11 +102,15 @@ export function updateFrontmatter(
   const lines = rawFrontmatter.split('\n');
   const result: string[] = [];
 
+  // Pre-compile one pattern per update key (instead of per line × key)
+  const compiledUpdates = Object.entries(updates).map(([key, value]) => {
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return { key, value, pattern: new RegExp(`^${escapedKey}\\s*:`) };
+  });
+
   for (const line of lines) {
     let replaced = false;
-    for (const [key, value] of Object.entries(updates)) {
-      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const pattern = new RegExp(`^${escapedKey}\\s*:`);
+    for (const { key, value, pattern } of compiledUpdates) {
       if (pattern.test(line)) {
         // Use raw number for numeric values, escape strings
         const formattedValue =

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -53,7 +53,6 @@ export function resolvePathTemplate(path: string, variables: Record<string, stri
  * Date-template tokens recognised by {@link resolvePathTemplate}.
  * Used by {@link getSearchBasePath} to detect the date-templated portion of a path.
  */
-const DATE_TOKENS = ['YYYY', 'YY', 'MM', 'DD'] as const;
 const DATE_TOKEN_PATTERN = /\{(YYYY|YY|MM|DD)\}/;
 
 /**
@@ -94,14 +93,9 @@ export function getDateVariables(date: Date): Record<string, string> {
  */
 export function getSearchBasePath(template: string, variables: Record<string, string>): string {
   const match = DATE_TOKEN_PATTERN.exec(template);
+  // The prefix ends before the first date token, so it can only contain
+  // non-date variables ({platform} etc.) — no filtering needed.
   const prefix = match ? template.slice(0, match.index) : template;
-  // Resolve {platform} (and any other non-date variables) on the prefix only.
-  const filtered: Record<string, string> = {};
-  for (const [key, value] of Object.entries(variables)) {
-    if (!(DATE_TOKENS as readonly string[]).includes(key)) {
-      filtered[key] = value;
-    }
-  }
-  const resolved = resolvePathTemplate(prefix, filtered);
+  const resolved = resolvePathTemplate(prefix, variables);
   return resolved.replace(/\/+$/, '');
 }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -108,6 +108,18 @@ export function validateObsidianUrl(url: string): string {
 }
 
 /**
+ * Check that a string parses as a URL with an http or https scheme.
+ */
+export function isHttpUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Validate API key
  * Conforms to Obsidian REST API implementation:
  * - SHA-256 hash hex string (64 characters)

--- a/test/extractors/base.test.ts
+++ b/test/extractors/base.test.ts
@@ -49,10 +49,6 @@ class TestExtractor extends BaseExtractor {
     return this.queryAllWithFallback(selectors, parent);
   }
 
-  public testGenerateHashValue(content: string): string {
-    return this.generateHashValue(content);
-  }
-
   public testGetPageTitle(): string | null {
     return this.getPageTitle();
   }
@@ -373,24 +369,6 @@ describe('BaseExtractor', () => {
     it('truncates to MAX_CONVERSATION_TITLE_LENGTH', () => {
       document.title = 'a'.repeat(200);
       expect(extractor.testGetPageTitle()!.length).toBe(100);
-    });
-  });
-
-  describe('generateHashValue', () => {
-    it('delegates to hash function', () => {
-      const hash = extractor.testGenerateHashValue('test content');
-      expect(hash).toBe('5b9662eb');
-    });
-
-    it('returns consistent hash', () => {
-      const hash1 = extractor.testGenerateHashValue('same content');
-      const hash2 = extractor.testGenerateHashValue('same content');
-      expect(hash1).toBe(hash2);
-    });
-
-    it('returns 8-character hex string', () => {
-      const hash = extractor.testGenerateHashValue('any content');
-      expect(hash).toMatch(/^[0-9a-f]{8}$/);
     });
   });
 


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup from a 4-angle review (reuse / simplification / efficiency / altitude) of `src/`.

- **Deep Research consolidation**: `BaseExtractor` now owns the full template — `tryExtractDeepResearch()` driven by a new `isDeepResearchVisible()` hook, `extractDeepResearchLinks()` over a new `extractSourceList()` hook, plus a shared `extractDomain()` helper. The byte-identical overrides in `GeminiExtractor` and `ClaudeExtractor` are deleted.
- **Derived platform lists**: `TITLE_SUFFIX_PATTERN` and the platform-only-title set are built from `PLATFORM_LABELS` instead of two hard-coded lists, so new platforms are picked up automatically.
- **Simplifications**: `validate()` reuses `metadata` counts instead of re-filtering messages; trivial `extractUserContent` wrappers inlined in Perplexity/NotebookLM extractors; dead `generateHashValue` wrapper and the dead `DATE_TOKENS` filter in `getSearchBasePath()` removed; new `isHttpUrl()` in `lib/validation.ts` replaces the inline protocol check duplicated in `background/validation.ts`; `messagesAppended` extraction collapsed to `results.find(...)`.
- **Efficiency**: append mode uses `note.body` directly instead of regenerating the full note via `generateNoteContent()` and re-parsing it (saves a ~1 MB round-trip on large conversations); `stringToBase64()` is chunked instead of O(n²) per-byte concatenation; `updateFrontmatter()` pre-compiles one regex per update key instead of per line × key.

Net: −67 lines. No behavior changes intended; the only observable difference is the unified Deep Research log message now including the platform label.

## Test plan

- [x] `npm run build` (tsc) succeeds
- [x] `npm run lint` passes (0 errors; one pre-existing warning fewer than main)
- [x] `npm run test` passes (1020/1020)
- [x] Coverage thresholds met (91.9% stmts / 86.6% branch vs 85/75 thresholds)
- [x] Platform consistency check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)