### PR TITLE
refactor(e2e): full-fidelity reporting via test attachments

### DIFF
--- a/e2e/selectors/__tests__/report-builder.test.ts
+++ b/e2e/selectors/__tests__/report-builder.test.ts
@@ -1,240 +1,262 @@
 import { describe, it, expect } from 'vitest';
-import type { PlatformReport } from '../notifier';
 import {
-  extractPlatform,
-  parseAnnotationCounts,
-  detectSkipReason,
+  parseDetailAttachment,
   processTestResult,
   buildValidationReport,
+  ATTACHMENT_NAME,
+  type TargetDetail,
   type TestEndInput,
 } from '../report-builder';
+import type { PlatformReport } from '../notifier';
+import type { SelectorResult, WarnDetail } from '../classifier';
+import type { BaselineComparison } from '../baseline';
 
-// --- Factory helpers ---
-
-function makeAnnotations(
-  counts: { pass?: number; warn?: number; fail?: number; baseline_issues?: number } = {},
-): Array<{ type: string; description: string }> {
-  return [
-    { type: 'pass', description: String(counts.pass ?? 0) },
-    { type: 'warn', description: String(counts.warn ?? 0) },
-    { type: 'fail', description: String(counts.fail ?? 0) },
-    { type: 'baseline_issues', description: String(counts.baseline_issues ?? 0) },
-  ];
-}
-
-function makeInput(overrides: Partial<TestEndInput> = {}): TestEndInput {
+function makeSelectorResult(overrides: Partial<SelectorResult> = {}): SelectorResult {
   return {
     platform: 'gemini',
-    status: 'passed',
-    annotations: makeAnnotations({ pass: 5 }),
+    group: 'SELECTORS',
+    name: 'turn',
+    selector: '.turn',
+    index: 0,
+    matchCount: 3,
     ...overrides,
   };
 }
 
-// --- Tests ---
+function makeComparison(overrides: Partial<BaselineComparison> = {}): BaselineComparison {
+  return {
+    group: 'SELECTORS',
+    name: 'turn',
+    selector: '.turn',
+    baselineCount: 3,
+    currentCount: 3,
+    status: 'match',
+    ...overrides,
+  };
+}
 
-describe('extractPlatform', () => {
-  it('converts title to lowercase', () => {
-    expect(extractPlatform('Gemini')).toBe('gemini');
+function makeDetail(overrides: Partial<TargetDetail> = {}): TargetDetail {
+  return {
+    platform: 'gemini',
+    target: 'gemini_conv',
+    mode: 'validate',
+    authStatus: 'authenticated',
+    classification: {
+      pass: [makeSelectorResult()],
+      warn: [],
+      fail: [],
+      baselineBlocking: [],
+      baselineAdvisory: [],
+    },
+    ...overrides,
+  };
+}
+
+function inputFor(
+  detail: TargetDetail | undefined,
+  status: TestEndInput['status'] = 'passed'
+): TestEndInput {
+  return {
+    platform: detail?.platform ?? 'gemini',
+    status,
+    attachments: detail
+      ? [
+          {
+            name: ATTACHMENT_NAME,
+            contentType: 'application/json',
+            body: Buffer.from(JSON.stringify(detail)),
+          },
+        ]
+      : [],
+  };
+}
+
+describe('parseDetailAttachment', () => {
+  it('parses the g2o detail attachment body', () => {
+    const detail = makeDetail();
+    const parsed = parseDetailAttachment(inputFor(detail).attachments);
+    expect(parsed?.target).toBe('gemini_conv');
+    expect(parsed?.classification?.pass).toHaveLength(1);
   });
 
-  it('passes through already-lowercase title', () => {
-    expect(extractPlatform('claude')).toBe('claude');
+  it('returns undefined when the attachment is absent', () => {
+    expect(parseDetailAttachment([])).toBeUndefined();
   });
 
-  it('returns "unknown" for empty string', () => {
-    expect(extractPlatform('')).toBe('unknown');
-  });
-});
-
-describe('parseAnnotationCounts', () => {
-  it('extracts all four counts from annotations', () => {
-    const annotations = makeAnnotations({ pass: 5, warn: 2, fail: 0, baseline_issues: 1 });
-    expect(parseAnnotationCounts(annotations)).toEqual({
-      pass: 5,
-      warn: 2,
-      fail: 0,
-      baselineIssues: 1,
-    });
-  });
-
-  it('returns zeros for empty annotations', () => {
-    expect(parseAnnotationCounts([])).toEqual({
-      pass: 0,
-      warn: 0,
-      fail: 0,
-      baselineIssues: 0,
-    });
-  });
-
-  it('returns zero when description is undefined', () => {
-    const annotations = [{ type: 'pass' }]; // no description
-    expect(parseAnnotationCounts(annotations)).toEqual({
-      pass: 0,
-      warn: 0,
-      fail: 0,
-      baselineIssues: 0,
-    });
-  });
-});
-
-describe('detectSkipReason', () => {
-  it('detects AUTH_EXPIRED from skip annotation', () => {
-    const annotations = [
-      { type: 'skip', description: 'gemini: AUTH_EXPIRED — run \'npm run e2e:auth\' to re-login' },
-    ];
-    expect(detectSkipReason(annotations)).toBe('auth_expired');
-  });
-
-  it('detects unreachable from skip annotation', () => {
-    const annotations = [{ type: 'skip', description: 'gemini: site unreachable' }];
-    expect(detectSkipReason(annotations)).toBe('unreachable');
-  });
-
-  it('returns null when no skip annotation exists', () => {
-    const annotations = makeAnnotations({ pass: 5 });
-    expect(detectSkipReason(annotations)).toBeNull();
-  });
-
-  it('returns null for skip with unrecognized reason', () => {
-    const annotations = [{ type: 'skip', description: 'some other reason' }];
-    expect(detectSkipReason(annotations)).toBeNull();
+  it('returns undefined for a malformed body instead of throwing', () => {
+    const parsed = parseDetailAttachment([
+      { name: ATTACHMENT_NAME, contentType: 'application/json', body: Buffer.from('not json') },
+    ]);
+    expect(parsed).toBeUndefined();
   });
 });
 
 describe('processTestResult', () => {
-  it('creates a new platform entry from empty map', () => {
-    const input = makeInput({ platform: 'gemini', annotations: makeAnnotations({ pass: 5, warn: 1 }) });
-    const result = processTestResult(new Map(), input);
+  it('merges classifications from both targets of a platform with REAL objects', () => {
+    const conv = makeDetail({
+      target: 'gemini_conv',
+      classification: {
+        pass: [makeSelectorResult({ name: 'a' })],
+        warn: [],
+        fail: [],
+        baselineBlocking: [],
+        baselineAdvisory: [makeComparison({ status: 'degraded' })],
+      },
+    });
+    const dr = makeDetail({
+      target: 'gemini_dr',
+      classification: {
+        pass: [makeSelectorResult({ name: 'b' }), makeSelectorResult({ name: 'c' })],
+        warn: [],
+        fail: [],
+        baselineBlocking: [makeComparison({ status: 'lost', currentCount: 0 })],
+        baselineAdvisory: [],
+      },
+    });
 
-    expect(result.has('gemini')).toBe(true);
-    const report = result.get('gemini')!;
-    expect(report.authStatus).toBe('authenticated');
-    expect(report.classification?.pass).toHaveLength(5);
-    expect(report.classification?.warn).toHaveLength(1);
+    let map: ReadonlyMap<string, PlatformReport> = new Map();
+    map = processTestResult(map, inputFor(conv));
+    map = processTestResult(map, inputFor(dr, 'failed'));
+
+    const gemini = map.get('gemini')!;
+    const c = gemini.classification!;
+    expect(c.pass).toHaveLength(3);
+    expect(c.pass.map(p => p.name).sort()).toEqual(['a', 'b', 'c']);
+    expect(c.baselineBlocking).toHaveLength(1);
+    expect(c.baselineBlocking[0].status).toBe('lost');
+    expect(c.baselineAdvisory).toHaveLength(1);
+    expect(gemini.failedTargets).toEqual(['gemini_dr']);
   });
 
-  it('merges counts for same platform across multiple tests', () => {
-    const first = makeInput({ platform: 'gemini', annotations: makeAnnotations({ pass: 5, warn: 1 }) });
-    const second = makeInput({ platform: 'gemini', annotations: makeAnnotations({ pass: 3, fail: 2 }) });
+  it('records auth_expired from the detail of a skipped target', () => {
+    const detail = makeDetail({
+      authStatus: 'auth_expired',
+      skipReason: 'gemini: AUTH_EXPIRED — run e2e:auth',
+      classification: undefined,
+    });
 
-    let map = processTestResult(new Map(), first);
-    map = processTestResult(map, second);
+    const map = processTestResult(new Map(), inputFor(detail, 'skipped'));
 
-    const report = map.get('gemini')!;
-    expect(report.classification?.pass).toHaveLength(8);
-    expect(report.classification?.warn).toHaveLength(1);
-    expect(report.classification?.fail).toHaveLength(2);
+    expect(map.get('gemini')!.authStatus).toBe('auth_expired');
   });
 
-  it('sets authStatus and clears classification on skipped test', () => {
-    const input: TestEndInput = {
-      platform: 'gemini',
-      status: 'skipped',
-      annotations: [{ type: 'skip', description: 'gemini: AUTH_EXPIRED — run \'npm run e2e:auth\' to re-login' }],
-    };
-    const result = processTestResult(new Map(), input);
+  it('records test_data_missing from a failed target', () => {
+    const detail = makeDetail({
+      authStatus: 'test_data_missing',
+      classification: undefined,
+    });
 
-    const report = result.get('gemini')!;
-    expect(report.authStatus).toBe('auth_expired');
-    expect(report.classification).toBeUndefined();
+    const map = processTestResult(new Map(), inputFor(detail, 'failed'));
+
+    expect(map.get('gemini')!.authStatus).toBe('test_data_missing');
   });
 
-  it('does not mutate the original map (immutability)', () => {
-    const original: ReadonlyMap<string, PlatformReport> = new Map();
-    const input = makeInput();
-    const result = processTestResult(original, input);
+  it('records stall skips with their target', () => {
+    const detail = makeDetail({
+      skipReason: 'gemini: content did not load (transient — loading indicator present, stall 2/3)',
+      classification: undefined,
+    });
 
-    expect(original.size).toBe(0);
-    expect(result.size).toBe(1);
-    expect(result).not.toBe(original);
+    const map = processTestResult(new Map(), inputFor(detail, 'skipped'));
+
+    const gemini = map.get('gemini')!;
+    expect(gemini.stallSkips).toEqual(['gemini_conv']);
+    expect(gemini.authStatus).toBe('authenticated');
   });
 
-  it('handles unreachable skip reason', () => {
-    const input: TestEndInput = {
+  it('marks a failed target even when the detail attachment is missing (crash before attach)', () => {
+    const map = processTestResult(new Map(), {
       platform: 'chatgpt',
-      status: 'skipped',
-      annotations: [{ type: 'skip', description: 'chatgpt: site unreachable' }],
-    };
-    const result = processTestResult(new Map(), input);
+      status: 'failed',
+      attachments: [],
+    });
 
-    expect(result.get('chatgpt')!.authStatus).toBe('unreachable');
-    expect(result.get('chatgpt')!.classification).toBeUndefined();
+    expect(map.get('chatgpt')!.failedTargets).toEqual(['chatgpt']);
   });
 });
 
-describe('buildValidationReport', () => {
-  function makePlatformMap(
-    entries: Array<{ platform: string; authStatus?: string; pass?: number; warn?: number; fail?: number }>,
-  ): Map<string, PlatformReport> {
-    const map = new Map<string, PlatformReport>();
-    for (const e of entries) {
-      if (e.authStatus === 'auth_expired' || e.authStatus === 'unreachable') {
-        map.set(e.platform, {
-          platform: e.platform,
-          authStatus: e.authStatus,
-          classification: undefined,
-        });
-      } else {
-        map.set(e.platform, {
-          platform: e.platform,
-          authStatus: 'authenticated',
-          classification: {
-            pass: new Array(e.pass ?? 0).fill(null),
-            warn: new Array(e.warn ?? 0).fill(null),
-            fail: new Array(e.fail ?? 0).fill(null),
-            baselineIssues: [],
-          },
-        });
-      }
-    }
-    return map;
+describe('buildValidationReport overallStatus', () => {
+  function reportFor(inputs: TestEndInput[]): ReturnType<typeof buildValidationReport> {
+    let map: ReadonlyMap<string, PlatformReport> = new Map();
+    for (const input of inputs) map = processTestResult(map, input);
+    return buildValidationReport(map, 'UTC');
   }
 
-  it('returns "pass" when all platforms pass', () => {
-    const map = makePlatformMap([
-      { platform: 'gemini', pass: 5 },
-      { platform: 'claude', pass: 3 },
-    ]);
-    const report = buildValidationReport(map);
+  it('is pass when everything is clean', () => {
+    const report = reportFor([inputFor(makeDetail())]);
     expect(report.overallStatus).toBe('pass');
-    expect(report.platforms).toHaveLength(2);
-    expect(report.timestamp).toBeTruthy();
   });
 
-  it('returns "fail" when any platform has failures', () => {
-    const map = makePlatformMap([
-      { platform: 'gemini', pass: 5, fail: 1 },
-      { platform: 'claude', pass: 3 },
+  it('is fail when any Playwright test failed (even without detail)', () => {
+    const report = reportFor([
+      { platform: 'chatgpt', status: 'failed', attachments: [] },
+      inputFor(makeDetail()),
     ]);
-    expect(buildValidationReport(map).overallStatus).toBe('fail');
+    expect(report.overallStatus).toBe('fail');
   });
 
-  it('returns "auth_expired" when no fail but auth expired', () => {
-    const map = makePlatformMap([
-      { platform: 'gemini', authStatus: 'auth_expired' },
-      { platform: 'claude', pass: 3 },
-    ]);
-    expect(buildValidationReport(map).overallStatus).toBe('auth_expired');
+  it('is fail on baseline blocking violations', () => {
+    const detail = makeDetail({
+      classification: {
+        pass: [],
+        warn: [],
+        fail: [],
+        baselineBlocking: [makeComparison({ status: 'new_selector', baselineCount: -1 })],
+        baselineAdvisory: [],
+      },
+    });
+    expect(reportFor([inputFor(detail, 'failed')]).overallStatus).toBe('fail');
   });
 
-  it('returns "warn" when only warnings exist', () => {
-    const map = makePlatformMap([
-      { platform: 'gemini', pass: 5, warn: 1 },
-      { platform: 'claude', pass: 3 },
-    ]);
-    expect(buildValidationReport(map).overallStatus).toBe('warn');
+  it('is fail on dead primaries (warn entries)', () => {
+    const warnDetail: WarnDetail = {
+      failedPrimary: makeSelectorResult({ matchCount: 0 }),
+      workingFallback: makeSelectorResult({ index: 1 }),
+    };
+    const detail = makeDetail({
+      classification: {
+        pass: [],
+        warn: [warnDetail],
+        fail: [],
+        baselineBlocking: [],
+        baselineAdvisory: [],
+      },
+    });
+    expect(reportFor([inputFor(detail, 'failed')]).overallStatus).toBe('fail');
   });
 
-  it('"fail" takes priority over "auth_expired"', () => {
-    const map = makePlatformMap([
-      { platform: 'gemini', pass: 3, fail: 1 },
-      { platform: 'claude', authStatus: 'auth_expired' },
-    ]);
-    expect(buildValidationReport(map).overallStatus).toBe('fail');
+  it('is fail on test_data_missing', () => {
+    const detail = makeDetail({ authStatus: 'test_data_missing', classification: undefined });
+    expect(reportFor([inputFor(detail, 'failed')]).overallStatus).toBe('fail');
   });
 
-  it('returns "pass" for empty map', () => {
-    expect(buildValidationReport(new Map()).overallStatus).toBe('pass');
+  it('is auth_expired when a session died and nothing failed harder', () => {
+    const detail = makeDetail({
+      authStatus: 'auth_expired',
+      skipReason: 'AUTH_EXPIRED',
+      classification: undefined,
+    });
+    expect(reportFor([inputFor(detail, 'skipped')]).overallStatus).toBe('auth_expired');
+  });
+
+  it('is warn on advisory-only degradation', () => {
+    const detail = makeDetail({
+      classification: {
+        pass: [makeSelectorResult()],
+        warn: [],
+        fail: [],
+        baselineBlocking: [],
+        baselineAdvisory: [makeComparison({ status: 'degraded', currentCount: 1 })],
+      },
+    });
+    expect(reportFor([inputFor(detail)]).overallStatus).toBe('warn');
+  });
+
+  it('is warn on a stall skip (transient, but visible)', () => {
+    const detail = makeDetail({
+      skipReason: 'stall 1/3 — transient',
+      classification: undefined,
+    });
+    expect(reportFor([inputFor(detail, 'skipped')]).overallStatus).toBe('warn');
   });
 });

--- a/e2e/selectors/classifier.ts
+++ b/e2e/selectors/classifier.ts
@@ -29,12 +29,6 @@ export interface ClassificationResult {
   warn: WarnDetail[];
   /** All selectors failed — includes the primary's metadata */
   fail: SelectorResult[];
-  /**
-   * All non-match baseline comparisons (blocking + advisory).
-   * Kept for the legacy report pipeline; removed once the reporter
-   * consumes the split buckets directly.
-   */
-  baselineIssues: BaselineComparison[];
   /** lost / new_selector / removed — must fail the run (baseline contract) */
   baselineBlocking: BaselineComparison[];
   /** degraded — reported for observability, not enforced */
@@ -85,5 +79,5 @@ export function classifyResults(
   const baselineBlocking = baselineIssues.filter(c => c.status !== 'degraded');
   const baselineAdvisory = baselineIssues.filter(c => c.status === 'degraded');
 
-  return { pass, warn, fail, baselineIssues, baselineBlocking, baselineAdvisory };
+  return { pass, warn, fail, baselineBlocking, baselineAdvisory };
 }

--- a/e2e/selectors/notifier.ts
+++ b/e2e/selectors/notifier.ts
@@ -5,8 +5,7 @@
  * when WARN, FAIL, or AUTH_EXPIRED conditions are detected.
  */
 
-import type { ClassificationResult, WarnDetail, SelectorResult } from './classifier';
-import type { BaselineComparison } from './baseline';
+import type { ClassificationResult } from './classifier';
 import type { AuthStatus } from './auth-check';
 
 interface NotificationConfig {
@@ -18,7 +17,12 @@ interface NotificationConfig {
 export interface PlatformReport {
   platform: string;
   authStatus: AuthStatus;
+  /** Merged across the platform's targets; real objects, never placeholders. */
   classification?: ClassificationResult;
+  /** Targets whose Playwright test failed/timed out/interrupted. */
+  failedTargets: string[];
+  /** Targets skipped on a transient content stall. */
+  stallSkips: string[];
 }
 
 export interface ValidationReport {
@@ -69,7 +73,20 @@ export async function notifyObsidian(
   }
 }
 
-function generateMarkdown(report: ValidationReport): string {
+const AUTH_LABELS: Readonly<Record<Exclude<AuthStatus, 'authenticated'>, string>> = {
+  auth_expired: '🔑 Authentication Expired',
+  unreachable: '🔌 Unreachable',
+  test_data_missing: '🗑️ Test Data Missing',
+};
+
+const AUTH_GUIDANCE: Readonly<Record<Exclude<AuthStatus, 'authenticated'>, string>> = {
+  auth_expired: "Run `npm run e2e:auth` to re-authenticate.",
+  unreachable: 'The site could not be reached; check network / service status.',
+  test_data_missing:
+    'The pinned test conversation no longer opens — refresh the `*_CONV_URL` value in `e2e/.env.local`.',
+};
+
+export function generateMarkdown(report: ValidationReport): string {
   const dateStr = report.timestamp.slice(0, 10);
   const lines: string[] = [
     '---',
@@ -84,92 +101,112 @@ function generateMarkdown(report: ValidationReport): string {
     '',
     '## Summary',
     '',
-    '| Platform | Auth | Pass | Warn | Fail | Baseline |',
-    '|----------|------|------|------|------|----------|',
+    '| Platform | Auth | Pass | Dead Primary | Fail | BL Blocking | BL Advisory | Stall Skips |',
+    '|----------|------|------|--------------|------|-------------|-------------|-------------|',
   ];
 
   for (const p of report.platforms) {
-    if (p.authStatus !== 'authenticated' || !p.classification) {
-      const authIcon = p.authStatus === 'auth_expired' ? '🔑 EXPIRED' : '🔌 DOWN';
-      lines.push(`| ${p.platform} | ${authIcon} | - | - | - | - |`);
-    } else {
-      const c = p.classification;
-      lines.push(
-        `| ${p.platform} | ✅ | ${c.pass.length} | ${c.warn.length} | ${c.fail.length} | ${c.baselineIssues.length} |`
-      );
-    }
+    const auth = p.authStatus === 'authenticated' ? '✅' : AUTH_LABELS[p.authStatus];
+    const c = p.classification;
+    lines.push(
+      `| ${p.platform} | ${auth} | ${c?.pass.length ?? '-'} | ${c?.warn.length ?? '-'} | ` +
+        `${c?.fail.length ?? '-'} | ${c?.baselineBlocking.length ?? '-'} | ` +
+        `${c?.baselineAdvisory.length ?? '-'} | ${p.stallSkips.length || '-'} |`
+    );
   }
 
   lines.push('');
 
   for (const p of report.platforms) {
+    const sections: string[] = [];
+
     if (p.authStatus !== 'authenticated') {
-      lines.push(
-        `## ${p.platform} — ${p.authStatus === 'auth_expired' ? '🔑 Authentication Expired' : '🔌 Unreachable'}`
-      );
-      lines.push('');
-      lines.push('Run `npm run e2e:auth` to re-authenticate.');
-      lines.push('');
-      continue;
+      sections.push(`### ${AUTH_LABELS[p.authStatus]}`, '', AUTH_GUIDANCE[p.authStatus], '');
     }
 
-    if (!p.classification) continue;
+    if (p.stallSkips.length > 0) {
+      sections.push(
+        '### ⏳ Content Stall (skipped)',
+        '',
+        `Targets: ${p.stallSkips.join(', ')} — escalates to FAIL after 3 consecutive stalls.`,
+        ''
+      );
+    }
+
+    if (p.failedTargets.length > 0 && !p.classification) {
+      sections.push(
+        '### ❌ Test Failed Before Validation',
+        '',
+        `Targets: ${p.failedTargets.join(', ')} — see the Playwright output for the failure message.`,
+        ''
+      );
+    }
+
     const c = p.classification;
-
-    if (c.warn.length === 0 && c.fail.length === 0 && c.baselineIssues.length === 0) continue;
-
-    lines.push(`## ${p.platform}`);
-    lines.push('');
-
-    if (c.warn.length > 0) {
-      lines.push('### ⚠️ Warnings (primary failed, fallback OK)');
-      lines.push('');
-      // Filter real WarnDetail objects (reporter uses null placeholders for count-only data)
-      const detailedWarns = c.warn.filter((w): w is WarnDetail => w != null);
-      if (detailedWarns.length > 0) {
-        lines.push('| Name | Failed Primary | Working Fallback | Fallback Matches |');
-        lines.push('|------|----------------|------------------|------------------|');
-        for (const w of detailedWarns) {
-          lines.push(
+    if (c) {
+      if (c.warn.length > 0) {
+        sections.push(
+          '### 💀 Dead Primary Selectors (FAIL — fallback carrying)',
+          '',
+          '| Name | Failed Primary | Working Fallback | Fallback Matches |',
+          '|------|----------------|------------------|------------------|'
+        );
+        for (const w of c.warn) {
+          sections.push(
             `| ${w.failedPrimary.group}:${w.failedPrimary.name} | \`${w.failedPrimary.selector}\` | \`${w.workingFallback.selector}\` | ${w.workingFallback.matchCount} |`
           );
         }
-      } else {
-        lines.push(`${c.warn.length} selector(s) with primary failure but working fallback.`);
+        sections.push('');
       }
-      lines.push('');
+
+      if (c.fail.length > 0) {
+        sections.push(
+          '### ❌ Failures (all selector variants broken)',
+          '',
+          '| Name | Primary Selector |',
+          '|------|------------------|'
+        );
+        for (const f of c.fail) {
+          sections.push(`| ${f.group}:${f.name} | \`${f.selector}\` |`);
+        }
+        sections.push('');
+      }
+
+      if (c.baselineBlocking.length > 0) {
+        sections.push(
+          '### 🚫 Baseline Contract Violations (FAIL)',
+          '',
+          "Intentional selector changes must be recorded via `npm run e2e:baseline:update`.",
+          '',
+          '| Selector | Status | Baseline | Current |',
+          '|----------|--------|----------|---------|'
+        );
+        for (const b of c.baselineBlocking) {
+          sections.push(
+            `| ${b.group}:${b.name} \`${b.selector}\` | ${b.status} | ${b.baselineCount} | ${b.currentCount} |`
+          );
+        }
+        sections.push('');
+      }
+
+      if (c.baselineAdvisory.length > 0) {
+        sections.push(
+          '### 📉 Baseline Degradation (advisory)',
+          '',
+          '| Selector | Baseline | Current |',
+          '|----------|----------|---------|'
+        );
+        for (const b of c.baselineAdvisory) {
+          sections.push(
+            `| ${b.group}:${b.name} \`${b.selector}\` | ${b.baselineCount} | ${b.currentCount} |`
+          );
+        }
+        sections.push('');
+      }
     }
 
-    if (c.fail.length > 0) {
-      lines.push('### ❌ Failures (all selectors broken)');
-      lines.push('');
-      const detailedFails = c.fail.filter((f): f is SelectorResult => f != null);
-      if (detailedFails.length > 0) {
-        lines.push('| Name | Primary Selector |');
-        lines.push('|------|------------------|');
-        for (const f of detailedFails) {
-          lines.push(`| ${f.group}:${f.name} | \`${f.selector}\` |`);
-        }
-      } else {
-        lines.push(`${c.fail.length} selector(s) with all variants broken.`);
-      }
-      lines.push('');
-    }
-
-    if (c.baselineIssues.length > 0) {
-      lines.push('### 📉 Baseline Degradation');
-      lines.push('');
-      const detailedBaseline = c.baselineIssues.filter((b): b is BaselineComparison => b != null);
-      if (detailedBaseline.length > 0) {
-        lines.push('| Selector | Baseline | Current | Status |');
-        lines.push('|----------|----------|---------|--------|');
-        for (const b of detailedBaseline) {
-          lines.push(`| ${b.name} | ${b.baselineCount} | ${b.currentCount} | ${b.status} |`);
-        }
-      } else {
-        lines.push(`${c.baselineIssues.length} selector(s) with baseline degradation.`);
-      }
-      lines.push('');
+    if (sections.length > 0) {
+      lines.push(`## ${p.platform}`, '', ...sections);
     }
   }
 

--- a/e2e/selectors/obsidian-reporter.ts
+++ b/e2e/selectors/obsidian-reporter.ts
@@ -1,15 +1,17 @@
 /**
  * Custom Playwright Reporter: sends Obsidian notifications after test completion.
  *
- * Replaces the broken globalTeardown approach (which could not read report.json
- * because Playwright writes it AFTER teardown). This reporter collects test
- * results directly via onTestEnd() and sends the notification in onEnd().
+ * Collects per-target detail from the JSON attachment each test emits
+ * (test.info().attach — the official structured-data channel) and builds a
+ * full-fidelity report: real classification objects, per-target failures,
+ * stall skips, and auth/test-data states. Replaces the v1 annotation-count
+ * transport that reduced everything to four integers.
  *
  * @see docs/adr/006-custom-reporter-for-obsidian-notification.md
  * @see docs/design/DES-015-live-selector-validation.md
  */
 
-import type { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter';
+import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
@@ -28,14 +30,14 @@ class ObsidianReporter implements Reporter {
     this.platformMap = processTestResult(this.platformMap, {
       platform,
       status: result.status,
-      annotations: result.annotations,
+      attachments: result.attachments,
     });
   }
 
-  async onEnd(_result: FullResult): Promise<void> {
+  async onEnd(): Promise<void> {
     const report = buildValidationReport(this.platformMap, process.env.TIMEZONE);
 
-    // Save timestamped JSON report
+    // Save timestamped JSON report (full detail — real objects, no placeholders)
     const resultsDir = path.join(import.meta.dirname, '..', 'results');
     try {
       if (!fs.existsSync(resultsDir)) {

--- a/e2e/selectors/report-builder.ts
+++ b/e2e/selectors/report-builder.ts
@@ -1,8 +1,11 @@
 /**
  * Pure functions for building ValidationReport from Playwright test results.
  *
- * Extracted from the Reporter class for unit-testability.
- * All functions are side-effect-free and operate on immutable inputs.
+ * Detail transport: each test attaches its full result (classification with
+ * real objects, auth status, skip reason) as a JSON attachment via
+ * test.info().attach() — the official Playwright channel for structured
+ * data. This replaces the v1 annotation counts, which collapsed everything
+ * to four integers and made saved reports arrays of nulls.
  */
 
 import type { AuthStatus } from './auth-check';
@@ -10,11 +13,36 @@ import type { ClassificationResult } from './classifier';
 import type { PlatformReport, ValidationReport } from './notifier';
 import { formatDateWithTimezone } from '../../src/lib/date-utils';
 
+/** Attachment name carrying the per-target detail JSON. */
+export const ATTACHMENT_NAME = 'g2o-detail';
+
+/** Per-target detail attached by the spec at every exit point. */
+export interface TargetDetail {
+  platform: string;
+  /** Ready-key of the validated target (e.g. gemini_conv, gemini_dr). */
+  target: string;
+  mode: 'validate' | 'update';
+  authStatus: AuthStatus;
+  /** Present when the target was skipped (auth, unreachable, stall). */
+  skipReason?: string;
+  /** Baseline usability at validation time (validate mode only). */
+  baselineState?: 'ok' | 'legacy' | 'missing_groups';
+  /** Present when validation ran. */
+  classification?: ClassificationResult;
+}
+
+export interface AttachmentLike {
+  name: string;
+  contentType: string;
+  body?: Buffer;
+  path?: string;
+}
+
 /** Minimal input extracted from Playwright's onTestEnd callback. */
 export interface TestEndInput {
   platform: string;
   status: 'passed' | 'failed' | 'skipped' | 'timedOut' | 'interrupted';
-  annotations: ReadonlyArray<{ type: string; description?: string }>;
+  attachments: ReadonlyArray<AttachmentLike>;
 }
 
 /**
@@ -26,42 +54,49 @@ export function extractPlatform(parentTitle: string): string {
   return trimmed || 'unknown';
 }
 
-/**
- * Parse annotation counts from a test result's annotations array.
- * Returns {pass, warn, fail, baselineIssues} as integers (defaults to 0).
- */
-export function parseAnnotationCounts(
-  annotations: ReadonlyArray<{ type: string; description?: string }>
-): { pass: number; warn: number; fail: number; baselineIssues: number } {
-  const getCount = (type: string): number => {
-    const ann = annotations.find(a => a.type === type);
-    if (!ann?.description) return 0;
-    const parsed = parseInt(ann.description, 10);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  };
+/** Parse the g2o detail attachment; undefined when absent or malformed. */
+export function parseDetailAttachment(
+  attachments: ReadonlyArray<AttachmentLike>
+): TargetDetail | undefined {
+  const attachment = attachments.find(a => a.name === ATTACHMENT_NAME);
+  if (!attachment?.body) return undefined;
+  try {
+    return JSON.parse(attachment.body.toString('utf-8')) as TargetDetail;
+  } catch {
+    return undefined;
+  }
+}
 
+const AUTH_SEVERITY: Readonly<Record<AuthStatus, number>> = {
+  authenticated: 0,
+  unreachable: 1,
+  auth_expired: 2,
+  test_data_missing: 3,
+};
+
+function worseAuthStatus(a: AuthStatus, b: AuthStatus): AuthStatus {
+  return AUTH_SEVERITY[b] > AUTH_SEVERITY[a] ? b : a;
+}
+
+function mergeClassification(
+  existing: ClassificationResult | undefined,
+  incoming: ClassificationResult
+): ClassificationResult {
+  if (!existing) return incoming;
   return {
-    pass: getCount('pass'),
-    warn: getCount('warn'),
-    fail: getCount('fail'),
-    baselineIssues: getCount('baseline_issues'),
+    pass: [...existing.pass, ...incoming.pass],
+    warn: [...existing.warn, ...incoming.warn],
+    fail: [...existing.fail, ...incoming.fail],
+    baselineBlocking: [...existing.baselineBlocking, ...incoming.baselineBlocking],
+    baselineAdvisory: [...existing.baselineAdvisory, ...incoming.baselineAdvisory],
   };
 }
 
-/**
- * Detect skip reason from annotations.
- * Returns 'auth_expired' | 'unreachable' | null.
- */
-export function detectSkipReason(
-  annotations: ReadonlyArray<{ type: string; description?: string }>
-): 'auth_expired' | 'unreachable' | null {
-  const skipAnn = annotations.find(a => a.type === 'skip');
-  if (!skipAnn?.description) return null;
-
-  if (skipAnn.description.includes('AUTH_EXPIRED')) return 'auth_expired';
-  if (skipAnn.description.includes('unreachable')) return 'unreachable';
-  return null;
-}
+const FAILED_STATUSES: ReadonlySet<TestEndInput['status']> = new Set([
+  'failed',
+  'timedOut',
+  'interrupted',
+]);
 
 /**
  * Process a single test result and merge into the platform map.
@@ -72,50 +107,50 @@ export function processTestResult(
   input: TestEndInput
 ): Map<string, PlatformReport> {
   const newMap = new Map(platformMap);
-  const { platform, status, annotations } = input;
+  const detail = parseDetailAttachment(input.attachments);
 
-  // Handle skipped tests
-  if (status === 'skipped') {
-    const skipReason = detectSkipReason(annotations);
-    const authStatus: AuthStatus = skipReason ?? 'authenticated';
-    newMap.set(platform, {
-      platform,
-      authStatus,
-      classification: undefined,
-    });
-    return newMap;
+  const existing = newMap.get(input.platform);
+  const report: PlatformReport = {
+    platform: input.platform,
+    authStatus: existing?.authStatus ?? 'authenticated',
+    classification: existing?.classification,
+    failedTargets: [...(existing?.failedTargets ?? [])],
+    stallSkips: [...(existing?.stallSkips ?? [])],
+  };
+
+  const targetName = detail?.target ?? input.platform;
+
+  if (FAILED_STATUSES.has(input.status)) {
+    report.failedTargets.push(targetName);
+  }
+  if (detail) {
+    report.authStatus = worseAuthStatus(report.authStatus, detail.authStatus);
+    if (
+      input.status === 'skipped' &&
+      detail.skipReason !== undefined &&
+      detail.authStatus === 'authenticated'
+    ) {
+      // Authenticated skip = content stall (auth/unreachable skips carry
+      // their own authStatus and are tracked via that field instead)
+      report.stallSkips.push(targetName);
+    }
+    if (detail.classification) {
+      report.classification = mergeClassification(existing?.classification, detail.classification);
+    }
   }
 
-  // Parse annotation counts
-  const counts = parseAnnotationCounts(annotations);
-
-  // Get or create platform entry
-  const existing = newMap.get(platform);
-  const existingClassification = existing?.classification;
-
-  // Merge counts using placeholder arrays (notifier reads .length only)
-  const classification: ClassificationResult = {
-    pass: [...(existingClassification?.pass ?? []), ...new Array<null>(counts.pass).fill(null)],
-    warn: [...(existingClassification?.warn ?? []), ...new Array<null>(counts.warn).fill(null)],
-    fail: [...(existingClassification?.fail ?? []), ...new Array<null>(counts.fail).fill(null)],
-    baselineIssues: [
-      ...(existingClassification?.baselineIssues ?? []),
-      ...new Array<null>(counts.baselineIssues).fill(null),
-    ],
-  } as ClassificationResult;
-
-  newMap.set(platform, {
-    platform,
-    authStatus: existing?.authStatus ?? ('authenticated' as AuthStatus),
-    classification,
-  });
-
+  newMap.set(input.platform, report);
   return newMap;
 }
 
 /**
  * Build the final ValidationReport from accumulated platform data.
+ *
  * overallStatus priority: fail > auth_expired > warn > pass.
+ * fail includes: any failed Playwright test (even without detail),
+ * test_data_missing, zero-match failures, dead primaries (warn entries),
+ * and baseline contract violations. warn covers advisory degradation and
+ * transient stall skips.
  */
 export function buildValidationReport(
   platformMap: ReadonlyMap<string, PlatformReport>,
@@ -124,9 +159,19 @@ export function buildValidationReport(
   const platforms = [...platformMap.values()];
   const timestamp = formatDateWithTimezone(new Date(), timezone ?? 'UTC');
 
-  const hasFail = platforms.some(p => p.classification && p.classification.fail.length > 0);
+  const hasFail = platforms.some(
+    p =>
+      p.failedTargets.length > 0 ||
+      p.authStatus === 'test_data_missing' ||
+      (p.classification !== undefined &&
+        (p.classification.fail.length > 0 ||
+          p.classification.warn.length > 0 ||
+          p.classification.baselineBlocking.length > 0))
+  );
   const hasAuthExpired = platforms.some(p => p.authStatus === 'auth_expired');
-  const hasWarn = platforms.some(p => p.classification && p.classification.warn.length > 0);
+  const hasWarn = platforms.some(
+    p => p.stallSkips.length > 0 || (p.classification?.baselineAdvisory.length ?? 0) > 0
+  );
 
   let overallStatus: ValidationReport['overallStatus'];
   if (hasFail) overallStatus = 'fail';

--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -34,6 +34,19 @@ import {
 import { classifyResults, type SelectorResult } from './classifier';
 import { waitForReadyWithRetry, decideLoadOutcome } from './load-readiness';
 import { getConsecutiveStalls, recordStall, resetStalls } from './stall-tracker';
+import { ATTACHMENT_NAME, type TargetDetail } from './report-builder';
+
+/**
+ * Attach the per-target detail JSON for ObsidianReporter.
+ * test.info().attach is the official channel for structured data between
+ * a test and a custom reporter (result.attachments in onTestEnd).
+ */
+async function attachDetail(detail: TargetDetail): Promise<void> {
+  await test.info().attach(ATTACHMENT_NAME, {
+    body: JSON.stringify(detail),
+    contentType: 'application/json',
+  });
+}
 
 dotenv.config({ path: path.join(import.meta.dirname, '..', '.env.local') });
 
@@ -109,17 +122,25 @@ async function runPlatformValidation(
   try {
     // Auth pre-flight
     const authStatus: AuthStatus = await checkAuthStatus(page, platform, url!);
+    const mode: TargetDetail['mode'] = process.env.UPDATE_BASELINE === '1' ? 'update' : 'validate';
 
     if (authStatus === 'unreachable') {
-      test.skip(true, `${platform}: site unreachable`);
+      const reason = `${platform}: site unreachable`;
+      await attachDetail({ platform, target: readyKey, mode, authStatus, skipReason: reason });
+      test.skip(true, reason);
       return;
     }
     if (authStatus === 'auth_expired') {
-      test.skip(true, `${platform}: AUTH_EXPIRED — run 'npm run e2e:auth' to re-login`);
+      const reason = `${platform}: AUTH_EXPIRED — run 'npm run e2e:auth' to re-login`;
+      await attachDetail({ platform, target: readyKey, mode, authStatus, skipReason: reason });
+      test.skip(true, reason);
       return;
     }
     // Session is fine but the pinned conversation no longer opens: this is
     // dead test data, not an auth problem — fail loudly with the fix.
+    if (authStatus === 'test_data_missing') {
+      await attachDetail({ platform, target: readyKey, mode, authStatus });
+    }
     expect(
       authStatus,
       `${platform}: authenticated but the conversation URL did not open (${url}) — ` +
@@ -172,6 +193,13 @@ async function runPlatformValidation(
         );
         if (decision.action === 'skip') {
           recordStall(readyKey);
+          await attachDetail({
+            platform,
+            target: readyKey,
+            mode,
+            authStatus,
+            skipReason: decision.reason,
+          });
           test.skip(true, decision.reason);
           return;
         }
@@ -189,8 +217,11 @@ async function runPlatformValidation(
 
     // Baseline contract (v2): explicit update mode writes; normal mode enforces.
     const groupNames = Object.keys(selectorGroups);
-    const updateMode = process.env.UPDATE_BASELINE === '1';
+    const updateMode = mode === 'update';
     let baselineComparisons: BaselineComparison[] = [];
+
+    let baselineState: TargetDetail['baselineState'] = 'ok';
+    let missingGroups: string[] = [];
 
     if (updateMode) {
       const grouped: Record<string, SelectorResult[]> = {};
@@ -203,29 +234,39 @@ async function runPlatformValidation(
       console.log(`${platform}: baseline updated for groups: ${groupNames.join(', ')}`);
     } else {
       const loaded = loadBaselineGroups(platform, groupNames);
-      expect(
-        loaded.legacy,
-        `${platform}: baseline file is legacy v1 — run 'npm run e2e:baseline:update'`
-      ).toBe(false);
-      expect(
-        loaded.missingGroups,
-        `${platform}: no baseline for group(s) ${loaded.missingGroups.join(', ')} — run 'npm run e2e:baseline:update'`
-      ).toEqual([]);
-      baselineComparisons = compareWithBaseline(allResults, loaded.entries);
+      if (loaded.legacy) {
+        baselineState = 'legacy';
+      } else if (loaded.missingGroups.length > 0) {
+        baselineState = 'missing_groups';
+        missingGroups = loaded.missingGroups;
+      } else {
+        baselineComparisons = compareWithBaseline(allResults, loaded.entries);
+      }
     }
 
     // Classify
     const classified = classifyResults(allResults, baselineComparisons);
 
-    // Record in annotations for ObsidianReporter to read
-    test
-      .info()
-      .annotations.push(
-        { type: 'pass', description: String(classified.pass.length) },
-        { type: 'warn', description: String(classified.warn.length) },
-        { type: 'fail', description: String(classified.fail.length) },
-        { type: 'baseline_issues', description: String(classified.baselineIssues.length) }
-      );
+    // Attach the full detail for ObsidianReporter BEFORE asserting, so a
+    // failing assertion still leaves a complete record in the report.
+    await attachDetail({
+      platform,
+      target: readyKey,
+      mode,
+      authStatus,
+      baselineState,
+      classification: classified,
+    });
+
+    // Assert: the baseline itself must be usable before its diff means anything
+    expect(
+      baselineState,
+      `${platform}: baseline file is legacy v1 — run 'npm run e2e:baseline:update'`
+    ).not.toBe('legacy');
+    expect(
+      baselineState,
+      `${platform}: no baseline for group(s) ${missingGroups.join(', ')} — run 'npm run e2e:baseline:update'`
+    ).not.toBe('missing_groups');
 
     // Assert: zero-match selector names always fail
     expect(


### PR DESCRIPTION
## Summary

R3 of the approved E2E redesign — the report pipeline now preserves every detail instead of collapsing to four integers:

- **Attachment transport**: each test attaches its complete result as JSON via `test.info().attach()` (verified against official Playwright docs via context7 — the sanctioned channel for structured data to custom reporters) at every exit point: auth/unreachable skips, stall skips, `test_data_missing`, and full classification **before** the assertions so failing runs still leave complete records
- **report-builder v2**: platform reports carry real merged classification objects, per-target failure names, and stall-skip targets; a failed Playwright test counts toward `overallStatus` even with no attachment (crash-early safety) — this kills the "All selectors passed" lie on 6-failed runs
- **overallStatus reflects R2 policy**: dead primaries / baseline contract violations / `test_data_missing` → fail; advisory degradation / transient stalls → warn; `baselineState` (legacy/missing) recorded in the detail and asserted after attachment
- Legacy `baselineIssues` compat field removed; Obsidian note renders blocking/advisory/stall/data-missing sections with concrete selectors and fix guidance
- TDD: report-builder suite rewritten RED-first (16 tests: attachment parsing incl. malformed bodies, real-object merging, status matrix)

## Live verification (CDP daemon, 2 runs)

`report-2026-07-04.json` now stores: named failed targets (`claude_conv`, `chatgpt_conv`, …), gemini stall skips by target, claude's dead primary (`userWrapper` + its selector — matching the R1 finding), and notebooklm's clean pass — and the run **sent a fail notification** instead of claiming success. The first live run also exposed (and this PR fixed) the last fidelity gap: baseline-usability asserts previously fired before attachment.

## Test plan

- [x] `npm run test:coverage` passes (1079/1079; thresholds green)
- [x] `npx tsc --noEmit` clean; edited files lint clean
- [x] Live runs verify detail preservation and truthful overallStatus

🤖 Generated with [Claude Code](https://claude.com/claude-code)