### PR TITLE
refactor: extract flatIdScan helper from lookupExistingFile

### DIFF
--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -99,24 +99,42 @@ export async function lookupExistingFile(
     );
     if (recursive) return recursive;
   } else if (resolvedPath) {
-    const files = await client.listFiles(resolvedPath);
-    for (const file of files) {
-      if (file.endsWith(`-${idSuffix}.md`)) {
-        const matchedPath = `${resolvedPath}/${file}`;
-        if (matchedPath === fullPath) continue; // Already checked
-        const content = await client.getFile(matchedPath);
-        if (content !== null) {
-          const parsed = parseFrontmatter(content);
-          if (parsed?.fields.id === expectedId) {
-            return { found: true, path: matchedPath, content, matchType: 'id-scan' };
-          }
-        }
-      }
-    }
+    const flat = await flatIdScan(client, resolvedPath, idSuffix, expectedId, fullPath);
+    if (flat) return flat;
   }
 
   // Step 3: Not found
   return { found: false, path: fullPath, content: '', matchType: 'none' };
+}
+
+/**
+ * Scan a single directory for any `.md` file whose name ends in `-{idSuffix}.md`
+ * and whose frontmatter id matches expectedId. Returns the first match, or null.
+ *
+ * Non-recursive sibling of {@link recursiveIdScan}, used when the vault path
+ * template has no date variables (legacy flat-scan behaviour).
+ */
+async function flatIdScan(
+  client: ObsidianApiClient,
+  dir: string,
+  idSuffix: string,
+  expectedId: string,
+  skipPath: string
+): Promise<FileLookupResult | null> {
+  const files = await client.listFiles(dir);
+  for (const file of files) {
+    if (!file.endsWith(`-${idSuffix}.md`)) continue;
+    const candidatePath = `${dir}/${file}`;
+    if (candidatePath === skipPath) continue; // Already checked as direct match
+    const content = await client.getFile(candidatePath);
+    if (content === null) continue;
+    const parsed = parseFrontmatter(content);
+    if (parsed?.fields.id === expectedId) {
+      return { found: true, path: candidatePath, content, matchType: 'id-scan' };
+    }
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extract the flat (non-recursive) id-scan loop out of `lookupExistingFile()` into a new `flatIdScan()` private helper, mirroring the existing `recursiveIdScan()` sibling
- The `else if (resolvedPath)` branch shrinks from 15 lines (5-deep nesting) to 2 lines; the two scan branches in `lookupExistingFile` are now symmetric (call helper → return on hit)
- Behavior-preserving: zero runtime change, no test files edited

## Why

Clears two ESLint warnings on `src/lib/append-utils.ts` (total project warnings 8 → 6):

- `complexity` 16 → under 15 (`lookupExistingFile`, was line 67)
- `max-depth` 5 → 2 (was line 110)

## Test plan

- [x] `npm run build` (tsc --noEmit) succeeds — 0 errors
- [x] `npm run lint` passes — both `append-utils` warnings gone, count 8 → 6, no new warnings
- [x] `npm run test` passes — 1025/1025, no test edits
- [x] `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)