### PR TITLE
feat: add build comparison tooling (local vs CI release ZIP)

### DIFF
--- a/docs/adr/013-build-reproducibility-comparison.md
+++ b/docs/adr/013-build-reproducibility-comparison.md
@@ -1,0 +1,95 @@
+# ADR-013: Build Reproducibility — Compare Contents, Not ZIP Bytes
+
+## Status
+
+Accepted (2026-06-20).
+
+## Context
+
+The released Chrome extension ZIP is produced by GitHub Actions
+(`.github/workflows/release-please.yml` → `build-and-upload` job, `npm run
+build:zip`) and attached to the GitHub Release. Maintainers need a way to
+verify that an artifact built **locally** matches the artifact GitHub Actions
+built and shipped — both to catch supply-chain tampering and to detect
+toolchain drift between local and CI.
+
+The naive approach — `sha256(local.zip) == sha256(ci.zip)` — does **not**
+work. `build:zip` uses `zip -r .`, and a ZIP archive is non-deterministic
+across machines for reasons unrelated to the actual build output:
+
+- **Entry order** follows filesystem `readdir` order, which differs between
+  macOS (local) and Linux (CI runner).
+- **Per-file timestamps** (mtime) are stored in each entry.
+- **File mode / uid / gid / OS-creator** metadata is stored per entry.
+
+So two ZIPs of byte-identical `dist/` trees will almost always differ in their
+container bytes. (Reproducible Builds project; see References.)
+
+### Verified facts (2026-06-20)
+
+- `build:zip` (both `package.json` and the `flake.nix` `build-zip` app) runs
+  `cd dist && zip -r ../gemini2obsidian-<version>.zip . -x '*.DS_Store' -x '.vite/*'`.
+  The archive root is the **contents of `dist/`**, so an extracted ZIP is
+  directly comparable to a local `dist/` tree.
+- `vite.config.ts` sets no `entryFileNames`/`chunkFileNames` overrides, so
+  Rollup emits **content-hashed** chunk filenames. Identical content ⇒
+  identical hash in the filename; a content difference surfaces as both a
+  filename and a hash-manifest difference.
+- A local build run twice on the same machine is byte-identical
+  (verified via `--twice`); Vite/Rollup run-to-run nondeterminism
+  (vitejs/vite#13071, #13672) is not currently observed here.
+- The release build originally ran on **Node 20** while local/CI use **Node
+  24**; this was corrected first (see "Prerequisite") because a Node/V8
+  mismatch can change Rollup output and make any comparison meaningless.
+
+## Decision
+
+Compare the **extracted file contents**, not the ZIP container.
+
+The tool (`scripts/compare-build.mjs` + `scripts/lib/build-compare.mjs`,
+exposed as `nix run .#compare-build` / `npm run compare-build`):
+
+1. Builds locally (`npm run build`) into `dist/`.
+2. Obtains the CI artifact via `gh release download <tag> --pattern
+'gemini2obsidian-*.zip'` (or an explicit `--ci-zip <path>`), and extracts
+   it with `unzip`.
+3. Builds a `posix-path → sha256` manifest of each tree, applying the **same
+   exclusions as `build:zip`** (`.vite/`, `*.DS_Store`) to both sides.
+4. Diffs the manifests, classifying every difference as `only-local`,
+   `only-ci`, or `content-mismatch`. Exits non-zero on any difference.
+5. On mismatch, prints a `diffoscope <local> <ci>` hint for human drill-down.
+
+### Rejected alternatives
+
+| Alternative                                                                                     | Why rejected                                                                                                                                                                                        |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sha256` of the whole ZIP                                                                       | Container metadata (order/mtime/perms) differs across OSes; guaranteed false mismatches.                                                                                                            |
+| diffoscope only                                                                                 | Excellent for humans, but not a scriptable pass/fail gate; kept as the drill-down step instead.                                                                                                     |
+| Make `build:zip` byte-reproducible (`SOURCE_DATE_EPOCH` + `zip -X -D` / `strip-nondeterminism`) | Stronger guarantee, but modifies the release-critical path (duplicated in `package.json` **and** `flake.nix`). Deferred as a separate, optional future change; not required for content comparison. |
+
+### Prerequisite
+
+Align the release build to Node 24 (PR: `ci: align release build to Node
+24`). Without matching Node majors, comparison is apples-to-oranges. Do not
+compare against releases built before that change.
+
+## Consequences
+
+- A reliable, scriptable equality gate that ignores ZIP-container noise.
+- `diffoscope` is provided via the Nix `compare-build` app's `runtimeInputs`,
+  so the drill-down works without a separate install. The gate itself
+  (manifest diff) needs no diffoscope.
+- `gh run download` is **not** used: the release job uploads via
+  `softprops/action-gh-release` (a Release asset), not `actions/upload-artifact`.
+  The supported retrieval path is `gh release download`.
+- The exclusion list lives in one place (`isExcluded` in
+  `scripts/lib/build-compare.mjs`) and must be kept in sync with `build:zip`
+  if the latter's `-x` patterns change.
+
+## References
+
+- Reproducible Builds — Tools (diffoscope, strip-nondeterminism, reprotest):
+  <https://reproducible-builds.org/tools/>
+- `SOURCE_DATE_EPOCH` specification:
+  <https://reproducible-builds.org/docs/source-date-epoch/>
+- Vite non-deterministic build reports: vitejs/vite#13071, vitejs/vite#13672

--- a/docs/build-reproducibility.md
+++ b/docs/build-reproducibility.md
@@ -1,0 +1,92 @@
+# Build Reproducibility — Comparing Local vs CI Builds
+
+This guide explains how to verify that the extension ZIP you build locally has
+the same file contents as the ZIP that GitHub Actions builds and attaches to a
+release.
+
+For the design rationale, see
+[ADR-013](adr/013-build-reproducibility-comparison.md).
+
+## TL;DR
+
+```bash
+# Compare your local build against the latest release zip
+nix run .#compare-build              # or: npm run compare-build
+
+# Compare against a specific release tag
+nix run .#compare-build -- --tag v1.2.16
+
+# Compare against a zip you already downloaded
+nix run .#compare-build -- --ci-zip ./gemini2obsidian-1.2.16.zip
+
+# Just check that your own build is deterministic (no network)
+nix run .#compare-build -- --twice
+```
+
+Exit code: `0` = identical, `1` = builds differ, `2` = operational error.
+
+## Why we compare contents, not the ZIP file
+
+You cannot simply compare `sha256` of the two `.zip` files. `build:zip` uses
+`zip -r .`, and a ZIP archive stores, per entry: the filesystem **order**
+(differs macOS vs Linux), **timestamps**, and **file mode / uid / gid**. Two
+zips of byte-identical `dist/` trees will therefore differ in their container
+bytes for reasons that have nothing to do with the build output.
+
+Instead, the tool extracts both archives and compares a **per-file SHA-256
+manifest**, applying the same exclusions as `build:zip` (`.vite/`,
+`*.DS_Store`) to both sides.
+
+## How it works
+
+1. **Build locally** — runs `npm run build` (`tsc --noEmit && vite build`) into
+   `dist/`, exactly as the release pipeline does.
+2. **Fetch the CI artifact** — `gh release download <tag> --pattern
+'gemini2obsidian-*.zip'`, then `unzip` into a temp dir. (The release job
+   uploads a Release **asset** via `softprops/action-gh-release`, so
+   `gh release download` is the correct command — `gh run download` will not
+   find it.)
+3. **Manifest + diff** — both trees become `posix-path → sha256` maps; the
+   diff classifies every difference as `only-local`, `only-ci`, or
+   `content-mismatch`.
+4. **Report** — prints a summary and exits non-zero on any difference.
+
+## When builds differ
+
+The tool prints a drill-down hint:
+
+```text
+Investigate with:
+  diffoscope dist /tmp/g2o-extract-XXXX
+```
+
+Run with `--keep` first so the extracted CI dir is retained, then run the
+`diffoscope` command to see exactly which bytes differ.
+[diffoscope](https://reproducible-builds.org/tools/) recursively unpacks and
+diffs archives and binaries in human-readable form. It is bundled into the Nix
+`compare-build` app, so it is already on `PATH` when you run via `nix`.
+
+### Common causes of a real mismatch
+
+- **Node version drift** — the release build and your local build must use the
+  same Node major (both Node 24; see
+  [ADR-013](adr/013-build-reproducibility-comparison.md) "Prerequisite"). Do
+  not compare against releases built on an older Node.
+- **Different commit** — the report prints your local `HEAD` sha. Make sure it
+  matches the commit the release tag points at; otherwise a content difference
+  is expected.
+- **Dependency drift** — `package-lock.json` must be identical on both sides
+  (CI runs `npm ci` against the tag's lockfile).
+- **Toolchain nondeterminism** — run `--twice` first. If your local build is
+  not even identical to itself, the cause is local (e.g. a Vite/Rollup
+  nondeterminism issue), not CI.
+
+## Limitations
+
+- This verifies **content parity**, not byte-identical zips. Making the ZIP
+  container itself reproducible (`SOURCE_DATE_EPOCH` + `zip -X -D` or
+  `strip-nondeterminism`) is a possible future enhancement; see ADR-013's
+  rejected-alternatives table.
+- The exclusion list (`.vite/`, `*.DS_Store`) is defined in `isExcluded` in
+  `scripts/lib/build-compare.mjs` and must stay in sync with the `-x` patterns
+  in `build:zip` (both `package.json` and the `flake.nix` `build-zip` app).

--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,14 @@
       # Tool binaries come from npm-managed node_modules; Nix supplies the
       # Node runtime and the invocation surface. See ADR-011.
       mkAppDrv =
-        pkgs: name: script:
+        pkgs: name: extraInputs: script:
         pkgs.writeShellApplication {
           inherit name;
           runtimeInputs = [
             pkgs.nodejs_24
             pkgs.zip
-          ];
+          ]
+          ++ extraInputs;
           text = ''
             if [ ! -d "$PWD/node_modules" ]; then
               echo "error: node_modules/ not found in $PWD" >&2
@@ -47,7 +48,12 @@
         let
           app = name: script: {
             type = "app";
-            program = "${mkAppDrv pkgs name script}/bin/${name}";
+            program = "${mkAppDrv pkgs name [ ] script}/bin/${name}";
+          };
+          # Variant for apps that need extra runtime tools on PATH.
+          appWith = name: extraInputs: script: {
+            type = "app";
+            program = "${mkAppDrv pkgs name extraInputs script}/bin/${name}";
           };
         in
         {
@@ -67,6 +73,17 @@
             node scripts/lint-platforms.mjs
           '';
           lint-platforms = app "lint-platforms" ''node scripts/lint-platforms.mjs "$@"'';
+          # Compare a local build against the GitHub Actions release ZIP.
+          # Needs gh (download release artifact), unzip (extract it), and
+          # diffoscope (human-readable drill-down on mismatch). See ADR.
+          compare-build =
+            appWith "compare-build"
+              [
+                pkgs.gh
+                pkgs.unzip
+                pkgs.diffoscope
+              ]
+              ''node scripts/compare-build.mjs "$@"'';
           format = app "format" ''prettier --write "src/**/*.{ts,tsx,css,html}" "$@"'';
           format-check = app "format-check" ''prettier --check "src/**/*.{ts,tsx,css,html}" "$@"'';
           test = app "test" ''vitest run "$@"'';

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:zip": "npm run build && cd dist && zip -r ../gemini2obsidian-$(node -p \"require('../package.json').version\").zip . -x '*.DS_Store' -x '.vite/*' && cd ..",
     "lint": "eslint src/ && node scripts/lint-platforms.mjs",
     "lint:platforms": "node scripts/lint-platforms.mjs",
+    "compare-build": "node scripts/compare-build.mjs",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,html}\"",
     "preview": "vite preview",

--- a/scripts/compare-build.mjs
+++ b/scripts/compare-build.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * compare-build — verify a local build matches the GitHub Actions release ZIP.
+ *
+ * Compares *file contents* (sorted per-file SHA-256), NOT the ZIP container,
+ * because `zip -r` records entry order / timestamps / perms that differ across
+ * machines even when the built files are identical. See
+ * docs/build-reproducibility.md.
+ *
+ * Usage:
+ *   node scripts/compare-build.mjs                 # build locally, compare vs release v<pkg version>
+ *   node scripts/compare-build.mjs --tag v1.2.16   # compare vs a specific release tag
+ *   node scripts/compare-build.mjs --ci-zip a.zip  # compare vs an already-downloaded zip
+ *   node scripts/compare-build.mjs --twice         # build twice locally, check determinism
+ *   node scripts/compare-build.mjs --keep          # keep temp dirs for inspection
+ *
+ * Exit code: 0 when identical, 1 when builds differ, 2 on operational error.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { buildManifest, diffManifests, formatReport } from './lib/build-compare.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DIST = join(ROOT, 'dist');
+
+/**
+ * Parse argv into options.
+ * @param {string[]} argv
+ */
+function parseArgs(argv) {
+  const opts = { twice: false, keep: false, tag: null, ciZip: null, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--twice') opts.twice = true;
+    else if (arg === '--keep') opts.keep = true;
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else if (arg === '--tag') {
+      opts.tag = argv[++i];
+      if (!opts.tag) die('--tag requires a value');
+    } else if (arg === '--ci-zip') {
+      opts.ciZip = argv[++i];
+      if (!opts.ciZip) die('--ci-zip requires a value');
+    } else die(`Unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+/** @param {string} msg */
+function die(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+/** @param {string} cmd @param {string[]} args @param {string} cwd */
+function run(cmd, args, cwd = ROOT) {
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' });
+}
+
+/** @returns {string} the version field from package.json */
+function readVersion() {
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+  return pkg.version;
+}
+
+/** @returns {string} short HEAD sha, or 'unknown' */
+function headSha() {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], { cwd: ROOT }).toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** Build the extension into dist/ exactly as the release pipeline does. */
+function buildLocal() {
+  console.log('▶ building locally (npm run build)…');
+  run('npm', ['run', 'build']);
+}
+
+const tempDirs = [];
+/** @param {string} prefix */
+function makeTemp(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Remove all temp dirs created this run (best effort).
+ * @param {boolean} keep when true, retain dirs and print their paths instead
+ */
+function cleanup(keep) {
+  if (keep && tempDirs.length > 0) {
+    console.log(`\nkept temp dirs:\n  ${tempDirs.join('\n  ')}`);
+    return;
+  }
+  for (const dir of tempDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort — the OS reclaims /tmp eventually
+    }
+  }
+}
+
+/**
+ * Download the release ZIP for a tag into a temp dir and return its path.
+ * @param {string} tag
+ * @returns {string} path to the downloaded .zip
+ */
+function downloadReleaseZip(tag) {
+  const dir = makeTemp('g2o-ci-');
+  console.log(`▶ downloading release ZIP for ${tag} via gh…`);
+  try {
+    run('gh', ['release', 'download', tag, '--pattern', 'gemini2obsidian-*.zip', '--dir', dir]);
+  } catch {
+    // Throw (not die) so main()'s catch cleans up temp dirs and exits 2.
+    throw new Error(
+      `gh release download failed for tag '${tag}'. Is the tag published and gh authenticated?`
+    );
+  }
+  const zips = readdirSync(dir).filter(f => f.endsWith('.zip'));
+  if (zips.length !== 1) {
+    throw new Error(
+      `expected exactly one zip for ${tag}, found ${zips.length}: ${zips.join(', ')}`
+    );
+  }
+  return join(dir, zips[0]);
+}
+
+/**
+ * Extract a zip into a fresh temp dir and return that dir.
+ * @param {string} zipPath
+ * @returns {string}
+ */
+function extractZip(zipPath) {
+  const dir = makeTemp('g2o-extract-');
+  run('unzip', ['-q', '-o', zipPath, '-d', dir]);
+  return dir;
+}
+
+/** Local-vs-local determinism check. */
+function runTwice() {
+  buildLocal();
+  const first = buildManifest(DIST);
+  buildLocal();
+  const second = buildManifest(DIST);
+  const diff = diffManifests(first, second);
+  console.log('\n' + formatReport(diff, { localLabel: 'build #1', ciLabel: 'build #2' }));
+  if (!diff.identical) {
+    console.log(
+      '\nLocal build is NON-deterministic on this machine (see Vite issues #13071/#13672).'
+    );
+  }
+  return diff;
+}
+
+/**
+ * Local-vs-CI content comparison.
+ * @param {{ tag: string | null, ciZip: string | null }} opts
+ */
+function runCompare(opts) {
+  buildLocal();
+  const localManifest = buildManifest(DIST);
+
+  const zipPath = opts.ciZip
+    ? resolve(opts.ciZip)
+    : downloadReleaseZip(opts.tag ?? `v${readVersion()}`);
+  const ciDir = extractZip(zipPath);
+  const ciManifest = buildManifest(ciDir);
+
+  const diff = diffManifests(localManifest, ciManifest);
+  console.log(`\nlocal HEAD: ${headSha()}  (ensure it matches the release tag's commit)`);
+  console.log(formatReport(diff));
+  if (!diff.identical) {
+    console.log(`\nInvestigate with:\n  diffoscope ${DIST} ${ciDir}`);
+    console.log('(re-run with --keep to retain the extracted CI dir for diffoscope)');
+  }
+  return diff;
+}
+
+function printHelp() {
+  console.log(
+    [
+      'compare-build — verify a local build matches the GitHub Actions release ZIP',
+      '',
+      'Usage:',
+      '  compare-build                 compare local build vs release v<package.json version>',
+      '  compare-build --tag <tag>     compare vs a specific release tag',
+      '  compare-build --ci-zip <path> compare vs an already-downloaded zip',
+      '  compare-build --twice         build twice locally, check determinism',
+      '  compare-build --keep          keep temp dirs for diffoscope inspection',
+    ].join('\n')
+  );
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+
+  try {
+    const diff = opts.twice ? runTwice() : runCompare(opts);
+    cleanup(opts.keep);
+    process.exit(diff.identical ? 0 : 1);
+  } catch (err) {
+    // Any operational failure (build, download, extract, FS) → exit 2,
+    // distinct from "builds differ" (exit 1). Always discard temp dirs.
+    cleanup(false);
+    die(err instanceof Error ? err.message : String(err));
+  }
+}
+
+main();

--- a/scripts/lib/build-compare.mjs
+++ b/scripts/lib/build-compare.mjs
@@ -1,0 +1,153 @@
+/**
+ * Build-comparison helpers.
+ *
+ * Pure / filesystem logic shared by `scripts/compare-build.mjs`. Compares the
+ * *contents* of two built artifact trees (a local `dist/` and an extracted CI
+ * ZIP) rather than the ZIP container bytes — because `zip -r` records
+ * filesystem entry order, per-file timestamps, and mode/uid/gid, all of which
+ * differ across machines (macOS vs Linux) even when the built files are
+ * byte-identical. See docs/build-reproducibility.md.
+ *
+ * @typedef {Map<string, string>} Manifest  posix-relative-path -> sha256 hex
+ * @typedef {Object} DiffResult
+ * @property {boolean} identical  true when every file matches
+ * @property {string[]} onlyLocal paths present only in the local tree
+ * @property {string[]} onlyCi    paths present only in the CI tree
+ * @property {string[]} mismatch  paths present in both with differing content
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative } from 'path';
+import { createHash } from 'crypto';
+
+/** Suffix marking macOS Finder metadata files excluded by build:zip. */
+const DS_STORE_SUFFIX = '.DS_Store';
+/** Directory segment for Vite's internal manifest, excluded by build:zip. */
+const VITE_DIR_SEGMENT = '.vite';
+
+/**
+ * Normalize a path to use forward slashes, so comparisons are OS-independent.
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+export function toPosix(p) {
+  return p.replace(/\\/g, '/');
+}
+
+/**
+ * Decide whether a posix-relative path is excluded from the comparison,
+ * mirroring `build:zip`'s `-x '*.DS_Store' -x '.vite/*'` exclusions so the
+ * local tree and the extracted CI ZIP are compared on equal footing.
+ *
+ * Note: the bare directory name `.vite` is also matched (not just `.vite/*`).
+ * This is intentional and slightly stricter than zip's glob: {@link buildManifest}
+ * calls this on directories too, so matching `.vite` lets the walk prune that
+ * subtree entirely instead of recursing into it.
+ *
+ * @param {string} posixPath
+ * @returns {boolean}
+ */
+export function isExcluded(posixPath) {
+  const segments = posixPath.split('/');
+  if (segments.includes(VITE_DIR_SEGMENT)) return true;
+  const base = segments[segments.length - 1];
+  return base.endsWith(DS_STORE_SUFFIX);
+}
+
+/**
+ * Walk a directory tree and build a manifest of `posixRelativePath -> sha256`.
+ * Excluded paths (see {@link isExcluded}) are skipped, including not recursing
+ * into excluded directories.
+ *
+ * @param {string} dir  root directory to scan
+ * @returns {Manifest}
+ */
+export function buildManifest(dir) {
+  /** @type {Manifest} */
+  const manifest = new Map();
+  walk(dir, dir, manifest);
+  return manifest;
+}
+
+/**
+ * @param {string} root
+ * @param {string} current
+ * @param {Manifest} manifest
+ */
+function walk(root, current, manifest) {
+  const entries = readdirSync(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = join(current, entry.name);
+    const relPosix = toPosix(relative(root, full));
+    if (isExcluded(relPosix)) continue;
+    // Only regular files and directories are walked. Symlinks (which a Chrome
+    // extension dist/ does not contain) are intentionally skipped.
+    if (entry.isDirectory()) {
+      walk(root, full, manifest);
+    } else if (entry.isFile()) {
+      const hash = createHash('sha256').update(readFileSync(full)).digest('hex');
+      manifest.set(relPosix, hash);
+    }
+  }
+}
+
+/**
+ * Compare two manifests, classifying every difference.
+ *
+ * @param {Manifest} local
+ * @param {Manifest} ci
+ * @returns {DiffResult}
+ */
+export function diffManifests(local, ci) {
+  /** @type {string[]} */
+  const onlyLocal = [];
+  /** @type {string[]} */
+  const onlyCi = [];
+  /** @type {string[]} */
+  const mismatch = [];
+
+  for (const [path, hash] of local) {
+    if (!ci.has(path)) {
+      onlyLocal.push(path);
+    } else if (ci.get(path) !== hash) {
+      mismatch.push(path);
+    }
+  }
+  for (const path of ci.keys()) {
+    if (!local.has(path)) onlyCi.push(path);
+  }
+
+  onlyLocal.sort();
+  onlyCi.sort();
+  mismatch.sort();
+
+  const identical = onlyLocal.length === 0 && onlyCi.length === 0 && mismatch.length === 0;
+  return { identical, onlyLocal, onlyCi, mismatch };
+}
+
+/**
+ * Render a human-readable summary of a diff result.
+ *
+ * @param {DiffResult} diff
+ * @param {{ localLabel?: string, ciLabel?: string }} [labels]
+ * @returns {string}
+ */
+export function formatReport(diff, labels = {}) {
+  const { localLabel = 'local', ciLabel = 'CI' } = labels;
+  if (diff.identical) {
+    return '✅ Builds are identical — every file content matches.';
+  }
+
+  const lines = ['❌ Builds differ:'];
+  if (diff.mismatch.length > 0) {
+    lines.push(`  content mismatch (${diff.mismatch.length}): ${diff.mismatch.join(', ')}`);
+  }
+  if (diff.onlyLocal.length > 0) {
+    lines.push(`  only in ${localLabel} (${diff.onlyLocal.length}): ${diff.onlyLocal.join(', ')}`);
+  }
+  if (diff.onlyCi.length > 0) {
+    lines.push(`  only in ${ciLabel} (${diff.onlyCi.length}): ${diff.onlyCi.join(', ')}`);
+  }
+  return lines.join('\n');
+}

--- a/test/scripts/build-compare.test.ts
+++ b/test/scripts/build-compare.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for the build-comparison helpers.
+ *
+ * These cover the pure / filesystem logic that powers `scripts/compare-build.mjs`:
+ * path normalization, build:zip exclusion parity, per-file SHA-256 manifests,
+ * and the manifest diff + report formatting.
+ *
+ * User journey: "As a maintainer, I want to know whether the artifact I built
+ * locally has the same file contents as the artifact GitHub Actions built and
+ * zipped, ignoring ZIP-container nondeterminism (entry order, timestamps, perms)."
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createHash } from 'crypto';
+// @ts-expect-error -- plain .mjs build tooling, no type declarations
+import {
+  toPosix,
+  isExcluded,
+  buildManifest,
+  diffManifests,
+  formatReport,
+} from '../../scripts/lib/build-compare.mjs';
+
+const tmpDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'g2o-cmp-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('toPosix', () => {
+  it('converts Windows backslashes to forward slashes', () => {
+    expect(toPosix('assets\\index.js')).toBe('assets/index.js');
+    expect(toPosix('a\\b\\c.txt')).toBe('a/b/c.txt');
+  });
+
+  it('leaves POSIX paths unchanged', () => {
+    expect(toPosix('assets/index.js')).toBe('assets/index.js');
+    expect(toPosix('manifest.json')).toBe('manifest.json');
+  });
+});
+
+describe('isExcluded (build:zip parity: -x "*.DS_Store" -x ".vite/*")', () => {
+  it('excludes anything inside a .vite directory', () => {
+    expect(isExcluded('.vite')).toBe(true);
+    expect(isExcluded('.vite/manifest.json')).toBe(true);
+    expect(isExcluded('nested/.vite/chunk.js')).toBe(true);
+  });
+
+  it('excludes .DS_Store files anywhere', () => {
+    expect(isExcluded('.DS_Store')).toBe(true);
+    expect(isExcluded('assets/.DS_Store')).toBe(true);
+  });
+
+  it('keeps regular build output files', () => {
+    expect(isExcluded('manifest.json')).toBe(false);
+    expect(isExcluded('assets/index-abc123.js')).toBe(false);
+    expect(isExcluded('_locales/en/messages.json')).toBe(false);
+  });
+});
+
+describe('buildManifest', () => {
+  it('produces a posix-keyed sha256 map of all files, recursively', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'manifest.json'), '{"a":1}');
+    mkdirSync(join(dir, 'assets'));
+    writeFileSync(join(dir, 'assets', 'index.js'), 'console.log(1)');
+
+    const manifest = buildManifest(dir);
+
+    expect(manifest.get('manifest.json')).toBe(sha256('{"a":1}'));
+    expect(manifest.get('assets/index.js')).toBe(sha256('console.log(1)'));
+    expect(manifest.size).toBe(2);
+  });
+
+  it('excludes .vite/ and .DS_Store to mirror build:zip', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'manifest.json'), '{}');
+    writeFileSync(join(dir, '.DS_Store'), 'junk');
+    mkdirSync(join(dir, '.vite'));
+    writeFileSync(join(dir, '.vite', 'manifest.json'), 'internal');
+
+    const manifest = buildManifest(dir);
+
+    expect(manifest.has('manifest.json')).toBe(true);
+    expect(manifest.has('.DS_Store')).toBe(false);
+    expect(manifest.has('.vite/manifest.json')).toBe(false);
+    expect(manifest.size).toBe(1);
+  });
+
+  it('detects content differences via differing hashes', () => {
+    const a = makeTempDir();
+    const b = makeTempDir();
+    writeFileSync(join(a, 'f.txt'), 'hello');
+    writeFileSync(join(b, 'f.txt'), 'world');
+
+    expect(buildManifest(a).get('f.txt')).not.toBe(buildManifest(b).get('f.txt'));
+  });
+});
+
+describe('diffManifests', () => {
+  it('reports identical when both manifests match', () => {
+    const local = new Map([
+      ['a.js', 'h1'],
+      ['b.js', 'h2'],
+    ]);
+    const ci = new Map([
+      ['a.js', 'h1'],
+      ['b.js', 'h2'],
+    ]);
+
+    const diff = diffManifests(local, ci);
+
+    expect(diff.identical).toBe(true);
+    expect(diff.onlyLocal).toEqual([]);
+    expect(diff.onlyCi).toEqual([]);
+    expect(diff.mismatch).toEqual([]);
+  });
+
+  it('reports files only present locally', () => {
+    const local = new Map([
+      ['a.js', 'h1'],
+      ['extra.js', 'h9'],
+    ]);
+    const ci = new Map([['a.js', 'h1']]);
+
+    const diff = diffManifests(local, ci);
+
+    expect(diff.identical).toBe(false);
+    expect(diff.onlyLocal).toEqual(['extra.js']);
+    expect(diff.onlyCi).toEqual([]);
+    expect(diff.mismatch).toEqual([]);
+  });
+
+  it('reports files only present in CI', () => {
+    const local = new Map([['a.js', 'h1']]);
+    const ci = new Map([
+      ['a.js', 'h1'],
+      ['only-ci.js', 'h8'],
+    ]);
+
+    const diff = diffManifests(local, ci);
+
+    expect(diff.identical).toBe(false);
+    expect(diff.onlyCi).toEqual(['only-ci.js']);
+    expect(diff.onlyLocal).toEqual([]);
+  });
+
+  it('reports content mismatches (same path, different hash)', () => {
+    const local = new Map([['a.js', 'h1']]);
+    const ci = new Map([['a.js', 'DIFFERENT']]);
+
+    const diff = diffManifests(local, ci);
+
+    expect(diff.identical).toBe(false);
+    expect(diff.mismatch).toEqual(['a.js']);
+  });
+
+  it('sorts each difference list for stable output', () => {
+    const local = new Map([
+      ['z.js', 'h'],
+      ['a.js', 'h'],
+    ]);
+    const ci = new Map<string, string>();
+
+    const diff = diffManifests(local, ci);
+
+    expect(diff.onlyLocal).toEqual(['a.js', 'z.js']);
+  });
+});
+
+describe('formatReport', () => {
+  it('reports success when identical', () => {
+    const report = formatReport({ identical: true, onlyLocal: [], onlyCi: [], mismatch: [] });
+    expect(report).toMatch(/identical/i);
+  });
+
+  it('lists each difference category when builds differ', () => {
+    const report = formatReport({
+      identical: false,
+      onlyLocal: ['extra.js'],
+      onlyCi: ['only-ci.js'],
+      mismatch: ['a.js'],
+    });
+    expect(report).toMatch(/differ/i);
+    expect(report).toContain('a.js');
+    expect(report).toContain('extra.js');
+    expect(report).toContain('only-ci.js');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `nix run .#compare-build` / `npm run compare-build` to verify a local build matches the GitHub Actions release ZIP — by comparing **file contents** (sorted per-file SHA-256), not ZIP-container bytes.

**Why not compare the zips directly?** `zip -r` records filesystem entry order, per-file timestamps, and mode/uid/gid — all of which differ across machines (macOS vs Linux) even when the built files are byte-identical. So the tool extracts both archives and diffs a per-file SHA-256 manifest, applying the same exclusions as `build:zip` (`.vite/`, `*.DS_Store`). See [ADR-013](docs/adr/013-build-reproducibility-comparison.md).

## What's included

- **`scripts/lib/build-compare.mjs`** — pure helpers (`toPosix`, `isExcluded`, `buildManifest`, `diffManifests`, `formatReport`), TDD'd with 15 unit tests
- **`scripts/compare-build.mjs`** — CLI orchestrator: builds locally, downloads the release ZIP via `gh release download`, extracts with `unzip`, diffs manifests. Flags: `--twice` (local determinism self-check), `--tag`, `--ci-zip`, `--keep`. Exit codes: `0` identical, `1` differ, `2` operational error
- **`flake.nix`** — `compare-build` app with `gh`, `unzip`, `diffoscope` in `runtimeInputs` (extended `mkAppDrv` to take per-app extra inputs)
- **`package.json`** — `compare-build` npm alias (ADR-011 dual surface)
- **docs** — `docs/build-reproducibility.md` + ADR-013

## Notes

- **Depends on #275** (align release build to Node 24). Without matching Node majors the comparison is apples-to-oranges; don't compare against releases built on Node 20.
- `gh run download` is intentionally **not** used — the release job uploads a Release asset via `softprops/action-gh-release`, so `gh release download` is the correct path (documented in the ADR).
- Verified: `--twice` reports builds identical (local build is deterministic here); error paths return exit 2; 15 unit tests pass.

## Test plan

- [x] `npm run build` (tsc) succeeds
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (1040 tests, +15 new)
- [x] `prettier --check` clean on new files
- [x] `node scripts/compare-build.mjs --twice` → builds identical, exit 0
- [x] Error paths (`--ci-zip` missing value, bad zip, unknown arg) → exit 2
- [x] `nix eval` confirms the `compare-build` app and existing apps still evaluate

🤖 Generated with [Claude Code](https://claude.com/claude-code)