### PR TITLE
feat(e2e): add gemini-pick-url helper for refreshing test conversation URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,12 +90,20 @@ Naming: Nix attribute names cannot contain `:`, so `npm run e2e:auth` maps to `n
 ```bash
 nix run .#e2e-auth                 # Manual login for all platforms
 nix run .#e2e-selectors            # Run selector validation
+nix run .#e2e-baseline-update      # Rewrite selector baselines from the live pages (only write path)
+nix run .#e2e-gemini-pick-url      # Pick a live Gemini conversation URL for .env.local
 nix run .#e2e-daemon -- start      # Start CDP daemon (headless Chrome + keep-alive)
 nix run .#e2e-daemon -- stop       # Stop CDP daemon
 nix run .#e2e-daemon -- status     # Check daemon health + open tabs
 ```
 
 Re-authentication workflow: `e2e-daemon -- stop` → `e2e-auth` → `e2e-daemon -- start`
+
+Dead test-conversation workflow (a `test_data_missing` failure or persistent Gemini stall):
+Gemini no longer exposes conversation links as hrefs, so run `e2e-gemini-pick-url` to open a
+conversation via the daemon and print its URL → update `*_CONV_URL` in `e2e/.env.local` →
+`e2e-baseline-update`. Baselines are per-machine (gitignored) and are written ONLY by the
+update command; zero-match selectors are rejected at update time.
 
 Load the extension in Chrome: `chrome://extensions` → Load unpacked → select `dist/` folder
 

--- a/e2e/tools/__tests__/gemini-pick-url.test.ts
+++ b/e2e/tools/__tests__/gemini-pick-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { extractConversationId } from '../gemini-pick-url';
+
+describe('extractConversationId', () => {
+  it('extracts the id from a conversation URL', () => {
+    expect(extractConversationId('https://gemini.google.com/app/8c6eb888f77e1571')).toBe(
+      '8c6eb888f77e1571'
+    );
+  });
+
+  it('handles URLs with query strings and fragments', () => {
+    expect(extractConversationId('https://gemini.google.com/app/abc123def?hl=ja#x')).toBe(
+      'abc123def'
+    );
+  });
+
+  it('returns null for the app root (no conversation opened)', () => {
+    expect(extractConversationId('https://gemini.google.com/app')).toBeNull();
+  });
+
+  it('returns null for non-Gemini URLs', () => {
+    expect(extractConversationId('https://evil.com/app/abc123')).toBeNull();
+  });
+});

--- a/e2e/tools/__tests__/gemini-pick-url.test.ts
+++ b/e2e/tools/__tests__/gemini-pick-url.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { extractConversationId } from '../gemini-pick-url';
+import { extractConversationId, isGeminiUrl } from '../gemini-pick-url';
+
+describe('isGeminiUrl', () => {
+  it('accepts the exact Gemini hostname', () => {
+    expect(isGeminiUrl('https://gemini.google.com/app')).toBe(true);
+    expect(isGeminiUrl('https://gemini.google.com/app/8c6eb888f77e1571')).toBe(true);
+  });
+
+  it('rejects lookalike hostnames (CodeQL js/incomplete-url-substring-sanitization)', () => {
+    expect(isGeminiUrl('https://gemini.google.com.attacker.com/app')).toBe(false);
+    expect(isGeminiUrl('https://evil.com/https://gemini.google.com')).toBe(false);
+  });
+
+  it('rejects unparseable URLs', () => {
+    expect(isGeminiUrl('about:blank')).toBe(false);
+    expect(isGeminiUrl('not a url')).toBe(false);
+  });
+});
 
 describe('extractConversationId', () => {
   it('extracts the id from a conversation URL', () => {

--- a/e2e/tools/gemini-pick-url.ts
+++ b/e2e/tools/gemini-pick-url.ts
@@ -25,6 +25,19 @@ export function extractConversationId(url: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Strict hostname check for the Gemini tab.
+ * URL parsing (not startsWith) prevents lookalike hosts such as
+ * "gemini.google.com.attacker.com" (CodeQL js/incomplete-url-substring-sanitization).
+ */
+export function isGeminiUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'gemini.google.com';
+  } catch {
+    return false;
+  }
+}
+
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
 const SPA_SETTLE_MS = 4000;
 
@@ -35,7 +48,7 @@ async function main(): Promise<void> {
   const browser = await chromium.connectOverCDP(`http://127.0.0.1:${config.cdpPort}`);
   try {
     const context = browser.contexts()[0];
-    const tab = context?.pages().find(p => p.url().startsWith('https://gemini.google.com'));
+    const tab = context?.pages().find(p => isGeminiUrl(p.url()));
     if (!tab) {
       console.error(
         '[pick-url] No Gemini tab in the daemon. Start it with: npm run e2e:daemon:start'

--- a/e2e/tools/gemini-pick-url.ts
+++ b/e2e/tools/gemini-pick-url.ts
@@ -1,0 +1,125 @@
+/**
+ * Helper: pick a live Gemini conversation URL for e2e/.env.local.
+ *
+ * Gemini's 2026 sidebar no longer exposes conversations as <a href> links —
+ * items are empty custom elements (gem-nav-list-item) navigated by SPA click
+ * handlers, and the off-canvas mobile layout hides them below ~960px. The
+ * only reliable way to obtain a conversation URL is therefore: desktop
+ * viewport, real pointer click on a sidebar item, then read the SPA-updated
+ * location. This script automates that against the CDP daemon.
+ *
+ * Usage:
+ *   npm run e2e:gemini:pick-url            # first conversation
+ *   npm run e2e:gemini:pick-url -- 3       # 4th conversation (0-based index)
+ *
+ * Prints the conversation URL to update GEMINI_CONV_URL in e2e/.env.local.
+ * Read-only apart from the sidebar click; restores the tab to /app.
+ */
+
+import { chromium } from 'playwright';
+import { loadConfig } from '../daemon/config';
+
+/** Extract the /app/<id> conversation id from a URL, or null. */
+export function extractConversationId(url: string): string | null {
+  const match = url.match(/^https:\/\/gemini\.google\.com\/app\/([0-9a-f]+)/);
+  return match ? match[1] : null;
+}
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+const SPA_SETTLE_MS = 4000;
+
+async function main(): Promise<void> {
+  const index = parseInt(process.argv[2] ?? '0', 10);
+  const config = loadConfig();
+
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${config.cdpPort}`);
+  try {
+    const context = browser.contexts()[0];
+    const tab = context?.pages().find(p => p.url().startsWith('https://gemini.google.com'));
+    if (!tab) {
+      console.error(
+        '[pick-url] No Gemini tab in the daemon. Start it with: npm run e2e:daemon:start'
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // Desktop viewport so the sidenav renders inline (mobile layout hides it)
+    await tab.setViewportSize(DESKTOP_VIEWPORT);
+    await tab.goto('https://gemini.google.com/app', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000,
+    });
+
+    // After a fresh navigation the sidenav starts collapsed (icon rail) and
+    // conversation items render without text. Expand it via its stable
+    // data-test-id (aria-labels are locale-dependent), then wait for the
+    // first text-bearing item.
+    const items = tab.locator('[data-test-id="conversation"]').filter({ hasText: /\S/ });
+    const expandButton = tab.locator('button[data-test-id="side-nav-sparkle-button"]').first();
+    try {
+      await items.first().waitFor({ timeout: 5_000 });
+    } catch {
+      if (await expandButton.count()) {
+        await expandButton.click();
+      }
+      try {
+        await items.first().waitFor({ timeout: 15_000 });
+      } catch {
+        // fall through to the count check below for a uniform error message
+      }
+    }
+    const count = await items.count();
+    if (count === 0) {
+      console.error(
+        '[pick-url] No conversations in the sidebar. Is the daemon session logged in? (npm run e2e:auth)'
+      );
+      process.exitCode = 1;
+      return;
+    }
+    if (index >= count) {
+      console.error(`[pick-url] Index ${index} out of range (${count} conversations visible).`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const target = items.nth(index);
+    const title = (await target.textContent())?.trim().slice(0, 60) ?? '';
+    await target.scrollIntoViewIfNeeded();
+    await target.click({ timeout: 10_000 });
+    await tab.waitForTimeout(SPA_SETTLE_MS);
+
+    const url = tab.url();
+    const id = extractConversationId(url);
+    if (!id) {
+      console.error(`[pick-url] Click did not yield a conversation URL (landed on: ${url})`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log('');
+    console.log(`Conversation: ${title}`);
+    console.log(`URL:          ${url}`);
+    console.log('');
+    console.log('Update e2e/.env.local:');
+    console.log(`  GEMINI_CONV_URL=${url}`);
+    console.log('');
+    console.log('Then regenerate the baseline: npm run e2e:baseline:update');
+
+    // Leave the daemon tab where the keep-alive expects it
+    await tab.goto('https://gemini.google.com/app', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000,
+    });
+  } finally {
+    await browser.close();
+  }
+}
+
+// Only run when executed directly (not when imported by tests)
+if (process.argv[1]?.endsWith('gemini-pick-url.ts')) {
+  main().catch(error => {
+    console.error(`[pick-url] ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,8 @@
           e2e-auth = app "e2e-auth" ''npx tsx e2e/auth/setup-profile.ts "$@"'';
           e2e-selectors = app "e2e-selectors" ''npx playwright test --config e2e/playwright.config.ts "$@"'';
           e2e-selectors-headed = app "e2e-selectors-headed" ''npx playwright test --config e2e/playwright.config.ts --headed "$@"'';
+          e2e-baseline-update = app "e2e-baseline-update" ''UPDATE_BASELINE=1 npx playwright test --config e2e/playwright.config.ts "$@"'';
+          e2e-gemini-pick-url = app "e2e-gemini-pick-url" ''npx tsx e2e/tools/gemini-pick-url.ts "$@"'';
           e2e-daemon = app "e2e-daemon" ''npx tsx e2e/daemon/daemon.ts "$@"'';
         };
     in

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "e2e:auth": "npx tsx e2e/auth/setup-profile.ts",
     "e2e:selectors": "npx playwright test --config e2e/playwright.config.ts",
     "e2e:baseline:update": "UPDATE_BASELINE=1 npx playwright test --config e2e/playwright.config.ts",
+    "e2e:gemini:pick-url": "npx tsx e2e/tools/gemini-pick-url.ts",
     "e2e:selectors:headed": "npx playwright test --config e2e/playwright.config.ts --headed",
     "e2e:daemon": "npx tsx e2e/daemon/daemon.ts",
     "e2e:daemon:start": "npx tsx e2e/daemon/daemon.ts start",


### PR DESCRIPTION
## Summary

R5 of the approved E2E redesign — closes the operational gap behind the broken Gemini target:

- `npm run e2e:gemini:pick-url` (optional index arg): connects to the CDP daemon, expands the collapsed sidenav via its stable `data-test-id` (aria-labels are locale-dependent), performs a **real pointer click** on a conversation (DOM-dispatched clicks are ignored by Angular's handlers), and prints the SPA-updated conversation URL + the exact `.env.local` / `e2e:baseline:update` follow-up steps
- Encodes the empirically-derived constraints of Gemini's 2026 DOM: no conversation hrefs, off-canvas mobile layout below ~960px, collapsed icon rail (textless items) after fresh navigation
- CLAUDE.md gains the "dead test-conversation workflow" beside the re-authentication workflow

## Live verification

Helper run against the daemon printed a real conversation (`レイヤー理解でシステムを創る` → `https://gemini.google.com/app/8c6eb888f77e1571`). Development itself hit and fixed two real-world modes: sidenav lazy render (fixed-sleep → waitFor) and the collapsed-rail state (expand button).

## Test plan

- [x] Unit tests for URL extraction (4)
- [x] `npx tsc --noEmit` / eslint clean; `npm run lint` platform check green
- [x] Live run produces a valid conversation URL and restores the daemon tab to /app

🤖 Generated with [Claude Code](https://claude.com/claude-code)