### PR TITLE
fix: prevent TypeError in message validation for missing note data

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -44,8 +44,16 @@ chrome.runtime.onMessage.addListener(
     }
 
     // Message content validation (M-02)
-    if (!validateMessageContent(message)) {
-      console.warn('[G2O Background] Invalid message content');
+    // A throw here would otherwise escape the listener and leave the sender
+    // hanging without a response, so treat it as invalid content
+    try {
+      if (!validateMessageContent(message)) {
+        console.warn('[G2O Background] Invalid message content');
+        sendResponse({ success: false, error: 'Invalid message content' });
+        return false;
+      }
+    } catch (error) {
+      console.warn('[G2O Background] Message validation threw:', getErrorMessage(error));
       sendResponse({ success: false, error: 'Invalid message content' });
       return false;
     }

--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -78,7 +78,7 @@ export function validateMessageContent(message: ExtensionMessage): boolean {
   }
 
   // Detailed validation for saveToObsidian action
-  if (message.action === 'saveToObsidian' && message.data) {
+  if (message.action === 'saveToObsidian') {
     if (!validateNoteData(message.data)) {
       return false;
     }
@@ -108,7 +108,12 @@ export function validateMessageContent(message: ExtensionMessage): boolean {
 /**
  * Validate note data structure
  */
-function validateNoteData(note: ObsidianNote): boolean {
+function validateNoteData(note: ObsidianNote | undefined): boolean {
+  // Messages arrive as unvalidated JSON: data may be absent despite the type
+  if (!note || typeof note !== 'object') {
+    return false;
+  }
+
   // Required field validation
   if (typeof note.fileName !== 'string' || typeof note.body !== 'string') {
     return false;

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -204,6 +204,59 @@ describe('background/index', () => {
       );
     });
 
+    describe('missing data validation', () => {
+      it('rejects saveToOutputs without data instead of throwing', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          { action: 'saveToOutputs', outputs: ['obsidian'] },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects saveToObsidian without data', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          { action: 'saveToObsidian' },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('responds instead of throwing when message property access throws', () => {
+        const sendResponse = vi.fn();
+        const poisonedMessage = {};
+        Object.defineProperty(poisonedMessage, 'action', {
+          enumerable: true,
+          get() {
+            throw new Error('poisoned getter');
+          },
+        });
+
+        expect(() =>
+          capturedListener(
+            poisonedMessage,
+            validSender as chrome.runtime.MessageSender,
+            sendResponse
+          )
+        ).not.toThrow();
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+    });
+
     describe('saveToObsidian validation', () => {
       const validNote: ObsidianNote = {
         fileName: 'test.md',


### PR DESCRIPTION
## Summary

- Guard `validateNoteData` against missing or non-object note data: a `saveToOutputs` message without `data` previously threw a synchronous TypeError inside the `onMessage` listener, so `sendResponse` never fired and the sender hung
- Validate `saveToObsidian` note data unconditionally: a missing `data` field previously skipped validation entirely and flowed into `handleSave` as `undefined`
- Wrap message-content validation in the listener with try/catch so any future validation throw responds with an error instead of escaping the listener
- Add 3 listener-driven regression tests (written RED-first): missing-data rejection for both actions, and a poisoned-getter message that must not escape the listener

## Test plan

- [x] `npm run test` passes (1072/1072, 3 new)
- [x] `npm run test:coverage` above thresholds (92.2% stmts / 86.8% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)