### PR TITLE
refactor: derive platform metadata from a single registry (ADR-014)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,18 +196,18 @@ source: gemini
 
 ## Adding New Platforms
 
-When adding a new platform extractor:
+When adding a new platform extractor (see [ADR-014](docs/adr/014-platform-registry-ssot.md)):
 
-1. Add platform to union types in `src/lib/types.ts` (`source`, `platform`)
-2. Add platform to `BaseExtractor` in `src/content/extractors/base.ts`
-3. Create new extractor class extending `BaseExtractor`
-4. Add routing in `src/content/index.ts` (`getExtractor()`)
+1. Add the platform to the `AIPlatform` union in `src/lib/types.ts`
+2. Add its entry (`host`, `label`) to `PLATFORM_REGISTRY` in `src/lib/platform-registry.ts` — `VALID_SOURCES`, `ALLOWED_ORIGINS`, and `PLATFORM_LABELS` derive from it automatically
+3. Create the extractor class extending `BaseExtractor`
+4. Add its constructor to `EXTRACTOR_CONSTRUCTORS` and root selectors to `PLATFORM_ROOT_SELECTORS` in `src/content/index.ts` (the compiler enforces both once the union grows)
 5. Update `waitForConversationContainer()` selectors if needed
-6. **Add origin to `ALLOWED_ORIGINS` in `src/background/service-worker.ts`** ← CRITICAL
-7. Update `src/manifest.json`:
+6. Update `src/manifest.json`:
    - `host_permissions`
    - `content_scripts.matches`
-8. Add DOM helpers and tests
+     (`test/arch/platform-ssot.test.ts` guards the manifest ⇄ registry seam)
+7. Add DOM helpers and tests
 
 ## Future Platforms
 

--- a/docs/adr/014-platform-registry-ssot.md
+++ b/docs/adr/014-platform-registry-ssot.md
@@ -1,0 +1,66 @@
+# ADR-014: Platform registry as single source of truth for platform metadata
+
+## Status
+
+Accepted (2026-07-04)
+
+## Context
+
+Supporting a platform requires consistent metadata in several places. Before
+this ADR, each was hand-maintained independently:
+
+- `AIPlatform` union (`src/lib/types.ts`)
+- `VALID_SOURCES` (`src/lib/constants.ts`) — duplicate of the union with **no
+  type relationship**
+- `ALLOWED_ORIGINS` (`src/lib/constants.ts`) — free-standing origin literals
+- `PLATFORM_LABELS` (`src/lib/constants.ts`) — the only one type-linked
+  (`Record<AIPlatform, string>`)
+- `getExtractor()` hostname if-chain (`src/content/index.ts`)
+- `PLATFORM_ROOT_SELECTORS` hostname-keyed map (`src/content/index.ts`)
+
+The `platform-ssot` fitness function (ADR-012) catches divergence at test
+time, but the 2026-07-04 architecture analysis rated this a bandaid: the
+duplication itself makes adding platform #6 an 8-step manual checklist where
+half the steps are re-stating the same three facts (id, hostname, label).
+
+## Decision
+
+Introduce `src/lib/platform-registry.ts` as the single source of truth for
+per-platform metadata:
+
+```ts
+export const PLATFORM_REGISTRY: Record<AIPlatform, PlatformInfo> = {
+  gemini: { host: 'gemini.google.com', label: 'Gemini' },
+  // ...
+};
+```
+
+Key properties:
+
+1. **Compile-time exhaustiveness.** `Record<AIPlatform, PlatformInfo>` means
+   extending the `AIPlatform` union fails to compile until a registry entry
+   exists, and vice versa for consumers keyed by the union
+   (`PLATFORM_ROOT_SELECTORS`, extractor constructor map).
+2. **Derived, not duplicated.** `VALID_SOURCES`, `ALLOWED_ORIGINS`, and
+   `PLATFORM_LABELS` in `constants.ts` are derived from the registry. Origins
+   are derived from hosts (`https://${host}`) — one fact, one place.
+3. **Layering preserved.** The registry is pure data and lives in `lib/`.
+   Extractor **constructors stay in `src/content/index.ts`** in a
+   `Record<AIPlatform, ...>` map: putting classes in a lib registry would
+   create a lib→content dependency and violate the one-way layering enforced
+   by `test/arch/layering.test.ts`.
+4. **Fitness function narrows.** `platform-ssot.test.ts` now guards the
+   manifest ⇄ registry seam (the only edge TypeScript cannot see) plus the
+   derivation structure, instead of pairwise-checking six hand-written lists.
+
+## Consequences
+
+- Adding a platform: extend the `AIPlatform` union, add one registry entry,
+  add the extractor + its constructor/selector map entries (compile-enforced),
+  update the manifest. `CLAUDE.md` "Adding New Platforms" is updated
+  accordingly.
+- `VALID_SOURCES` changes type from a literal tuple to `readonly AIPlatform[]`;
+  `(typeof VALID_SOURCES)[number]` now resolves to `AIPlatform` (semantically
+  identical for existing call sites).
+- The manifest remains hand-maintained (JSON cannot import TypeScript); the
+  fitness function remains the guard for that seam.

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -27,21 +27,38 @@ import {
   MUTATION_DEBOUNCE_DELAY,
 } from '../lib/constants';
 import type {
+  AIPlatform,
   ContentScriptSettings,
   ObsidianNote,
   OutputDestination,
   OutputResult,
   MultiOutputResponse,
 } from '../lib/types';
+import { platformForHost } from '../lib/platform-registry';
 import { throttle } from '../lib/throttle';
 
-/** Platform-specific main content container selectors for optimized observation */
-const PLATFORM_ROOT_SELECTORS: Record<string, string[]> = {
-  'gemini.google.com': ['main', '#app-container'],
-  'claude.ai': ['main', '#__next'],
-  'chatgpt.com': ['main', '#__next'],
-  'www.perplexity.ai': ['main', '#__next'],
-  'notebooklm.google.com': ['main', '#app-container'],
+/**
+ * Platform-specific main content container selectors for optimized observation.
+ * Keyed by AIPlatform so the compiler enforces an entry per platform (ADR-014).
+ */
+const PLATFORM_ROOT_SELECTORS: Record<AIPlatform, string[]> = {
+  gemini: ['main', '#app-container'],
+  claude: ['main', '#__next'],
+  chatgpt: ['main', '#__next'],
+  perplexity: ['main', '#__next'],
+  notebooklm: ['main', '#app-container'],
+};
+
+/**
+ * Extractor constructors per platform. Lives here (not in the lib registry)
+ * so lib/ stays free of content-layer imports (ADR-014).
+ */
+const EXTRACTOR_CONSTRUCTORS: Record<AIPlatform, new () => IConversationExtractor> = {
+  gemini: GeminiExtractor,
+  claude: ClaudeExtractor,
+  chatgpt: ChatGPTExtractor,
+  perplexity: PerplexityExtractor,
+  notebooklm: NotebookLMExtractor,
 };
 
 /** Conversation container selectors to detect when content is ready */
@@ -53,8 +70,8 @@ const CONVERSATION_CONTAINER_SELECTOR =
  * Falls back to document.body if no platform-specific root is found
  */
 function getObservationRoot(): Element {
-  const hostname = window.location.hostname;
-  const selectors = PLATFORM_ROOT_SELECTORS[hostname];
+  const platform = platformForHost(window.location.hostname);
+  const selectors = platform ? PLATFORM_ROOT_SELECTORS[platform] : undefined;
 
   if (selectors) {
     for (const selector of selectors) {
@@ -135,26 +152,10 @@ function waitForConversationContainer(): Promise<void> {
  * @see CodeQL: js/incomplete-url-substring-sanitization
  */
 function getExtractor(): IConversationExtractor | null {
-  const hostname = window.location.hostname;
-
-  // Strict comparison prevents attacks like "evil-gemini.google.com.attacker.com"
-  if (hostname === 'gemini.google.com') {
-    return new GeminiExtractor();
-  }
-  if (hostname === 'claude.ai') {
-    return new ClaudeExtractor();
-  }
-  if (hostname === 'chatgpt.com') {
-    return new ChatGPTExtractor();
-  }
-  if (hostname === 'www.perplexity.ai') {
-    return new PerplexityExtractor();
-  }
-  if (hostname === 'notebooklm.google.com') {
-    return new NotebookLMExtractor();
-  }
-
-  return null;
+  // platformForHost uses strict hostname equality, which prevents attacks
+  // like "evil-gemini.google.com.attacker.com"
+  const platform = platformForHost(window.location.hostname);
+  return platform ? new EXTRACTOR_CONSTRUCTORS[platform]() : null;
 }
 
 // Initialize when DOM is ready

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AIPlatform } from './types';
+import { PLATFORM_REGISTRY, ALL_PLATFORMS, platformOrigin } from './platform-registry';
 
 // ============================================================
 // String Length Limits
@@ -101,15 +102,10 @@ export const MUTATION_DEBOUNCE_DELAY = 100;
 
 /**
  * Allowed origins for content script messages (M-02)
- * Only these origins can send messages to the background worker
+ * Only these origins can send messages to the background worker.
+ * Derived from PLATFORM_REGISTRY (ADR-014).
  */
-export const ALLOWED_ORIGINS = [
-  'https://gemini.google.com',
-  'https://claude.ai',
-  'https://chatgpt.com',
-  'https://www.perplexity.ai',
-  'https://notebooklm.google.com',
-] as const;
+export const ALLOWED_ORIGINS: readonly string[] = ALL_PLATFORMS.map(platformOrigin);
 
 /**
  * Valid message actions for background worker (M-02)
@@ -123,9 +119,9 @@ export const VALID_MESSAGE_ACTIONS = ['getSettings', 'testConnection', 'saveToOu
 export const VALID_OUTPUT_DESTINATIONS = ['obsidian', 'file', 'clipboard'] as const;
 
 /**
- * Valid AI platform sources
+ * Valid AI platform sources. Derived from PLATFORM_REGISTRY (ADR-014).
  */
-export const VALID_SOURCES = ['gemini', 'claude', 'perplexity', 'chatgpt', 'notebooklm'] as const;
+export const VALID_SOURCES: readonly AIPlatform[] = ALL_PLATFORMS;
 
 /**
  * Valid message format options for template rendering
@@ -133,15 +129,12 @@ export const VALID_SOURCES = ['gemini', 'claude', 'perplexity', 'chatgpt', 'note
 export const VALID_MESSAGE_FORMATS = ['callout', 'plain', 'blockquote'] as const;
 
 /**
- * Human-readable display labels for AI platforms
+ * Human-readable display labels for AI platforms.
+ * Derived from PLATFORM_REGISTRY (ADR-014).
  */
-export const PLATFORM_LABELS: Record<AIPlatform, string> = {
-  gemini: 'Gemini',
-  claude: 'Claude',
-  chatgpt: 'ChatGPT',
-  perplexity: 'Perplexity',
-  notebooklm: 'NotebookLM',
-} as const;
+export const PLATFORM_LABELS: Record<AIPlatform, string> = Object.fromEntries(
+  ALL_PLATFORMS.map(platform => [platform, PLATFORM_REGISTRY[platform].label])
+) as Record<AIPlatform, string>;
 
 // ============================================================
 // Auto-Scroll Configuration (Gemini)

--- a/src/lib/platform-registry.ts
+++ b/src/lib/platform-registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Platform registry — single source of truth for per-platform metadata (ADR-014)
+ *
+ * `Record<AIPlatform, PlatformInfo>` forces compile-time exhaustiveness:
+ * extending the AIPlatform union fails to compile until an entry is added
+ * here, and consumers keyed by the union stay in sync automatically.
+ *
+ * Extractor constructors intentionally live in src/content/index.ts, not
+ * here: this module is pure data so lib/ keeps its one-way layering
+ * (enforced by test/arch/layering.test.ts).
+ *
+ * The manifest (src/manifest.json) cannot import TypeScript; the
+ * manifest ⇄ registry seam is guarded by test/arch/platform-ssot.test.ts.
+ */
+
+import type { AIPlatform } from './types';
+
+export interface PlatformInfo {
+  /** Content-script hostname, exactly as matched in the manifest */
+  host: string;
+  /** Human-readable display label */
+  label: string;
+}
+
+export const PLATFORM_REGISTRY: Record<AIPlatform, PlatformInfo> = {
+  gemini: { host: 'gemini.google.com', label: 'Gemini' },
+  claude: { host: 'claude.ai', label: 'Claude' },
+  chatgpt: { host: 'chatgpt.com', label: 'ChatGPT' },
+  perplexity: { host: 'www.perplexity.ai', label: 'Perplexity' },
+  notebooklm: { host: 'notebooklm.google.com', label: 'NotebookLM' },
+};
+
+/** All platform ids, in registry declaration order */
+export const ALL_PLATFORMS = Object.keys(PLATFORM_REGISTRY) as readonly AIPlatform[];
+
+/**
+ * Resolve a hostname to its platform id.
+ *
+ * Strict equality prevents subdomain attacks like
+ * "evil-gemini.google.com.attacker.com" (CodeQL js/incomplete-url-substring-sanitization).
+ */
+export function platformForHost(hostname: string): AIPlatform | undefined {
+  return ALL_PLATFORMS.find(platform => PLATFORM_REGISTRY[platform].host === hostname);
+}
+
+/** Origin for a platform, derived from its host — one fact, one place */
+export function platformOrigin(platform: AIPlatform): string {
+  return `https://${PLATFORM_REGISTRY[platform].host}`;
+}

--- a/test/arch/platform-ssot.test.ts
+++ b/test/arch/platform-ssot.test.ts
@@ -41,8 +41,8 @@ const manifest = JSON.parse(read('src/manifest.json')) as Manifest;
 
 // Derive platform hosts from the SSOT (skip infrastructure hosts like 127.0.0.1).
 const platformHosts = manifest.content_scripts[0].matches
-  .map((m) => m.replace('https://', '').replace('/*', ''))
-  .filter((h) => !h.startsWith('127.'));
+  .map(m => m.replace('https://', '').replace('/*', ''))
+  .filter(h => !h.startsWith('127.'));
 
 describe('architecture: platform SSOT (manifest <-> code)', () => {
   it('every manifest platform host has a known AIPlatform id', () => {
@@ -51,22 +51,39 @@ describe('architecture: platform SSOT (manifest <-> code)', () => {
     }
   });
 
-  it.each(platformHosts)('host %s is consistent across manifest + code', (host) => {
+  it.each(platformHosts)('host %s is consistent across manifest + code', host => {
     const id = PLATFORM_IDS[host];
 
     // manifest host_permissions
     expect(manifest.host_permissions).toContain(`https://${host}/*`);
 
-    // ALLOWED_ORIGINS (constants.ts)
-    expect(read('src/lib/constants.ts')).toContain(`'https://${host}'`);
+    // PLATFORM_REGISTRY (platform-registry.ts) — the one code-side SSOT (ADR-014)
+    const registry = read('src/lib/platform-registry.ts');
+    expect(registry, `registry must map ${id} to its host`).toContain(`'${host}'`);
+    expect(new RegExp(`\\b${id}:`).test(registry), `registry must have a ${id} entry`).toBe(true);
 
-    // getExtractor() routing (content/index.ts)
-    expect(read('src/content/index.ts')).toContain(`hostname === '${host}'`);
+    // Extractor routing (content/index.ts): constructor map keyed by platform id
+    expect(
+      new RegExp(`\\b${id}: \\w+Extractor\\b`).test(read('src/content/index.ts')),
+      `content/index.ts must map ${id} to its extractor constructor`
+    ).toBe(true);
 
     // AIPlatform union (types.ts)
     const types = read('src/lib/types.ts');
     const union = /export type AIPlatform\s*=\s*([^;]+);/.exec(types);
     expect(union, 'AIPlatform union not found in types.ts').not.toBeNull();
     expect(union?.[1]).toContain(`'${id}'`);
+  });
+
+  it('constants.ts derives platform lists from the registry instead of hand-writing them', () => {
+    const constants = read('src/lib/constants.ts');
+    expect(constants).toContain(`from './platform-registry'`);
+    // No hand-maintained origin literals: origins must come from the registry
+    for (const host of platformHosts) {
+      expect(
+        constants.includes(`'https://${host}'`),
+        `constants.ts hand-writes origin for ${host} — derive it from PLATFORM_REGISTRY`
+      ).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- New `src/lib/platform-registry.ts`: `PLATFORM_REGISTRY: Record<AIPlatform, {host, label}>` is the code-side single source of truth — the `Record` keying makes union⇄registry divergence a **compile error** instead of a test failure
- `VALID_SOURCES`, `ALLOWED_ORIGINS` (origins derived from hosts — one fact, one place), and `PLATFORM_LABELS` in `constants.ts` are now derived from the registry
- `content/index.ts` routing rebuilt on the registry: `EXTRACTOR_CONSTRUCTORS` and `PLATFORM_ROOT_SELECTORS` are keyed by platform id (compiler-enforced exhaustiveness); `platformForHost()` keeps the strict-equality hostname check (CodeQL js/incomplete-url-substring-sanitization)
- Extractor constructors intentionally stay in `content/index.ts` so `lib/` keeps its one-way layering (`test/arch/layering.test.ts` stays green) — this is the ADR-014 design decision
- `platform-ssot` fitness test extended (RED-first: 6 assertions failed before the registry existed): now guards the manifest ⇄ registry seam and asserts `constants.ts` derives rather than hand-writes the lists
- Fix two stale steps in CLAUDE.md "Adding New Platforms" (BaseExtractor enumeration no longer exists; `ALLOWED_ORIGINS` location was wrong)
- Add `docs/adr/014-platform-registry-ssot.md`

Adding platform #6 is now: union entry + registry entry + extractor + manifest — the compiler and the fitness function force the rest.

## Test plan

- [x] `npm run test:coverage` passes (1070/1070, thresholds green: 92.1% stmts / 86.7% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` + platform consistency check pass
- [x] `npm run build` succeeds
- [x] `test/arch/layering.test.ts` green (no lib→content edge introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)