### PR TITLE
refactor: remove dead message actions and type the offscreen channel

### DIFF
--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -125,39 +125,6 @@ export async function handleSave(
 }
 
 /**
- * Get existing file content from Obsidian
- */
-export async function handleGetFile(
-  settings: ExtensionSettings,
-  fileName: string,
-  vaultPath?: string
-): Promise<{ success: boolean; content?: string; error?: string }> {
-  const client = createObsidianClient(settings);
-  if (isClientError(client)) {
-    return { success: false, error: client.error };
-  }
-
-  try {
-    const path = vaultPath ? `${vaultPath}/${fileName}` : fileName;
-
-    if (containsPathTraversal(path)) {
-      return { success: false, error: 'Invalid file path' };
-    }
-
-    const content = await client.getFile(path);
-
-    if (content === null) {
-      return { success: true, content: undefined };
-    }
-
-    return { success: true, content };
-  } catch (error) {
-    console.error('[G2O Background] Get file failed:', error);
-    return { success: false, error: getErrorMessage(error) };
-  }
-}
-
-/**
  * Test connection to Obsidian REST API
  */
 export async function handleTestConnection(

--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -13,6 +13,7 @@ import type {
   OutputDestination,
   OutputResult,
   MultiOutputResponse,
+  OffscreenClipboardMessage,
 } from '../lib/types';
 
 /** Runtime type guard for offscreen clipboard response */
@@ -192,11 +193,12 @@ async function handleCopyToClipboard(
 
     await ensureOffscreenDocument();
 
-    const response: unknown = await chrome.runtime.sendMessage({
+    const clipboardMessage: OffscreenClipboardMessage = {
       action: 'clipboardWrite',
       target: 'offscreen',
       content,
-    });
+    };
+    const response: unknown = await chrome.runtime.sendMessage(clipboardMessage);
 
     scheduleOffscreenClose();
 

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -6,7 +6,7 @@
 import { getErrorMessage } from '../lib/error-utils';
 import { getSettings, migrateSettings } from '../lib/storage';
 import { validateSender, validateMessageContent } from './validation';
-import { handleSave, handleGetFile, handleTestConnection } from './obsidian-handlers';
+import { handleTestConnection } from './obsidian-handlers';
 import { handleMultiOutput } from './output-handlers';
 import type { ExtensionMessage, ContentScriptSettings, ExtensionSettings } from '../lib/types';
 
@@ -107,14 +107,8 @@ async function handleMessage(
   const settings = await getSettings();
 
   switch (message.action) {
-    case 'saveToObsidian':
-      return handleSave(settings, message.data);
-
     case 'saveToOutputs':
       return handleMultiOutput(message.data, message.outputs, settings);
-
-    case 'getExistingFile':
-      return handleGetFile(settings, message.fileName, message.vaultPath);
 
     case 'testConnection':
       return handleTestConnection(settings);

--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -11,7 +11,6 @@ import {
   MAX_FRONTMATTER_TITLE_LENGTH,
   MAX_TAGS_COUNT,
   MAX_TAG_LENGTH,
-  MAX_VAULT_PATH_LENGTH,
   ALLOWED_ORIGINS,
   VALID_MESSAGE_ACTIONS,
   VALID_OUTPUT_DESTINATIONS,
@@ -57,31 +56,6 @@ export function validateMessageContent(message: ExtensionMessage): boolean {
   // Validate action against whitelist (using centralized constants)
   if (!VALID_MESSAGE_ACTIONS.includes(message.action as (typeof VALID_MESSAGE_ACTIONS)[number])) {
     return false;
-  }
-
-  // Path traversal validation for getExistingFile action
-  if (message.action === 'getExistingFile') {
-    if (typeof message.fileName !== 'string') {
-      return false;
-    }
-    if (containsPathTraversal(message.fileName)) {
-      return false;
-    }
-    if (typeof message.vaultPath === 'string') {
-      if (containsPathTraversal(message.vaultPath)) {
-        return false;
-      }
-      if (message.vaultPath.length > MAX_VAULT_PATH_LENGTH) {
-        return false;
-      }
-    }
-  }
-
-  // Detailed validation for saveToObsidian action
-  if (message.action === 'saveToObsidian') {
-    if (!validateNoteData(message.data)) {
-      return false;
-    }
   }
 
   // Detailed validation for saveToOutputs action

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -115,13 +115,7 @@ export const ALLOWED_ORIGINS = [
  * Valid message actions for background worker (M-02)
  * Whitelist of actions accepted from content scripts
  */
-export const VALID_MESSAGE_ACTIONS = [
-  'getSettings',
-  'getExistingFile',
-  'testConnection',
-  'saveToObsidian',
-  'saveToOutputs',
-] as const;
+export const VALID_MESSAGE_ACTIONS = ['getSettings', 'testConnection', 'saveToOutputs'] as const;
 
 /**
  * Valid output destinations for multi-output operations

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -3,12 +3,7 @@
  * Promise-based wrapper for chrome.runtime.sendMessage
  */
 
-import type {
-  ExtensionMessage,
-  ContentScriptSettings,
-  SaveResponse,
-  MultiOutputResponse,
-} from './types';
+import type { ExtensionMessage, ContentScriptSettings, MultiOutputResponse } from './types';
 
 /** User-friendly message for extension context invalidation */
 const CONTEXT_INVALIDATED_MESSAGE = 'Extension context invalidated. Please reload the page.';
@@ -19,9 +14,7 @@ const CONTEXT_INVALIDATED_MESSAGE = 'Extension context invalidated. Please reloa
 interface MessageResponseMap {
   getSettings: ContentScriptSettings;
   testConnection: { success: boolean; error?: string };
-  saveToObsidian: SaveResponse;
   saveToOutputs: MultiOutputResponse;
-  getExistingFile: string | null;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -239,11 +239,20 @@ export interface TemplateOptions {
  * Message types for chrome.runtime communication
  */
 export type ExtensionMessage =
-  | { action: 'saveToObsidian'; data: ObsidianNote }
   | { action: 'saveToOutputs'; data: ObsidianNote; outputs: OutputDestination[] }
-  | { action: 'getExistingFile'; fileName: string; vaultPath: string }
   | { action: 'getSettings' }
   | { action: 'testConnection' };
+
+/**
+ * Message sent from the background worker to the offscreen document.
+ * Kept separate from ExtensionMessage: the background listener routes
+ * `target: 'offscreen'` messages away before validation.
+ */
+export interface OffscreenClipboardMessage {
+  action: 'clipboardWrite';
+  target: 'offscreen';
+  content: string;
+}
 
 /**
  * Response from background service worker

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -11,13 +11,7 @@
  */
 
 import { extractErrorMessage } from '../lib/error-utils';
-import type { ClipboardWriteResponse } from '../lib/types';
-
-interface ClipboardWriteMessage {
-  action: 'clipboardWrite';
-  target: 'offscreen';
-  content: string;
-}
+import type { ClipboardWriteResponse, OffscreenClipboardMessage } from '../lib/types';
 
 /**
  * Handle clipboard write request using document.execCommand
@@ -50,7 +44,7 @@ function handleClipboardWrite(content: string): boolean {
  */
 chrome.runtime.onMessage.addListener(
   (
-    message: ClipboardWriteMessage,
+    message: OffscreenClipboardMessage,
     sender: chrome.runtime.MessageSender,
     sendResponse: (response: ClipboardWriteResponse) => void
   ) => {

--- a/test/arch/message-senders.test.ts
+++ b/test/arch/message-senders.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Fitness function: no vestigial message actions.
+ *
+ * VALID_MESSAGE_ACTIONS (src/lib/constants.ts) is the whitelist the background
+ * worker accepts. Every whitelisted action must have at least one live sender
+ * in the client layers (src/content/, src/popup/) — an action with handlers
+ * and validation but no sender is dead surface that still carries security
+ * review weight (see the saveToObsidian/getExistingFile removal, analysis
+ * 2026-07-04).
+ *
+ * Senders are detected as `action: '<name>'` object literals, the only form
+ * used with sendMessage() in this codebase.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (rel: string): string => fs.readFileSync(path.join(root, rel), 'utf-8');
+
+/** Collect all .ts sources under a directory, recursively. */
+function collectSources(rel: string): string[] {
+  const abs = path.join(root, rel);
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true, recursive: true })) {
+    if (entry.isFile() && entry.name.endsWith('.ts')) {
+      out.push(fs.readFileSync(path.join(entry.parentPath, entry.name), 'utf-8'));
+    }
+  }
+  return out;
+}
+
+// Extract the whitelist from constants.ts without importing chrome-flavored code.
+const constantsSource = read('src/lib/constants.ts');
+const whitelistMatch = constantsSource.match(
+  /VALID_MESSAGE_ACTIONS\s*=\s*\[([^\]]+)\]/
+);
+if (!whitelistMatch) {
+  throw new Error('VALID_MESSAGE_ACTIONS not found in src/lib/constants.ts');
+}
+const actions = [...whitelistMatch[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+
+const clientSources = [...collectSources('src/content'), ...collectSources('src/popup')];
+
+describe('architecture: message actions have live senders', () => {
+  it('extracts a non-empty whitelist', () => {
+    expect(actions.length).toBeGreaterThan(0);
+  });
+
+  it.each(actions)('action "%s" is sent by at least one client', action => {
+    const sender = new RegExp(`action:\\s*'${action}'`);
+    const hasSender = clientSources.some(src => sender.test(src));
+    expect(
+      hasSender,
+      `"${action}" is whitelisted in VALID_MESSAGE_ACTIONS but no client in ` +
+        `src/content/ or src/popup/ sends it — remove the action or its whitelist entry`
+    ).toBe(true);
+  });
+});

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -219,20 +219,6 @@ describe('background/index', () => {
         });
       });
 
-      it('rejects saveToObsidian without data', () => {
-        const sendResponse = vi.fn();
-        capturedListener(
-          { action: 'saveToObsidian' },
-          validSender as chrome.runtime.MessageSender,
-          sendResponse
-        );
-
-        expect(sendResponse).toHaveBeenCalledWith({
-          success: false,
-          error: 'Invalid message content',
-        });
-      });
-
       it('responds instead of throwing when message property access throws', () => {
         const sendResponse = vi.fn();
         const poisonedMessage = {};
@@ -257,7 +243,7 @@ describe('background/index', () => {
       });
     });
 
-    describe('saveToObsidian validation', () => {
+    describe('note data validation', () => {
       const validNote: ObsidianNote = {
         fileName: 'test.md',
         body: '# Test',
@@ -277,7 +263,11 @@ describe('background/index', () => {
       it('rejects missing fileName', () => {
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: { ...validNote, fileName: undefined } },
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: { ...validNote, fileName: undefined },
+          },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -291,7 +281,7 @@ describe('background/index', () => {
       it('rejects empty fileName', () => {
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: { ...validNote, fileName: '' } },
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: { ...validNote, fileName: '' } },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -305,7 +295,11 @@ describe('background/index', () => {
       it('rejects fileName over 200 chars', () => {
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: { ...validNote, fileName: 'a'.repeat(201) } },
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: { ...validNote, fileName: 'a'.repeat(201) },
+          },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -319,7 +313,11 @@ describe('background/index', () => {
       it('rejects fileName with path traversal (DES-014 H-1)', () => {
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: { ...validNote, fileName: '../../etc/passwd' } },
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: { ...validNote, fileName: '../../etc/passwd' },
+          },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -334,7 +332,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: { ...validNote, fileName: '%2e%2e%2fetc%2fpasswd' },
           },
           validSender as chrome.runtime.MessageSender,
@@ -351,7 +350,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: { fileName: 'test.md', body: 'content', contentHash: 'abc' },
           },
           validSender as chrome.runtime.MessageSender,
@@ -367,7 +367,11 @@ describe('background/index', () => {
       it('rejects body over 1MB', () => {
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: { ...validNote, body: 'a'.repeat(1024 * 1024 + 1) } },
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: { ...validNote, body: 'a'.repeat(1024 * 1024 + 1) },
+          },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -382,7 +386,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: { ...validNote, frontmatter: { ...validNote.frontmatter, source: 'invalid' } },
           },
           validSender as chrome.runtime.MessageSender,
@@ -399,7 +404,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, tags: Array(51).fill('tag') },
@@ -419,7 +425,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, tags: [123, null] },
@@ -439,7 +446,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, tags: ['a'.repeat(101)] },
@@ -459,7 +467,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, tags: [''] },
@@ -479,7 +488,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, url: 'javascript:alert(1)' },
@@ -499,7 +509,8 @@ describe('background/index', () => {
         const sendResponse = vi.fn();
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: {
@@ -523,7 +534,8 @@ describe('background/index', () => {
         // This should NOT be rejected - it should proceed to save
         capturedListener(
           {
-            action: 'saveToObsidian',
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
             data: {
               ...validNote,
               frontmatter: { ...validNote.frontmatter, url: 'https://gemini.google.com/app/123' },
@@ -726,7 +738,7 @@ describe('background/index', () => {
     });
   });
 
-  describe('saveToObsidian handler', () => {
+  describe('obsidian save via saveToOutputs', () => {
     const validSender = { url: `chrome-extension://${chrome.runtime.id}/popup.html` };
     const validNote: ObsidianNote = {
       fileName: 'test.md',
@@ -750,14 +762,19 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: validNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       expect(mockClient.putFile).toHaveBeenCalledWith('AI/Gemini/test.md', expect.any(String));
-      expect(sendResponse).toHaveBeenCalledWith({ success: true, isNewFile: true });
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allSuccessful: true,
+          results: [expect.objectContaining({ destination: 'obsidian', success: true })],
+        })
+      );
     });
 
     it('updates existing file', async () => {
@@ -766,13 +783,18 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: validNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({ success: true, isNewFile: false });
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allSuccessful: true,
+          results: [expect.objectContaining({ destination: 'obsidian', success: true })],
+        })
+      );
     });
 
     it('handles save errors', async () => {
@@ -781,13 +803,24 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: validNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'Server error' });
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allSuccessful: false,
+          results: [
+            expect.objectContaining({
+              destination: 'obsidian',
+              success: false,
+              error: 'Server error',
+            }),
+          ],
+        })
+      );
     });
 
     it('returns error when API key not configured', async () => {
@@ -795,16 +828,24 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: validNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: 'API key not configured',
-      });
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allSuccessful: false,
+          results: [
+            expect.objectContaining({
+              destination: 'obsidian',
+              success: false,
+              error: 'API key not configured',
+            }),
+          ],
+        })
+      );
     });
 
     it('resolves date variables in vault path at save time (local time)', async () => {
@@ -818,7 +859,7 @@ describe('background/index', () => {
 
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: validNote },
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -844,7 +885,7 @@ describe('background/index', () => {
 
         const sendResponse = vi.fn();
         capturedListener(
-          { action: 'saveToObsidian', data: validNote },
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
           validSender as chrome.runtime.MessageSender,
           sendResponse
         );
@@ -857,111 +898,6 @@ describe('background/index', () => {
       } finally {
         vi.useRealTimers();
       }
-    });
-  });
-
-  describe('getExistingFile handler', () => {
-    const validSender = { url: `chrome-extension://${chrome.runtime.id}/popup.html` };
-
-    it('returns file content when exists', async () => {
-      mockClient.getFile.mockResolvedValue('# File Content');
-
-      const sendResponse = vi.fn();
-      capturedListener(
-        { action: 'getExistingFile', fileName: 'test.md', vaultPath: 'AI/Gemini' },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({ success: true, content: '# File Content' });
-    });
-
-    it('returns undefined content when file not found', async () => {
-      mockClient.getFile.mockResolvedValue(null);
-
-      const sendResponse = vi.fn();
-      capturedListener(
-        { action: 'getExistingFile', fileName: 'test.md' },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({ success: true, content: undefined });
-    });
-
-    it('returns error when API key not configured', async () => {
-      mockGetSettings = vi.fn(() => Promise.resolve({ ...defaultSettings, obsidianApiKey: '' }));
-
-      const sendResponse = vi.fn();
-      capturedListener(
-        { action: 'getExistingFile', fileName: 'test.md' },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: 'API key not configured',
-      });
-    });
-
-    it('rejects vaultPath exceeding MAX_VAULT_PATH_LENGTH', () => {
-      const sendResponse = vi.fn();
-      capturedListener(
-        {
-          action: 'getExistingFile',
-          fileName: 'test.md',
-          vaultPath: 'a'.repeat(201),
-        },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: 'Invalid message content',
-      });
-    });
-
-    it('handles getFile errors gracefully', async () => {
-      mockClient.getFile.mockRejectedValue(new Error('Network timeout'));
-
-      const sendResponse = vi.fn();
-      capturedListener(
-        { action: 'getExistingFile', fileName: 'test.md' },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'Network timeout' });
-    });
-
-    it('rejects assembled path with traversal (SEC-04)', async () => {
-      // vaultPath and fileName individually pass validation, but combined they could traverse
-      // This tests the defense-in-depth check on the assembled fullPath
-      mockGetSettings = vi.fn(() =>
-        Promise.resolve({
-          ...defaultSettings,
-          vaultPath: 'AI/../../../etc',
-        })
-      );
-
-      const sendResponse = vi.fn();
-      capturedListener(
-        { action: 'getExistingFile', fileName: 'passwd', vaultPath: 'AI/../../../etc' },
-        validSender as chrome.runtime.MessageSender,
-        sendResponse
-      );
-
-      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: false,
-        error: expect.stringContaining('Invalid'),
-      });
     });
   });
 
@@ -1695,16 +1631,15 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
+      expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBe(2);
-      expect(response.isNewFile).toBe(false);
     });
 
     it('returns messagesAppended: 0 when no new messages', async () => {
@@ -1717,14 +1652,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
+      expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBe(0);
     });
 
@@ -1737,15 +1672,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
-      expect(response.isNewFile).toBe(true);
+      expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBeUndefined();
     });
 
@@ -1757,15 +1691,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
-      expect(response.isNewFile).toBe(true);
+      expect(response.allSuccessful).toBe(true);
     });
 
     it('skips append mode for deep-research type', async () => {
@@ -1779,15 +1712,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: deepResearchNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: deepResearchNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
-      expect(response.isNewFile).toBe(true);
+      expect(response.allSuccessful).toBe(true);
       // Should NOT have messagesAppended (went through overwrite path)
       expect(response.messagesAppended).toBeUndefined();
     });
@@ -1802,15 +1734,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
-      expect(response.isNewFile).toBe(true);
+      expect(response.allSuccessful).toBe(true);
     });
 
     it('uses ID scan when direct path has wrong ID', async () => {
@@ -1830,14 +1761,14 @@ describe('background/index', () => {
 
       const sendResponse = vi.fn();
       capturedListener(
-        { action: 'saveToObsidian', data: appendNote },
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
         validSender as chrome.runtime.MessageSender,
         sendResponse
       );
 
       await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
       const response = sendResponse.mock.calls[0][0];
-      expect(response.success).toBe(true);
+      expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBe(2);
     });
   });

--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -275,11 +275,11 @@ describe('content script messaging', () => {
     });
   });
 
-  describe('saveToObsidian', () => {
-    it('sends saveToObsidian action with note data', async () => {
+  describe('saveToOutputs', () => {
+    it('sends saveToOutputs action with note data', async () => {
       const mockSendMessage = vi.fn().mockResolvedValue({
-        success: true,
-        isNewFile: true,
+        allSuccessful: true,
+        results: [{ destination: 'obsidian', success: true }],
       });
 
       const note = {
@@ -298,26 +298,35 @@ describe('content script messaging', () => {
         },
       };
 
-      const result = await mockSendMessage({ action: 'saveToObsidian', data: note });
-
-      expect(mockSendMessage).toHaveBeenCalledWith({
-        action: 'saveToObsidian',
+      const result = await mockSendMessage({
+        action: 'saveToOutputs',
+        outputs: ['obsidian'],
         data: note,
       });
-      expect(result.success).toBe(true);
-      expect(result.isNewFile).toBe(true);
+
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        action: 'saveToOutputs',
+        outputs: ['obsidian'],
+        data: note,
+      });
+      expect(result.allSuccessful).toBe(true);
+      expect(result.results[0].success).toBe(true);
     });
 
     it('handles save failure', async () => {
       const mockSendMessage = vi.fn().mockResolvedValue({
-        success: false,
-        error: 'Failed to save',
+        allSuccessful: false,
+        results: [{ destination: 'obsidian', success: false, error: 'Failed to save' }],
       });
 
-      const result = await mockSendMessage({ action: 'saveToObsidian', data: {} });
+      const result = await mockSendMessage({
+        action: 'saveToOutputs',
+        outputs: ['obsidian'],
+        data: {},
+      });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Failed to save');
+      expect(result.allSuccessful).toBe(false);
+      expect(result.results[0].error).toBe('Failed to save');
     });
   });
 });

--- a/test/lib/messaging.test.ts
+++ b/test/lib/messaging.test.ts
@@ -78,8 +78,8 @@ describe('sendMessage', () => {
     expect(result).toEqual({ success: true });
   });
 
-  it('handles saveToObsidian action', async () => {
-    const mockResponse = { success: true, filePath: '/path/to/file.md' };
+  it('handles saveToOutputs action', async () => {
+    const mockResponse = { allSuccessful: true, anySuccessful: true, results: [] };
     vi.mocked(chrome.runtime.sendMessage).mockImplementation(
       (message: unknown, callback?: (response: unknown) => void) => {
         if (callback) callback(mockResponse);
@@ -87,10 +87,11 @@ describe('sendMessage', () => {
     );
 
     const result = await sendMessage({
-      action: 'saveToObsidian',
+      action: 'saveToOutputs',
+      outputs: ['obsidian'],
       data: {} as Parameters<typeof sendMessage>[0] extends { data?: infer D } ? D : never,
     } as Parameters<typeof sendMessage>[0]);
-    expect(result).toEqual({ success: true, filePath: '/path/to/file.md' });
+    expect(result).toEqual(mockResponse);
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove the `saveToObsidian` and `getExistingFile` message actions end to end (union, `VALID_MESSAGE_ACTIONS`, `MessageResponseMap`, validation branches, switch cases, `handleGetFile`): both were fully wired but had **zero live senders** — clients only send `saveToOutputs`, and append/existing-file logic runs server-side in `obsidian-handlers`
- Fold the offscreen clipboard channel into the typed protocol: new `OffscreenClipboardMessage` in `lib/types.ts` shared by the sender (`output-handlers.ts`) and the offscreen listener, replacing two ad-hoc declarations with no compile-time link
- Add an architecture fitness test (`test/arch/message-senders.test.ts`, written RED-first — it failed for exactly the two dead actions) asserting every whitelisted action has a live sender in `src/content/` or `src/popup/`
- Port listener tests (note-data validation edge cases, obsidian save scenarios, append mode) to the live `saveToOutputs` path; drop `isNewFile` assertions since that field was only surfaced by the removed channel

Net: −73 lines of production/validation surface, +1 fitness function.

## Test plan

- [x] `npm run test` passes (1069/1069, 50 files)
- [x] `npm run test:coverage` above thresholds (92.2% stmts / 86.7% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] New arch test fails on main (dead actions present), passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)