### PR TITLE
refactor: reuse BaseExtractor helpers in gemini extractor

### DIFF
--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -155,13 +155,7 @@ export class GeminiExtractor extends BaseExtractor {
     }
 
     // Priority 2: First user query text
-    const firstQueryText = this.queryWithFallback<HTMLElement>(SELECTORS.queryTextLine);
-    if (firstQueryText?.textContent) {
-      const title = this.sanitizeText(firstQueryText.textContent);
-      return title.substring(0, MAX_CONVERSATION_TITLE_LENGTH);
-    }
-
-    return 'Untitled Gemini Conversation';
+    return this.getFirstMessageTitle(SELECTORS.queryTextLine, 'Untitled Gemini Conversation');
   }
 
   /**
@@ -268,7 +262,7 @@ export class GeminiExtractor extends BaseExtractor {
     }
 
     // Final fallback: element's full text content
-    return this.sanitizeText(element.textContent || '');
+    return this.extractPlainText(element);
   }
 
   /**


### PR DESCRIPTION
## Summary

- `GeminiExtractor.getTitle()` Priority-2 now calls the inherited `getFirstMessageTitle(SELECTORS.queryTextLine, …)` instead of re-implementing the same `queryWithFallback → sanitizeText → substring → fallback` logic (the form Claude/ChatGPT/Perplexity already use).
- `extractUserQueryContent()` final fallback now calls the inherited `extractPlainText(element)` instead of the equivalent inline `sanitizeText(element.textContent || '')`.
- Net: 2 insertions, 8 deletions; no behavior change — both replacements are provably equivalent to the code they replace.

## Test plan

- [x] `npm run test` passes (1047/1047)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` (eslint) clean on changed file
- [x] `npm run build` succeeds