### PR TITLE
test: include offscreen module in coverage measurement

### DIFF
--- a/test/offscreen/offscreen.test.ts
+++ b/test/offscreen/offscreen.test.ts
@@ -85,7 +85,13 @@ describe('offscreen/offscreen', () => {
       { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
       {
         id: chrome.runtime.id,
-        tab: { id: 1, index: 0, highlighted: false, active: true, pinned: false } as chrome.tabs.Tab,
+        tab: {
+          id: 1,
+          index: 0,
+          highlighted: false,
+          active: true,
+          pinned: false,
+        } as chrome.tabs.Tab,
       } as chrome.runtime.MessageSender,
       sendResponse
     );
@@ -117,5 +123,53 @@ describe('offscreen/offscreen', () => {
     expect(mockTextarea.select).toHaveBeenCalled();
     expect(document.execCommand).toHaveBeenCalledWith('copy');
     expect(sendResponse).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('responds with error when execCommand copy fails', () => {
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn(() => false),
+      writable: true,
+      configurable: true,
+    });
+
+    const sendResponse = vi.fn();
+    capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
+      { id: chrome.runtime.id } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      error: 'execCommand copy failed',
+    });
+  });
+
+  it('responds with error when clipboard textarea is missing', () => {
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
+
+    const sendResponse = vi.fn();
+    capturedListener(
+      { action: 'clipboardWrite', target: 'offscreen', content: 'test' },
+      { id: chrome.runtime.id } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: false,
+      error: 'Clipboard textarea element not found',
+    });
+  });
+
+  it('ignores messages with a different action or target', () => {
+    const sendResponse = vi.fn();
+    const result = capturedListener(
+      { action: 'getSettings' },
+      { id: chrome.runtime.id } as chrome.runtime.MessageSender,
+      sendResponse
+    );
+
+    expect(result).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
         'src/lib/types.ts', // Type definitions only
         'src/popup/index.ts', // Has side effects on import, tested via patterns
         'src/content/index.ts', // Has side effects on import, tested via patterns
-        'src/offscreen/offscreen.ts', // Chrome-specific runtime, cannot test in jsdom
         'test/**/*.ts', // Test infrastructure should not count toward coverage
       ],
       // Final thresholds - achieved 88.5% statements


### PR DESCRIPTION
## Summary

- Remove the stale `src/offscreen/offscreen.ts` coverage exclusion — its comment claimed the module "cannot test in jsdom", but `test/offscreen/offscreen.test.ts` has been importing and exercising the real module all along
- Add 3 branch tests for the previously unasserted paths: `execCommand` copy failure, missing clipboard textarea (throw → catch), and non-clipboard message fallthrough
- `offscreen.ts` now measures **100% lines / branches / functions** (verified via lcov)

## Test plan

- [x] `npm run test:coverage` passes with offscreen included (1075/1075, thresholds green: 92.2% stmts / 86.9% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)