### PR TITLE
ci: align release build to Node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 24 to match flake.nix (nodejs_24) and ci.yml, so the released
+          # ZIP is built on the same toolchain as local/dev builds. Keeps the
+          # release artifact reproducible/comparable against a local build.
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Pin the `build-and-upload` job in `release-please.yml` to Node 24 (was Node 20)
- Now consistent with `ci.yml` (Node 24) and `flake.nix` (`nodejs_24`)

## Why

The release job built the published ZIP on Node 20 while everything else uses Node 24. A different Node/V8 can yield different Vite/Rollup output, so the released artifact was not reproducibly comparable to a local build. This is a prerequisite for upcoming build-comparison tooling.

## Test plan

- [x] No `node-version: '20'` remains in `.github/workflows/`
- [x] All Node references (workflows + flake.nix) are 24
- [ ] Next release builds successfully on Node 24 (verified on next release-please run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)