### PR TITLE
fix: harden URL scheme and path traversal validation

### DIFF
--- a/src/content/markdown-deep-research.ts
+++ b/src/content/markdown-deep-research.ts
@@ -15,6 +15,7 @@
 
 import { htmlToMarkdown } from './markdown-rules';
 import { buildSourceMap } from '../lib/source-map';
+import { isHttpUrl } from '../lib/validation';
 import { escapeMarkdownLink } from './extractors/footnotes';
 import type { DeepResearchLinks, DeepResearchSource } from '../lib/types';
 
@@ -30,19 +31,15 @@ const STANDALONE_CITATION_PATTERN =
   /<sup[^>]*?data-turn-source-index="(\d+)"[^>]*?>[\s\S]*?<\/sup>/gi;
 
 /**
- * Sanitize URL to remove dangerous schemes
+ * Sanitize URL for use in footnote links.
+ *
+ * Allowlist (http/https via isHttpUrl) rather than a scheme denylist:
+ * denylists miss unlisted schemes (file:, mailto:, about:, ...) and are
+ * bypassable with whitespace or casing tricks.
  */
 function sanitizeUrl(url: string): string {
-  const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'blob:'];
-  const lowerUrl = url.toLowerCase().trim();
-
-  for (const scheme of dangerousSchemes) {
-    if (lowerUrl.startsWith(scheme)) {
-      return ''; // Return empty for dangerous URLs
-    }
-  }
-
-  return url;
+  const trimmed = url.trim();
+  return isHttpUrl(trimmed) ? trimmed : '';
 }
 
 /**

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -18,8 +18,8 @@ export function containsPathTraversal(path: string): boolean {
   // ../ or ..\ : .. before path separator
   // ..$   : trailing ..
   if (/(?:^|[\\/])\.\.(?:[\\/]|$)/.test(path)) return true;
-  // Detect absolute paths
-  if (path.startsWith('/') || /^[a-zA-Z]:/.test(path)) return true;
+  // Detect absolute paths, including Windows rooted (\foo) and UNC (\\server) forms
+  if (path.startsWith('/') || path.startsWith('\\') || /^[a-zA-Z]:/.test(path)) return true;
   // Detect URL-encoded .. combined with path separators
   if (/(?:^|%2f|%5c)%2e%2e(?:%2f|%5c|$)/i.test(path)) return true;
   return false;

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -910,6 +910,29 @@ describe('convertDeepResearchContent', () => {
     expect(result).toContain('[^1]: XSS');
     expect(result).toContain('[^2]: Data');
   });
+
+  it('rejects non-http URL schemes not on any denylist (allowlist enforcement)', () => {
+    const html = '<p>Text</p>';
+    const links: DeepResearchLinks = {
+      sources: [
+        { index: 0, url: 'file:///etc/passwd', title: 'File', domain: 'localhost' },
+        { index: 1, url: 'mailto:a@b.com', title: 'Mail', domain: 'b.com' },
+        { index: 2, url: '  \tjavascript:alert(1)', title: 'Sneaky', domain: 'bad.com' },
+        { index: 3, url: 'https://safe.com', title: 'Safe', domain: 'safe.com' },
+      ],
+    };
+
+    const result = convertDeepResearchContent(html, links);
+
+    expect(result).not.toContain('file://');
+    expect(result).not.toContain('mailto:');
+    expect(result).not.toContain('javascript:');
+    // Non-http(s) sources fall back to title only
+    expect(result).toContain('[^1]: File');
+    expect(result).toContain('[^2]: Mail');
+    expect(result).toContain('[^3]: Sneaky');
+    expect(result).toContain('[^4]: [Safe](https://safe.com)');
+  });
 });
 
 describe('conversationToNote with Deep Research links', () => {

--- a/test/lib/path-utils.test.ts
+++ b/test/lib/path-utils.test.ts
@@ -24,6 +24,11 @@ describe('containsPathTraversal', () => {
     expect(containsPathTraversal('D:\\Users')).toBe(true);
   });
 
+  it('detects Windows rooted and UNC paths', () => {
+    expect(containsPathTraversal('\\Windows\\System32')).toBe(true);
+    expect(containsPathTraversal('\\\\server\\share')).toBe(true);
+  });
+
   it('detects URL-encoded traversal', () => {
     // The current implementation only detects URL-encoded patterns with path separators
     expect(containsPathTraversal('%2e%2e%2f')).toBe(true);


### PR DESCRIPTION
## Summary

- Replace the Deep Research `sanitizeUrl` scheme **denylist** (`javascript:`, `data:`, `vbscript:`, `blob:`) with the existing `isHttpUrl` **allowlist** — denylists miss unlisted schemes (`file:`, `mailto:`, `about:`, …) and are bypassable with leading whitespace; non-http(s) sources now fall back to title-only footnotes
- Extend `containsPathTraversal` to reject Windows rooted (`\foo`) and UNC (`\\server\share`) paths — it previously caught POSIX absolute and drive-letter paths only
- Both changes written RED-first: new tests failed on the old implementations before the fix

Part of the 2026-07-04 security analysis follow-up (defense-in-depth items; the loopback-URL enforcement was explicitly descoped).

## Test plan

- [x] `npm run test:coverage` passes (1071/1071, thresholds green: 92.2% stmts / 86.7% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)