### PR TITLE
feat(e2e): separate auth, stall, and dead-test-data states

### DIFF
--- a/e2e/selectors/__tests__/auth-check.test.ts
+++ b/e2e/selectors/__tests__/auth-check.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAuthStatus, isLoginUrl } from '../auth-check';
+
+const GEMINI_PATTERN = /^https:\/\/gemini\.google\.com\/(app|deepresearch)\//;
+
+describe('isLoginUrl', () => {
+  it('recognizes Google account login URLs', () => {
+    expect(isLoginUrl('https://accounts.google.com/v3/signin/identifier?x=1')).toBe(true);
+  });
+
+  it('recognizes platform login paths', () => {
+    expect(isLoginUrl('https://claude.ai/login?returnTo=%2F')).toBe(true);
+    expect(isLoginUrl('https://auth.openai.com/authorize?client=x')).toBe(true);
+  });
+
+  it('does not flag ordinary platform pages', () => {
+    expect(isLoginUrl('https://gemini.google.com/app')).toBe(false);
+    expect(isLoginUrl('https://claude.ai/chat/abc')).toBe(false);
+  });
+});
+
+describe('resolveAuthStatus', () => {
+  it('returns authenticated when the URL matches the conversation pattern', () => {
+    const status = resolveAuthStatus({
+      finalUrl: 'https://gemini.google.com/app/8c6eb888f77e1571',
+      conversationPattern: GEMINI_PATTERN,
+      loggedOutMarkerPresent: false,
+    });
+    expect(status).toBe('authenticated');
+  });
+
+  it('returns auth_expired when redirected to a login URL', () => {
+    const status = resolveAuthStatus({
+      finalUrl: 'https://accounts.google.com/v3/signin/identifier',
+      conversationPattern: GEMINI_PATTERN,
+      loggedOutMarkerPresent: false,
+    });
+    expect(status).toBe('auth_expired');
+  });
+
+  it('returns auth_expired when a logged-out marker is present on an off-pattern page', () => {
+    // Gemini bounces to /app (in-origin logged-out shell) instead of accounts.google.com
+    const status = resolveAuthStatus({
+      finalUrl: 'https://gemini.google.com/app',
+      conversationPattern: GEMINI_PATTERN,
+      loggedOutMarkerPresent: true,
+    });
+    expect(status).toBe('auth_expired');
+  });
+
+  it('returns test_data_missing when authenticated but bounced off the conversation URL', () => {
+    // The stale-conversation case: logged in, no logged-out marker, but the
+    // pinned conversation no longer opens — lands on the app root.
+    const status = resolveAuthStatus({
+      finalUrl: 'https://gemini.google.com/app',
+      conversationPattern: GEMINI_PATTERN,
+      loggedOutMarkerPresent: false,
+    });
+    expect(status).toBe('test_data_missing');
+  });
+
+  it('returns authenticated when no pattern is configured (unknown platform)', () => {
+    const status = resolveAuthStatus({
+      finalUrl: 'https://example.com/anything',
+      conversationPattern: undefined,
+      loggedOutMarkerPresent: false,
+    });
+    expect(status).toBe('authenticated');
+  });
+});

--- a/e2e/selectors/__tests__/load-readiness.test.ts
+++ b/e2e/selectors/__tests__/load-readiness.test.ts
@@ -72,3 +72,39 @@ describe('decideLoadOutcome', () => {
     expect(d.reason).toMatch(/regression/i);
   });
 });
+
+describe('decideLoadOutcome stall escalation', () => {
+  const base = { platform: 'gemini', readyFound: false, loadingPresent: true };
+
+  it('skips while consecutive stalls are below the threshold', () => {
+    const d = decideLoadOutcome({ ...base, priorConsecutiveStalls: 0, maxConsecutiveStalls: 3 });
+    expect(d.action).toBe('skip');
+    expect(d.reason).toContain('1/3');
+  });
+
+  it('escalates to validate (-> FAIL) when the threshold is reached', () => {
+    const d = decideLoadOutcome({ ...base, priorConsecutiveStalls: 2, maxConsecutiveStalls: 3 });
+    expect(d.action).toBe('validate');
+    expect(d.reason).toContain('no longer treated as transient');
+  });
+
+  it('keeps escalating on subsequent stalled runs past the threshold', () => {
+    const d = decideLoadOutcome({ ...base, priorConsecutiveStalls: 5, maxConsecutiveStalls: 3 });
+    expect(d.action).toBe('validate');
+  });
+
+  it('still validates immediately when no loading indicator is present', () => {
+    const d = decideLoadOutcome({
+      ...base,
+      loadingPresent: false,
+      priorConsecutiveStalls: 0,
+      maxConsecutiveStalls: 3,
+    });
+    expect(d.action).toBe('validate');
+  });
+
+  it('defaults to legacy skip behavior when stall counts are not provided', () => {
+    const d = decideLoadOutcome(base);
+    expect(d.action).toBe('skip');
+  });
+});

--- a/e2e/selectors/__tests__/stall-tracker.test.ts
+++ b/e2e/selectors/__tests__/stall-tracker.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getConsecutiveStalls, recordStall, resetStalls } from '../stall-tracker';
+
+let statePath: string;
+
+beforeEach(() => {
+  statePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'stall-')), 'stall-state.json');
+});
+
+afterEach(() => {
+  fs.rmSync(path.dirname(statePath), { recursive: true, force: true });
+});
+
+describe('stall-tracker', () => {
+  it('returns 0 for an unknown key (no state file)', () => {
+    expect(getConsecutiveStalls('gemini_conv', statePath)).toBe(0);
+  });
+
+  it('increments per recordStall and persists across reads', () => {
+    expect(recordStall('gemini_conv', statePath)).toBe(1);
+    expect(recordStall('gemini_conv', statePath)).toBe(2);
+    expect(getConsecutiveStalls('gemini_conv', statePath)).toBe(2);
+  });
+
+  it('tracks keys independently', () => {
+    recordStall('gemini_conv', statePath);
+    recordStall('gemini_conv', statePath);
+    recordStall('gemini_dr', statePath);
+
+    expect(getConsecutiveStalls('gemini_conv', statePath)).toBe(2);
+    expect(getConsecutiveStalls('gemini_dr', statePath)).toBe(1);
+  });
+
+  it('resetStalls clears only the given key', () => {
+    recordStall('gemini_conv', statePath);
+    recordStall('gemini_dr', statePath);
+
+    resetStalls('gemini_conv', statePath);
+
+    expect(getConsecutiveStalls('gemini_conv', statePath)).toBe(0);
+    expect(getConsecutiveStalls('gemini_dr', statePath)).toBe(1);
+  });
+
+  it('survives a corrupt state file by starting fresh', () => {
+    fs.writeFileSync(statePath, 'not json');
+    expect(getConsecutiveStalls('gemini_conv', statePath)).toBe(0);
+    expect(recordStall('gemini_conv', statePath)).toBe(1);
+  });
+});

--- a/e2e/selectors/auth-check.ts
+++ b/e2e/selectors/auth-check.ts
@@ -1,16 +1,22 @@
 /**
  * Authentication pre-flight check for live selector validation.
  *
- * After navigating to a conversation URL, verifies the browser
- * stayed on the target page (authenticated) vs. being redirected
- * to a login page (auth_expired).
+ * After navigating to a conversation URL, distinguishes THREE off-nominal
+ * states that v1 conflated into one:
+ * - authenticated:      still on the conversation URL pattern
+ * - auth_expired:       bounced to a login page, or an in-origin logged-out
+ *                       shell (Gemini bounces dead sessions to /app with a
+ *                       "Sign in" link instead of accounts.google.com)
+ * - test_data_missing:  session is fine but the pinned conversation no longer
+ *                       opens (deleted/expired conversation URL) — this must
+ *                       FAIL with guidance, not silently skip as an auth issue
  */
 
 import type { Page } from 'playwright';
 
 /**
  * Platform-specific URL patterns that indicate a successful authenticated navigation.
- * If the current URL doesn't match, the session has expired.
+ * If the current URL doesn't match, the session has expired or the test data is gone.
  */
 const AUTH_URL_PATTERNS: Readonly<Record<string, RegExp>> = {
   gemini: /^https:\/\/gemini\.google\.com\/(app|deepresearch)\//,
@@ -20,14 +26,61 @@ const AUTH_URL_PATTERNS: Readonly<Record<string, RegExp>> = {
   notebooklm: /^https:\/\/notebooklm\.google\.com\/notebook\//,
 };
 
-export type AuthStatus = 'authenticated' | 'auth_expired' | 'unreachable';
+/**
+ * DOM markers indicating a logged-out shell, consulted only when the final
+ * URL is off-pattern but not a recognizable login URL. Google properties
+ * bounce dead sessions to an in-origin page with sign-in links rather than
+ * redirecting to accounts.google.com.
+ */
+const LOGGED_OUT_MARKERS: Readonly<Record<string, string>> = {
+  gemini: 'a[href*="accounts.google.com/ServiceLogin"], a[href*="accounts.google.com/v3/signin"]',
+  notebooklm:
+    'a[href*="accounts.google.com/ServiceLogin"], a[href*="accounts.google.com/v3/signin"]',
+};
+
+/** URL shapes that unambiguously identify a login/authorization page. */
+const LOGIN_URL_PATTERN =
+  /accounts\.google\.com|auth\.openai\.com|auth0\.com|[/.]login(?:[/?#]|$)|\/signin(?:[/?#]|$)|\/auth\//i;
+
+export type AuthStatus = 'authenticated' | 'auth_expired' | 'test_data_missing' | 'unreachable';
+
+export function isLoginUrl(url: string): boolean {
+  return LOGIN_URL_PATTERN.test(url);
+}
+
+export interface AuthResolutionInput {
+  /** URL the browser actually landed on after navigation + settle time */
+  finalUrl: string;
+  /** Expected conversation-URL pattern; undefined for unknown platforms */
+  conversationPattern: RegExp | undefined;
+  /** Whether a platform logged-out DOM marker was found on the landed page */
+  loggedOutMarkerPresent: boolean;
+}
 
 /**
- * Navigate to the target URL and check authentication status.
- *
- * - authenticated: URL matches the expected pattern (still on conversation page)
- * - auth_expired:  Redirected to login page
- * - unreachable:   Navigation failed (network error, HTTP 4xx/5xx)
+ * Pure decision: classify the post-navigation state.
+ * Extracted from the page I/O so the tri-state logic is unit-testable.
+ */
+export function resolveAuthStatus(
+  input: AuthResolutionInput
+): Exclude<AuthStatus, 'unreachable'> {
+  const { finalUrl, conversationPattern, loggedOutMarkerPresent } = input;
+
+  if (!conversationPattern) {
+    // Unknown platform: nothing to judge against
+    return 'authenticated';
+  }
+  if (conversationPattern.test(finalUrl)) {
+    return 'authenticated';
+  }
+  if (isLoginUrl(finalUrl) || loggedOutMarkerPresent) {
+    return 'auth_expired';
+  }
+  return 'test_data_missing';
+}
+
+/**
+ * Navigate to the target URL and check authentication / test-data status.
  */
 export async function checkAuthStatus(
   page: Page,
@@ -49,15 +102,24 @@ export async function checkAuthStatus(
       return 'unreachable';
     }
 
-    const currentUrl = page.url();
-    const pattern = AUTH_URL_PATTERNS[platform];
+    const finalUrl = page.url();
+    const marker = LOGGED_OUT_MARKERS[platform];
+    const loggedOutMarkerPresent = marker
+      ? await page.evaluate((sel: string) => document.querySelector(sel) !== null, marker)
+      : false;
 
-    if (pattern && pattern.test(currentUrl)) {
-      return 'authenticated';
+    const status = resolveAuthStatus({
+      finalUrl,
+      conversationPattern: AUTH_URL_PATTERNS[platform],
+      loggedOutMarkerPresent,
+    });
+
+    if (status !== 'authenticated') {
+      console.warn(
+        `[G2O Auth] ${platform}: ${status} — expected ${AUTH_URL_PATTERNS[platform]}, got: ${finalUrl}`
+      );
     }
-
-    console.warn(`[G2O Auth] ${platform}: auth_expired — expected ${pattern}, got: ${currentUrl}`);
-    return 'auth_expired';
+    return status;
   } catch {
     return 'unreachable';
   }

--- a/e2e/selectors/load-readiness.ts
+++ b/e2e/selectors/load-readiness.ts
@@ -61,24 +61,40 @@ export interface LoadOutcomeInput {
   readonly readyFound: boolean;
   /** Whether a loading indicator (spinner / empty-state) is still present. */
   readonly loadingPresent: boolean;
+  /** Consecutive stall-skips recorded BEFORE this run (stall-tracker). */
+  readonly priorConsecutiveStalls?: number;
+  /** Threshold at which a persistent stall stops being treated as transient. */
+  readonly maxConsecutiveStalls?: number;
 }
 
 /**
  * Decide whether to run selector validation or skip the test.
  *
  * - ready found                         -> validate (normal path)
- * - ready absent + loading indicator    -> skip (transient content stall)
- * - ready absent + no loading indicator -> validate (possible real regression,
- *   let the zero-match assertion FAIL so genuine DOM changes are caught)
+ * - ready absent + loading indicator    -> skip (transient content stall),
+ *   but only up to maxConsecutiveStalls in a row: a stall persisting run
+ *   after run is indistinguishable from a masked regression (or dead test
+ *   data) and escalates to validate -> the zero-match assertion FAILs
+ * - ready absent + no loading indicator -> validate (possible real regression)
  */
 export function decideLoadOutcome(input: LoadOutcomeInput): LoadDecision {
   if (input.readyFound) {
     return { action: 'validate', reason: `${input.platform}: ready selector found` };
   }
   if (input.loadingPresent) {
+    const max = input.maxConsecutiveStalls ?? Number.POSITIVE_INFINITY;
+    const thisStall = (input.priorConsecutiveStalls ?? 0) + 1;
+    if (thisStall >= max) {
+      return {
+        action: 'validate',
+        reason:
+          `${input.platform}: content stall persisted ${thisStall} consecutive runs — ` +
+          `no longer treated as transient (validating; expect FAIL until fixed)`,
+      };
+    }
     return {
       action: 'skip',
-      reason: `${input.platform}: content did not load (transient — loading indicator present)`,
+      reason: `${input.platform}: content did not load (transient — loading indicator present, stall ${thisStall}/${max})`,
     };
   }
   return {

--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -33,6 +33,7 @@ import {
 } from './baseline';
 import { classifyResults, type SelectorResult } from './classifier';
 import { waitForReadyWithRetry, decideLoadOutcome } from './load-readiness';
+import { getConsecutiveStalls, recordStall, resetStalls } from './stall-tracker';
 
 dotenv.config({ path: path.join(import.meta.dirname, '..', '.env.local') });
 
@@ -68,6 +69,8 @@ const LOADING_SELECTORS: Readonly<Record<string, string>> = {
 const READY_MAX_ATTEMPTS = 3;
 /** Per-attempt wait for the ready selector. */
 const READY_TIMEOUT_MS = 15_000;
+/** Consecutive stall-skips before a stall is treated as a real failure. */
+const MAX_CONSECUTIVE_STALLS = 3;
 
 // --- Helper Functions ---
 
@@ -115,6 +118,14 @@ async function runPlatformValidation(
       test.skip(true, `${platform}: AUTH_EXPIRED — run 'npm run e2e:auth' to re-login`);
       return;
     }
+    // Session is fine but the pinned conversation no longer opens: this is
+    // dead test data, not an auth problem — fail loudly with the fix.
+    expect(
+      authStatus,
+      `${platform}: authenticated but the conversation URL did not open (${url}) — ` +
+        `the pinned test conversation is gone or its URL is invalid; ` +
+        `refresh the *_CONV_URL / *_DR_URL value in e2e/.env.local`
+    ).not.toBe('test_data_missing');
 
     // Wait for page ready, retrying with a reload between attempts. Live SPAs
     // (notably Gemini) intermittently stall while fetching conversation history,
@@ -147,14 +158,25 @@ async function runPlatformValidation(
             )) > 0
           : false;
 
-        const decision = decideLoadOutcome({ platform, readyFound, loadingPresent });
+        // A stall that persists MAX_CONSECUTIVE_STALLS runs in a row stops
+        // being "transient" and falls through to validation (-> FAIL).
+        const decision = decideLoadOutcome({
+          platform,
+          readyFound,
+          loadingPresent,
+          priorConsecutiveStalls: getConsecutiveStalls(readyKey),
+          maxConsecutiveStalls: MAX_CONSECUTIVE_STALLS,
+        });
         console.warn(
           `${platform}: ready selector '${readySelector}' not found — ${decision.reason}`
         );
         if (decision.action === 'skip') {
+          recordStall(readyKey);
           test.skip(true, decision.reason);
           return;
         }
+      } else {
+        resetStalls(readyKey);
       }
     }
 
@@ -220,6 +242,18 @@ async function runPlatformValidation(
           `${b.group}:${b.name} [${b.status}] ${b.baselineCount} -> ${b.currentCount} (${b.selector})`
       ),
       `${platform}: baseline contract violations — if the selector change is intentional, run 'npm run e2e:baseline:update'`
+    ).toEqual([]);
+
+    // Assert: a dead primary selector fails even while a fallback carries it.
+    // The extension still works via the fallback, but a primary that stays
+    // broken silently rots — fix the primary or promote the fallback.
+    expect(
+      classified.warn.map(
+        w =>
+          `${w.failedPrimary.group}:${w.failedPrimary.name} primary '${w.failedPrimary.selector}' ` +
+          `has 0 matches (fallback '${w.workingFallback.selector}' carrying)`
+      ),
+      `${platform}: dead primary selectors — fix the primary or promote the working fallback in src/content/extractors/selectors/`
     ).toEqual([]);
   } finally {
     await page.close();

--- a/e2e/selectors/stall-tracker.ts
+++ b/e2e/selectors/stall-tracker.ts
@@ -1,0 +1,56 @@
+/**
+ * Consecutive-stall tracker for load-readiness decisions.
+ *
+ * A transient content stall (loading spinner never resolves) is skipped, but
+ * a stall that persists run after run is indistinguishable from a real
+ * regression being masked. This tracker persists per-target consecutive
+ * stall counts across runs (local state file, e2e/results/ is gitignored)
+ * so decideLoadOutcome can escalate to validate → FAIL at a threshold.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_STATE_PATH = path.join(import.meta.dirname, '..', 'results', 'stall-state.json');
+
+type StallState = Record<string, number>;
+
+function readState(statePath: string): StallState {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return {};
+    return raw as StallState;
+  } catch {
+    // Missing or corrupt state: start fresh — worst case one extra skip cycle
+    return {};
+  }
+}
+
+function writeState(statePath: string, state: StallState): void {
+  const dir = path.dirname(statePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+
+/** Consecutive stalls recorded for this key (0 if none). */
+export function getConsecutiveStalls(key: string, statePath = DEFAULT_STATE_PATH): number {
+  return readState(statePath)[key] ?? 0;
+}
+
+/** Record one more consecutive stall; returns the new count. */
+export function recordStall(key: string, statePath = DEFAULT_STATE_PATH): number {
+  const state = readState(statePath);
+  const next = (state[key] ?? 0) + 1;
+  writeState(statePath, { ...state, [key]: next });
+  return next;
+}
+
+/** Clear the streak for a key (content loaded normally). */
+export function resetStalls(key: string, statePath = DEFAULT_STATE_PATH): void {
+  const state = { ...readState(statePath) };
+  if (!(key in state)) return;
+  delete state[key];
+  writeState(statePath, state);
+}


### PR DESCRIPTION
## Summary

R2 of the approved E2E redesign — three failure modes that v1 conflated into silent skips are now first-class states:

- **`test_data_missing` (new)**: authenticated but the pinned conversation URL no longer opens → **FAILs** with guidance to refresh `*_CONV_URL` in `e2e/.env.local` (was: misclassified as `auth_expired` → skipped). Detection is a pure `resolveAuthStatus()` (unit-tested): conversation-URL pattern → login-URL pattern → platform logged-out DOM marker (Gemini bounces dead sessions to an in-origin `/app` shell with sign-in links, never to accounts.google.com)
- **Persistent-stall escalation**: the #289 transient-stall skip now records consecutive occurrences per target (`stall-tracker.ts`, local state in gitignored `e2e/results/`); at 3 consecutive stalls it escalates to validation → FAIL. A logged-in Gemini tab on a dead conversation URL keeps the URL and spins forever — this counter is what surfaces that exact case
- **Dead primaries FAIL**: `warn` (primary 0 matches, fallback carrying) is now asserted — a primary that silently rots for months is no longer green

TDD: 18 unit tests RED-first (tri-state auth resolution, stall escalation thresholds, tracker persistence incl. corrupt-state recovery), then GREEN.

## Live verification (CDP daemon)

- gemini: skipped with the visible counter `stall 1/3` (escalation armed)
- claude / chatgpt / perplexity: failed loudly on legacy v1 baselines with the `e2e:baseline:update` hint (vs 103 days of silent warn)
- notebooklm: full PASS on its v2 baseline

## Test plan

- [x] `npm run test:coverage` passes (1084/1084; thresholds green)
- [x] `npx tsc --noEmit` clean; edited files lint clean
- [x] Live `e2e:selectors` run exercises skip-with-counter, legacy-fail, and pass paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)