### PR TITLE
fix: bump dompurify to 3.4.11 and undici override to ^7.28.0 for audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.14",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "^3.4.9",
+        "dompurify": "^3.4.11",
         "turndown": "^7.1.2"
       },
       "devDependencies": {
@@ -2681,6 +2681,16 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3058,9 +3068,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5601,16 +5611,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
-      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "e2e:daemon:status": "npx tsx e2e/daemon/daemon.ts status"
   },
   "dependencies": {
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "turndown": "^7.1.2"
   },
   "devDependencies": {
@@ -56,7 +56,7 @@
     "@crxjs/vite-plugin": {
       "rollup": "2.80.0"
     },
-    "undici": ">=7.24.0"
+    "undici": "^7.28.0"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
## Summary

- Bump `dompurify` `^3.4.9` → `^3.4.11`, patching the moderate `ALLOWED_ATTR` pollution advisory (GHSA-cmwh-pvxp-8882) in the shipped runtime HTML sanitizer. Also resolves a stale lockfile (3.4.0 was installed, violating the declared range).
- Bump the `undici` override `>=7.24.0` → `^7.28.0`, patching the high-severity TLS certificate-validation bypass (GHSA-vmh5-mc38-953g) and cross-user cache disclosure (GHSA-pr7r-676h-xcf6). undici is build-toolchain only (`@crxjs/vite-plugin → cheerio → undici`), not shipped in the extension.
- Used `^7.28.0` (not `>=7.28.0`) deliberately: an unbounded `>=` override *forces* the version past cheerio's declared `^7.12.0` range and pulled in undici 8.x; `^7.28.0` keeps the patched 7.x line cheerio supports.
- `npm audit` now reports **0 vulnerabilities**.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run test` passes (1023/1023)
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)