### PR TITLE
perf: memoize append-mode file paths and reduce KaTeX DOM parses

### DIFF
--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -42,6 +42,25 @@ function isClientError(client: ObsidianApiClient | { error: string }): client is
 }
 
 /**
+ * conversationId → vault path where the conversation's note was last found
+ * (append mode). Best-effort cache: after a calendar rollover the direct path
+ * misses on every save and the fallback directory scan re-runs each time —
+ * the memo turns that into a single GET. Service-worker restarts clear it;
+ * misses simply fall back to the scan.
+ */
+const appendPathMemo = new Map<string, string>();
+
+/** Bound memory: far above any realistic number of active conversations */
+const APPEND_MEMO_MAX_ENTRIES = 100;
+
+function rememberAppendPath(conversationId: string, path: string): void {
+  if (appendPathMemo.size >= APPEND_MEMO_MAX_ENTRIES && !appendPathMemo.has(conversationId)) {
+    appendPathMemo.clear();
+  }
+  appendPathMemo.set(conversationId, path);
+}
+
+/**
  * Try to append new messages to an existing file.
  * Returns a SaveResponse on success, or null to fall through to overwrite.
  */
@@ -58,8 +77,16 @@ async function tryAppendMode(
   }
 
   try {
-    const lookup = await lookupExistingFile(client, fullPath, resolvedPath, note, searchBasePath);
+    const lookup = await lookupExistingFile(
+      client,
+      fullPath,
+      resolvedPath,
+      note,
+      searchBasePath,
+      appendPathMemo.get(note.frontmatter.id)
+    );
     if (!lookup.found) return null;
+    rememberAppendPath(note.frontmatter.id, lookup.path);
 
     const appendResult = buildAppendContent(lookup.content, note, settings);
     if (appendResult !== null) {

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -18,7 +18,7 @@ interface FileLookupResult {
   found: boolean;
   path: string;
   content: string;
-  matchType: 'direct' | 'id-scan' | 'none';
+  matchType: 'direct' | 'memo' | 'id-scan' | 'none';
 }
 
 /**
@@ -63,15 +63,30 @@ const RECURSIVE_SCAN_MAX_DEPTH = 6;
  * @param searchBasePath - Optional. When provided AND different from resolvedPath,
  *   triggers the recursive scan. Defaults to resolvedPath (preserves the legacy
  *   flat-scan behaviour for templates without date variables).
+ * @param hintPath - Optional. Path where this conversation's file was previously
+ *   found (caller-memoized). Tried before anything else so repeat appends after
+ *   a calendar rollover cost one GET instead of a directory scan.
  */
 export async function lookupExistingFile(
   client: ObsidianApiClient,
   fullPath: string,
   resolvedPath: string,
   note: ObsidianNote,
-  searchBasePath: string = resolvedPath
+  searchBasePath: string = resolvedPath,
+  hintPath?: string
 ): Promise<FileLookupResult> {
   const expectedId = note.frontmatter.id;
+
+  // Step 0: Caller-memoized hint (id re-verified — the memo may be stale)
+  if (hintPath && hintPath !== fullPath) {
+    const hintContent = await client.getFile(hintPath);
+    if (hintContent !== null) {
+      const parsed = parseFrontmatter(hintContent);
+      if (parsed?.fields.id === expectedId) {
+        return { found: true, path: hintPath, content: hintContent, matchType: 'memo' };
+      }
+    }
+  }
 
   // Step 1: Direct path match
   const directContent = await client.getFile(fullPath);

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -42,6 +42,16 @@ function extractLatexFromKatex(element: Element): string | null {
  * @returns HTML with standard KaTeX converted to data-math format
  */
 export function preprocessKatex(html: string): string {
+  const result = preprocessKatexToNode(html);
+  return typeof result === 'string' ? result : result.innerHTML;
+}
+
+/**
+ * Same as {@link preprocessKatex}, but returns the already-parsed body when a
+ * conversion happened. sanitizeHtml passes the node straight to DOMPurify
+ * (which accepts Node input), avoiding a serialize + re-parse per message.
+ */
+function preprocessKatexToNode(html: string): string | HTMLElement {
   // Fast path: skip DOMParser overhead when no KaTeX content present
   if (!html.includes('katex')) {
     return html;
@@ -76,7 +86,7 @@ export function preprocessKatex(html: string): string {
     modified = true;
   }
 
-  return modified ? doc.body.innerHTML : html;
+  return modified ? doc.body : html;
 }
 
 /**
@@ -105,8 +115,10 @@ export function preprocessKatex(html: string): string {
  */
 export function sanitizeHtml(html: string): string {
   // Pre-process: convert standard KaTeX structures to data-math attributes
-  // Must run BEFORE DOMPurify, which strips MathML elements (<math>, <annotation>)
-  const preprocessed = preprocessKatex(html);
+  // Must run BEFORE DOMPurify, which strips MathML elements (<math>, <annotation>).
+  // When conversion happened, the parsed body is handed to DOMPurify directly
+  // (Node input) so the message is not serialized and re-parsed a third time.
+  const preprocessed = preprocessKatexToNode(html);
 
   DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
     if (

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -1771,6 +1771,41 @@ describe('background/index', () => {
       expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBe(2);
     });
+
+    it('memoizes the found path and skips re-scanning on subsequent appends', async () => {
+      mockGetSettings = vi.fn(() => Promise.resolve(appendSettings));
+      mockClient.getFile.mockImplementation((path: string) => {
+        if (path === 'AI/claude/old-title-abc12345.md') {
+          return Promise.resolve(existingContent);
+        }
+        return Promise.resolve(null); // direct path never exists
+      });
+      mockClient.listFiles.mockResolvedValue(['old-title-abc12345.md']);
+      mockClient.putFile.mockResolvedValue(undefined);
+
+      // First save: file is only findable via the ID scan
+      const firstResponse = vi.fn();
+      capturedListener(
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
+        validSender as chrome.runtime.MessageSender,
+        firstResponse
+      );
+      await vi.waitFor(() => expect(firstResponse).toHaveBeenCalled());
+      expect(mockClient.listFiles).toHaveBeenCalled();
+
+      // Second save: the memoized path must be tried directly — no directory scan
+      mockClient.listFiles.mockClear();
+      const secondResponse = vi.fn();
+      capturedListener(
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
+        validSender as chrome.runtime.MessageSender,
+        secondResponse
+      );
+      await vi.waitFor(() => expect(secondResponse).toHaveBeenCalled());
+      const response = secondResponse.mock.calls[0][0];
+      expect(response.allSuccessful).toBe(true);
+      expect(mockClient.listFiles).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleMessage rejection path', () => {


### PR DESCRIPTION
## Summary

- **Append-scan memo**: after a calendar rollover with date-templated vault paths (`AI/{platform}/{YYYY}/{MM}`), the direct lookup misses on *every* save and the sequential directory scan re-runs each time. The service worker now memoizes `conversationId → found path`; `lookupExistingFile` gains an optional `hintPath` tried first with the same frontmatter-id verification (a stale memo degrades safely to the old behavior). Repeat appends cost one GET instead of a depth-≤6 `listFiles` walk. Memo is size-capped (100) and naturally cleared on worker restart.
- **KaTeX single-parse**: messages containing KaTeX were DOM-parsed 3× (KaTeX preprocess → serialize → DOMPurify re-parse → Turndown). `preprocessKatex` now hands the already-parsed body to DOMPurify via its documented Node-input support, eliminating one serialize+parse per KaTeX message. The exported string API is unchanged for tests.
- RED-first regression test: second append save must not call `listFiles` (failed before the memo existed). KaTeX output equivalence is locked by the existing sanitize/markdown test suites.

## Test plan

- [x] `npm run test:coverage` passes (1075/1075, thresholds green: 92.3% stmts / 86.7% branch)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)