### PR TITLE
fix: capture full Claude response across multiple thinking-status blocks

### DIFF
--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -183,19 +183,33 @@ export class ClaudeExtractor extends BaseExtractor {
    * @see NFR-001-2 in design document
    */
   private extractAssistantContent(element: Element): string {
-    // Grid layout: Extended Thinking or Tool-Use (.row-start-1 + .row-start-2)
-    const responseSection = element.querySelector('.row-start-2');
-    if (responseSection) {
-      // Check if .row-start-2 has markdown content (Extended Thinking / Tool-Use)
-      const markdownInSection = this.queryWithFallback<HTMLElement>(
-        SELECTORS.markdownContent,
-        responseSection
-      );
-      if (markdownInSection) {
-        return sanitizeHtml(markdownInSection.innerHTML);
+    // Grid layout: Extended Thinking or Tool-Use (.row-start-1 + .row-start-2).
+    //
+    // A single response may be split across MULTIPLE sequential grid blocks
+    // (interleaved thinking / tool-use steps), each with its own .row-start-2
+    // content section and the final answer in the last block. Gather every
+    // section's markdown so the answer isn't dropped when it follows earlier
+    // preamble blocks (a prior single-querySelector kept only the first).
+    // Tool-use / thinking summaries live in .row-start-1 headers, so reading
+    // only .row-start-2 keeps status labels out of the response body.
+    const responseSections = element.querySelectorAll<HTMLElement>('.row-start-2');
+    if (responseSections.length > 0) {
+      const parts: string[] = [];
+      responseSections.forEach(section => {
+        const markdownInSection = this.queryWithFallback<HTMLElement>(
+          SELECTORS.markdownContent,
+          section
+        );
+        if (markdownInSection) {
+          const html = sanitizeHtml(markdownInSection.innerHTML);
+          if (html.trim()) parts.push(html);
+        }
+      });
+      if (parts.length > 0) {
+        return parts.join('\n');
       }
-      // .row-start-2 has no markdown content (e.g., thinking-status responses
-      // where content is a grid sibling). Fall through to search entire element.
+      // All .row-start-2 sections empty (e.g., thinking-status responses where
+      // content is a grid sibling). Fall through to search entire element.
     }
 
     // Non-grid fallback or empty .row-start-2: search the entire element

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -15,6 +15,7 @@ import {
   createEmptyClaudeDeepResearchPanel,
   createClaudePageWithToolUse,
   createClaudePageWithThinkingStatus,
+  createClaudePageWithMultiStatusResponse,
 } from '../fixtures/dom-helpers';
 
 describe('ClaudeExtractor', () => {
@@ -1489,6 +1490,55 @@ console.log(x);</code></pre>
       expect(result.success).toBe(true);
       const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
       expect(assistantMsg?.content).toContain('Found several hotels.');
+    });
+  });
+
+  // ========== Multi-block interleaved-thinking response ==========
+  // A single response split across several sequential status/tool-use grid
+  // blocks: each block has its own .row-start-1 status header + .row-start-2
+  // content; the final block holds the full answer. Regression: only the
+  // first block's preamble was captured (see reported Salesforce DOM).
+  describe('Multi-block thinking-status response', () => {
+    it('captures the final answer when it follows intermediate preamble blocks', async () => {
+      createClaudePageWithMultiStatusResponse(
+        '22b989c9-b969-49d2-a726-de037f920d41',
+        'ナレッジ共有の方法を調査して',
+        [
+          { statusText: '検証し、解決策を調査した。', content: '<p>少し調査します。</p>' },
+          { statusText: '後継機能を精査中。', content: '<p>深掘りします。</p>' },
+          { statusText: '体系的に整理中。', content: '<p>確認します。</p>' },
+          {
+            statusText: '多角的に分析し、実装パターンを整理した。',
+            content: '<p>調査結果をまとめます。</p><h3>1. なぜ特殊か</h3><p>二層構造です。</p>',
+          },
+        ]
+      );
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      // The full final answer must be captured (regression: only first block was)
+      expect(assistantMsg?.content).toContain('調査結果をまとめます');
+      expect(assistantMsg?.content).toContain('なぜ特殊か');
+      expect(assistantMsg?.content).toContain('二層構造');
+      // Intermediate preamble text is part of the visible response too
+      expect(assistantMsg?.content).toContain('少し調査します');
+      // Status summary labels (.row-start-1 buttons) must not leak into content
+      expect(assistantMsg?.content).not.toContain('多角的に分析し');
+    });
+
+    it('captures multi-block content without leaking status labels (tool content off)', async () => {
+      createClaudePageWithMultiStatusResponse('22b989c9-b969-49d2-a726-de037f920d42', 'Question', [
+        { statusText: 'Investigated the problem.', content: '<p>Let me look into this.</p>' },
+        { statusText: 'Summarized findings.', content: '<p>Final answer body.</p>' },
+      ]);
+
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      const assistantMsg = result.data?.messages.find(m => m.role === 'assistant');
+      expect(assistantMsg?.content).toContain('Final answer body.');
+      expect(assistantMsg?.content).not.toContain('Investigated the problem');
+      expect(assistantMsg?.content).not.toContain('Summarized findings');
     });
   });
 

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -865,6 +865,64 @@ export function createClaudePageWithThinkingStatus(
   `);
 }
 
+/**
+ * Create a Claude page whose assistant response is split across multiple
+ * sequential thinking-status / tool-use blocks (interleaved-thinking layout).
+ *
+ * Mirrors Claude's real DOM where a single response is composed of several
+ * `.grid.grid-rows-[auto_auto]` step blocks. Each block exposes its own
+ * `.row-start-1` status header and `.row-start-2` content section; the final
+ * block carries the full answer while earlier blocks hold short preambles.
+ *
+ * @see Issue: multi-block responses captured only the first preamble block
+ */
+export function createClaudePageWithMultiStatusResponse(
+  conversationId: string,
+  userContent: string,
+  steps: Array<{ statusText: string; content: string }>
+): void {
+  setClaudeLocation(conversationId);
+
+  const stepBlocks = steps
+    .map(
+      (step, i) => `
+      <div class="${i === 0 ? '' : 'mt-4'}"><div class="grid grid-rows-[auto_auto] min-w-0">
+        <div class="row-start-1 col-start-1 min-w-0">
+          <div class="min-w-0 pl-2 py-1.5">
+            <button class="group/status" aria-expanded="false">
+              <span class="truncate font-base">${escapeHtmlForClaude(step.statusText)}</span>
+            </button>
+          </div>
+        </div>
+        <div class="row-start-2 col-start-1 relative grid isolate min-w-0">
+          <div class="row-start-1 col-start-1 relative z-[2] min-w-0">
+            <div><div class="standard-markdown grid-cols-1 grid">${step.content}</div></div>
+          </div>
+        </div>
+      </div></div>`
+    )
+    .join('\n');
+
+  loadFixture(`
+    <div class="app-container">
+      <div class="conversation-thread">
+        <div data-test-render-count="2" class="group" style="height: auto;">
+          <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
+            <div data-testid="user-message">
+              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(userContent)}</p>
+            </div>
+          </div>
+        </div>
+        <div data-test-render-count="1" class="group" style="height: auto;">
+          <div class="font-claude-response" data-is-streaming="false">
+            <div>${stepBlocks}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `);
+}
+
 // ========== ChatGPT DOM Helpers ==========
 
 /**


### PR DESCRIPTION
## Summary

- Fix `ClaudeExtractor.extractAssistantContent()` dropping most of a response when Claude renders a single answer across **multiple sequential thinking-status / tool-use grid blocks** (interleaved-thinking layout). Previously only the first `.row-start-2` was read, so only the opening preamble (e.g. "少し調査します。") was captured and the full final answer was lost.
- Now gathers **every** `.row-start-2` content section in DOM order and joins their markdown; status summary labels in `.row-start-1` headers stay excluded from the body, and the empty-`.row-start-2` grid-sibling fallback is preserved.
- Add `createClaudePageWithMultiStatusResponse` fixture reproducing the real multi-block DOM, plus 2 regression tests (final answer captured, status labels not leaked).

## Test plan

- [x] `npm run test` passes (1025 tests; Claude suite 96 incl. 2 new regression tests)
- [x] `npm run lint` passes (`src/` 0 errors)
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] `npm run build` succeeds
- [x] (optional) live `e2e:selectors` against a multi-block Claude conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)