### PR TITLE
chore: bump nixpkgs input to latest nixpkgs-25.11-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779975975,
-        "narHash": "sha256-gvG59uDld9KrCg6rD9eQtGGGUbKNf51dngL5SPB/xng=",
+        "lastModified": 1781509190,
+        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d66785aca79f0b08eb560a82672f55859af59ca",
+        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bump the `nixpkgs` flake input from rev `4d66785` to `d6df351` (still on the `nixpkgs-25.11-darwin` branch).
- `lastModified` advances `1779975975` → `1781509190`; `narHash` updated accordingly.
- Only `flake.lock` changes; `flake.nix` and the `pkgs.nodejs_24` pin are untouched.

## Context

- This lock bump was produced by a `nix eval` run; releasing it intentionally as a routine dependency refresh.
- Node/npm versions are derived transitively from `nixpkgs.nodejs_24`, so CI must confirm the toolchain still resolves and builds.

## Test plan

- [x] `nix run .#build` (tsc + vite) succeeds with the new lock
- [x] `nix run .#lint` passes
- [x] `nix run .#test` passes
- [x] Confirm `node --version` / `npm --version` under the new lock are acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)