### PR TITLE
refactor: reduce duplication and hoist regexes in src

### DIFF
--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -8,25 +8,32 @@
 import TurndownService from 'turndown';
 import { MAX_LANG_HINT_LENGTH } from '../lib/constants';
 
+/** Leading blockquote prefix (one or more `> ` markers) to preserve as-is. */
+const BLOCKQUOTE_PREFIX_PATTERN = /^(\s*>\s*)+/;
+/** Inline code segments — capture group means odd split indices are code. */
+const INLINE_CODE_SPLIT_PATTERN = /(`[^`]+`)/;
+/** Angle brackets, including backslash-escaped forms (`\<`, `\>`). */
+const ANGLE_BRACKET_PATTERN = /\\[<>]|[<>]/g;
+
 /**
  * Escape angle brackets in a single line of Markdown text.
  * Preserves blockquote markers and inline code segments.
  */
 function escapeAngleBracketsInLine(line: string): string {
   // 1. Extract blockquote prefix (preserve as-is)
-  const bqMatch = line.match(/^(\s*>\s*)+/);
+  const bqMatch = line.match(BLOCKQUOTE_PREFIX_PATTERN);
   const prefix = bqMatch ? bqMatch[0] : '';
   const rest = line.slice(prefix.length);
 
   // 2. Split by inline code segments (capture group → odd indices are code)
-  const parts = rest.split(/(`[^`]+`)/);
+  const parts = rest.split(INLINE_CODE_SPLIT_PATTERN);
 
   // 3. Escape angle brackets in non-code segments.
   //    Also handle \< and \> (backslash+angle) to prevent incomplete escaping (CodeQL js/incomplete-sanitization).
   const escaped = parts
     .map((part, i) => {
       if (i % 2 === 1) return part; // inline code — preserve
-      return part.replace(/\\[<>]|[<>]/g, match => {
+      return part.replace(ANGLE_BRACKET_PATTERN, match => {
         if (match.length === 2) {
           // \< or \> → escaped backslash + escaped angle bracket
           return '\\\\' + '\\' + match[1];

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -56,8 +56,10 @@ export function validateCalloutType(type: string, defaultType: CalloutType): Cal
  * Validate vault path
  */
 export function validateVaultPath(path: string): string {
+  const trimmed = path.trim();
+
   // Empty path is allowed (saves to vault root)
-  if (!path.trim()) return '';
+  if (!trimmed) return '';
 
   // Path traversal check
   if (containsPathTraversal(path)) {
@@ -69,7 +71,7 @@ export function validateVaultPath(path: string): string {
     throw new Error(`Vault path is too long (max ${MAX_VAULT_PATH_LENGTH} characters)`);
   }
 
-  return path.trim();
+  return trimmed;
 }
 
 /**

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -277,25 +277,20 @@ function populateTimezoneOptions(): void {
   }
 }
 
+/** Toggle a settings group's visibility via inline display style. */
+function setGroupVisible(group: HTMLElement, visible: boolean): void {
+  group.style.display = visible ? '' : 'none';
+}
+
 /**
  * Show/hide timezone dropdown based on includeDates checkbox
  */
 function updateTimezoneVisibility(): void {
-  const group = elements.timezoneGroup;
-  if (elements.includeDates.checked) {
-    group.style.display = '';
-  } else {
-    group.style.display = 'none';
-  }
+  setGroupVisible(elements.timezoneGroup, elements.includeDates.checked);
 }
 
 function updateCalloutSettingsVisibility(): void {
-  const group = elements.calloutSettingsGroup;
-  if (elements.messageFormat.value === 'callout') {
-    group.style.display = '';
-  } else {
-    group.style.display = 'none';
-  }
+  setGroupVisible(elements.calloutSettingsGroup, elements.messageFormat.value === 'callout');
 }
 
 /**


### PR DESCRIPTION
## Summary

- `src/lib/validation.ts`: `validateVaultPath()` trimmed the input twice; trim once into a local and reuse it (path-traversal and length checks still run against the raw path to preserve behavior).
- `src/content/markdown-rules.ts`: hoisted three regexes that were recompiled per line inside `escapeAngleBracketsInLine` into named module-scope constants (`BLOCKQUOTE_PREFIX_PATTERN`, `INLINE_CODE_SPLIT_PATTERN`, `ANGLE_BRACKET_PATTERN`).
- `src/popup/index.ts`: extracted a `setGroupVisible()` helper to replace the duplicated `style.display` toggle in `updateTimezoneVisibility` and `updateCalloutSettingsVisibility`.

These are behavior-preserving cleanups surfaced by a `/simplify` review of `src/` (reuse, simplification, efficiency angles).

## Test plan

- [x] `npx tsc --noEmit` succeeds (exit 0)
- [x] `npm run test` passes (1040/1040)
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` succeeds