### PR TITLE
refactor: share the citation-to-footnote transform skeleton

### DIFF
--- a/src/content/extractors/footnotes.ts
+++ b/src/content/extractors/footnotes.ts
@@ -18,6 +18,46 @@ export interface CitationTransformResult {
   footnotes: string[];
 }
 
+/**
+ * Platform hooks for {@link transformCitations}.
+ * The skeleton owns parsing and serialization; hooks own the DOM specifics.
+ */
+export interface CitationTransformHooks {
+  /** True when the parsed document contains citations worth transforming. */
+  hasCitations(doc: Document): boolean;
+  /**
+   * Replace citation nodes with footnote-ref placeholders (mutating `doc`)
+   * and return the deduped footnote definition lines.
+   */
+  collectFootnotes(doc: Document): string[];
+}
+
+/**
+ * Shared citation→footnote transform skeleton (parse → detect → transform →
+ * serialize). Platform DOM shapes differ (NotebookLM buttons vs Perplexity
+ * pills), but the surrounding lifecycle is identical — a fix to it applies
+ * to every platform at once.
+ */
+export function transformCitations(
+  html: string,
+  hooks: CitationTransformHooks
+): CitationTransformResult {
+  if (!html) {
+    return { html, footnotes: [] };
+  }
+
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  // Return the original string untouched when there is nothing to transform,
+  // avoiding parse→serialize normalization differences for plain messages.
+  if (!hooks.hasCitations(doc)) {
+    return { html, footnotes: [] };
+  }
+
+  const footnotes = hooks.collectFootnotes(doc);
+  return { html: doc.body.innerHTML, footnotes };
+}
+
 const HTML_ESCAPE_MAP: Record<string, string> = {
   '&': '&amp;',
   '<': '&lt;',

--- a/src/content/extractors/notebooklm.ts
+++ b/src/content/extractors/notebooklm.ts
@@ -15,7 +15,7 @@
 import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import type { ConversationMessage } from '../../lib/types';
-import { createFootnoteRef, footnoteDefsToHtml } from './footnotes';
+import { createFootnoteRef, footnoteDefsToHtml, transformCitations } from './footnotes';
 import type { CitationTransformResult } from './footnotes';
 
 import { SELECTORS } from './selectors/notebooklm';
@@ -63,36 +63,35 @@ function transformCitationsToFootnotes(
   html: string,
   messageIndex: number
 ): CitationTransformResult {
-  if (!html) return { html: '', footnotes: [] };
+  return transformCitations(html, {
+    hasCitations: doc => doc.querySelector('button.citation-marker') !== null,
+    collectFootnotes: doc => {
+      const buttons = Array.from(doc.querySelectorAll('button.citation-marker'));
+      const footnoteByNumber = new Map<string, string>();
+      const order: string[] = [];
 
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  const buttons = Array.from(doc.querySelectorAll('button.citation-marker'));
-  if (buttons.length === 0) return { html, footnotes: [] };
+      for (const button of buttons) {
+        if (isMoreCitationsButton(button)) {
+          button.remove();
+          continue;
+        }
+        const parsed = parseCitation(button);
+        if (!parsed) {
+          button.remove();
+          continue;
+        }
+        const label = `m${messageIndex}-${parsed.number}`;
+        button.replaceWith(createFootnoteRef(doc, label));
 
-  const footnoteByNumber = new Map<string, string>();
-  const order: string[] = [];
+        if (!footnoteByNumber.has(parsed.number)) {
+          footnoteByNumber.set(parsed.number, parsed.title);
+          order.push(parsed.number);
+        }
+      }
 
-  for (const button of buttons) {
-    if (isMoreCitationsButton(button)) {
-      button.remove();
-      continue;
-    }
-    const parsed = parseCitation(button);
-    if (!parsed) {
-      button.remove();
-      continue;
-    }
-    const label = `m${messageIndex}-${parsed.number}`;
-    button.replaceWith(createFootnoteRef(doc, label));
-
-    if (!footnoteByNumber.has(parsed.number)) {
-      footnoteByNumber.set(parsed.number, parsed.title);
-      order.push(parsed.number);
-    }
-  }
-
-  const footnotes = order.map(num => `[^m${messageIndex}-${num}]: ${footnoteByNumber.get(num)}`);
-  return { html: doc.body.innerHTML, footnotes };
+      return order.map(num => `[^m${messageIndex}-${num}]: ${footnoteByNumber.get(num)}`);
+    },
+  });
 }
 
 /**

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -11,7 +11,12 @@ import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { isHttpUrl } from '../../lib/validation';
 import type { ConversationMessage } from '../../lib/types';
-import { createFootnoteRef, escapeMarkdownLink, footnoteDefsToHtml } from './footnotes';
+import {
+  createFootnoteRef,
+  escapeMarkdownLink,
+  footnoteDefsToHtml,
+  transformCitations,
+} from './footnotes';
 import type { CitationTransformResult } from './footnotes';
 
 import { SELECTORS } from './selectors/perplexity';
@@ -141,33 +146,25 @@ function transformCitationsToFootnotes(
   html: string,
   messageIndex: number
 ): CitationTransformResult {
-  if (!html) {
-    return { html, footnotes: [] };
-  }
-
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-
-  // Return the original string untouched when there is nothing to transform,
-  // avoiding parse→serialize normalization differences for plain messages.
   const citationGroups = [
     SELECTORS.citation,
     SELECTORS.legacyCitationPill,
     SELECTORS.citationSpacer,
   ];
-  if (!citationGroups.some(group => doc.querySelector(group.join(', ')))) {
-    return { html, footnotes: [] };
-  }
 
-  const sources = collectCitationSources(doc, messageIndex);
-  removeCitationResidue(doc);
+  return transformCitations(html, {
+    hasCitations: doc => citationGroups.some(group => doc.querySelector(group.join(', '))),
+    collectFootnotes: doc => {
+      const sources = collectCitationSources(doc, messageIndex);
+      removeCitationResidue(doc);
 
-  const footnotes = [...sources.entries()].map(
-    ([url, source]) =>
-      `[^m${messageIndex}-${source.number}]: ` +
-      `[${escapeMarkdownLink(source.title)}](${toMarkdownSafeUrl(url)})`
-  );
-
-  return { html: doc.body.innerHTML, footnotes };
+      return [...sources.entries()].map(
+        ([url, source]) =>
+          `[^m${messageIndex}-${source.number}]: ` +
+          `[${escapeMarkdownLink(source.title)}](${toMarkdownSafeUrl(url)})`
+      );
+    },
+  });
 }
 
 /** Tagged element for DOM-order sorting */


### PR DESCRIPTION
## Summary

- Extract `transformCitations()` into `extractors/footnotes.ts`: the shared lifecycle (empty-input guard → parse → untouched-string fast path → transform → serialize) that NotebookLM and Perplexity each hand-rolled around their citation DOM
- Both extractors now supply only platform hooks (`hasCitations`, `collectFootnotes`) — a future fix to the lifecycle reaches every platform at once
- Deliberately NOT swapped: the hardcoded `button.citation-marker` selector in NotebookLM's hook (the richer `SELECTORS.citationMarker` *excludes* mat-icon "more" buttons, which this code must select in order to remove — a swap would change behavior)
- Pure refactor: extractor unit tests and e2e snapshots byte-identical

## Test plan

- [x] `npm run test:coverage` passes (1074/1074, thresholds green: 92.3% stmts / 86.9% branch)
- [x] e2e snapshot tests unchanged
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)