### PR TITLE
feat(e2e): notify only on state change

### DIFF
--- a/e2e/selectors/__tests__/notify-policy.test.ts
+++ b/e2e/selectors/__tests__/notify-policy.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  buildStateFingerprint,
+  shouldNotify,
+  loadNotifyState,
+  saveNotifyState,
+} from '../notify-policy';
+import type { ValidationReport, PlatformReport } from '../notifier';
+import type { SelectorResult } from '../classifier';
+
+function makeSelectorResult(overrides: Partial<SelectorResult> = {}): SelectorResult {
+  return {
+    platform: 'gemini',
+    group: 'SELECTORS',
+    name: 'turn',
+    selector: '.turn',
+    index: 0,
+    matchCount: 3,
+    ...overrides,
+  };
+}
+
+function makePlatform(overrides: Partial<PlatformReport> = {}): PlatformReport {
+  return {
+    platform: 'gemini',
+    authStatus: 'authenticated',
+    classification: {
+      pass: [makeSelectorResult()],
+      warn: [],
+      fail: [],
+      baselineBlocking: [],
+      baselineAdvisory: [],
+    },
+    failedTargets: [],
+    stallSkips: [],
+    ...overrides,
+  };
+}
+
+function makeReport(
+  overallStatus: ValidationReport['overallStatus'],
+  platforms: PlatformReport[]
+): ValidationReport {
+  return { timestamp: '2026-07-04T10:00:00+09:00', platforms, overallStatus };
+}
+
+describe('buildStateFingerprint', () => {
+  it('captures issue identities, not counts', () => {
+    const report = makeReport('fail', [
+      makePlatform({
+        failedTargets: ['gemini_dr'],
+        classification: {
+          pass: [makeSelectorResult()],
+          warn: [],
+          fail: [makeSelectorResult({ name: 'turn', selector: '.gone' })],
+          baselineBlocking: [],
+          baselineAdvisory: [],
+        },
+      }),
+    ]);
+
+    const fp = buildStateFingerprint(report);
+
+    expect(fp.overallStatus).toBe('fail');
+    expect(JSON.stringify(fp)).toContain('.gone');
+    expect(JSON.stringify(fp)).toContain('gemini_dr');
+    // The pass list must NOT affect the fingerprint (pass-count churn is noise)
+    expect(JSON.stringify(fp)).not.toContain('"pass"');
+  });
+
+  it('is order-insensitive for issue lists', () => {
+    const a = makeReport('fail', [
+      makePlatform({ failedTargets: ['gemini_conv', 'gemini_dr'] }),
+    ]);
+    const b = makeReport('fail', [
+      makePlatform({ failedTargets: ['gemini_dr', 'gemini_conv'] }),
+    ]);
+
+    expect(buildStateFingerprint(a)).toEqual(buildStateFingerprint(b));
+  });
+
+  it('ignores the timestamp', () => {
+    const a = buildStateFingerprint(makeReport('pass', [makePlatform()]));
+    const b = buildStateFingerprint({
+      ...makeReport('pass', [makePlatform()]),
+      timestamp: '2027-01-01T00:00:00Z',
+    });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('shouldNotify', () => {
+  const passFp = buildStateFingerprint(makeReport('pass', [makePlatform()]));
+  const failFp = buildStateFingerprint(
+    makeReport('fail', [makePlatform({ failedTargets: ['gemini_conv'] })])
+  );
+  const otherFailFp = buildStateFingerprint(
+    makeReport('fail', [makePlatform({ failedTargets: ['gemini_dr'] })])
+  );
+
+  it('does not notify when the state is unchanged (standing failure)', () => {
+    expect(shouldNotify(failFp, failFp).notify).toBe(false);
+  });
+
+  it('notifies when the failing set changes, even at the same overallStatus', () => {
+    const decision = shouldNotify(otherFailFp, failFp);
+    expect(decision.notify).toBe(true);
+  });
+
+  it('notifies on recovery (fail -> pass)', () => {
+    const decision = shouldNotify(passFp, failFp);
+    expect(decision.notify).toBe(true);
+    expect(decision.recovered).toBe(true);
+  });
+
+  it('stays silent on pass -> pass', () => {
+    expect(shouldNotify(passFp, passFp).notify).toBe(false);
+  });
+
+  it('first run: notifies when not pass', () => {
+    expect(shouldNotify(failFp, undefined).notify).toBe(true);
+  });
+
+  it('first run: silent when pass', () => {
+    expect(shouldNotify(passFp, undefined).notify).toBe(false);
+  });
+});
+
+describe('notify state persistence', () => {
+  let statePath: string;
+
+  beforeEach(() => {
+    statePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'notify-')), 'state.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(path.dirname(statePath), { recursive: true, force: true });
+  });
+
+  it('round-trips a fingerprint', () => {
+    const fp = buildStateFingerprint(
+      makeReport('fail', [makePlatform({ failedTargets: ['gemini_conv'] })])
+    );
+    saveNotifyState(fp, statePath);
+    expect(loadNotifyState(statePath)).toEqual(fp);
+  });
+
+  it('returns undefined when no state exists', () => {
+    expect(loadNotifyState(statePath)).toBeUndefined();
+  });
+
+  it('returns undefined for a corrupt state file', () => {
+    fs.writeFileSync(statePath, '{broken');
+    expect(loadNotifyState(statePath)).toBeUndefined();
+  });
+});

--- a/e2e/selectors/notifier.ts
+++ b/e2e/selectors/notifier.ts
@@ -31,20 +31,22 @@ export interface ValidationReport {
   overallStatus: 'pass' | 'warn' | 'fail' | 'auth_expired';
 }
 
+export interface NotifyOptions {
+  /** State changed to a clean pass — send a short recovery note. */
+  recovered?: boolean;
+}
+
 /**
  * Send a health report to Obsidian.
- * Skips notification when overallStatus is 'pass'.
+ * WHETHER to notify is decided upstream (notify-policy, diff-based);
+ * this function always sends when called.
  */
 export async function notifyObsidian(
   report: ValidationReport,
-  config: NotificationConfig
+  config: NotificationConfig,
+  options: NotifyOptions = {}
 ): Promise<void> {
-  if (report.overallStatus === 'pass') {
-    console.log('[ObsidianReporter] All selectors passed. No notification needed.');
-    return;
-  }
-
-  const markdown = generateMarkdown(report);
+  const markdown = options.recovered ? generateRecoveryMarkdown(report) : generateMarkdown(report);
   const dateStr = report.timestamp.slice(0, 10);
   const fileName = `selector-health-${dateStr}.md`;
   const notePath = `${config.vaultPath}/${fileName}`;
@@ -80,11 +82,30 @@ const AUTH_LABELS: Readonly<Record<Exclude<AuthStatus, 'authenticated'>, string>
 };
 
 const AUTH_GUIDANCE: Readonly<Record<Exclude<AuthStatus, 'authenticated'>, string>> = {
-  auth_expired: "Run `npm run e2e:auth` to re-authenticate.",
+  auth_expired: 'Run `npm run e2e:auth` to re-authenticate.',
   unreachable: 'The site could not be reached; check network / service status.',
   test_data_missing:
     'The pinned test conversation no longer opens — refresh the `*_CONV_URL` value in `e2e/.env.local`.',
 };
+
+/** Short note for a transition back to a clean pass. */
+export function generateRecoveryMarkdown(report: ValidationReport): string {
+  const dateStr = report.timestamp.slice(0, 10);
+  return [
+    '---',
+    `date: "${report.timestamp}"`,
+    'status: recovered',
+    'tags: [selector-health, automated]',
+    '---',
+    '',
+    `# Selector Health Report - ${dateStr}`,
+    '',
+    '**✅ RECOVERED — all selectors pass again.**',
+    '',
+    `Platforms verified: ${report.platforms.map(p => p.platform).join(', ')}`,
+    '',
+  ].join('\n');
+}
 
 export function generateMarkdown(report: ValidationReport): string {
   const dateStr = report.timestamp.slice(0, 10);
@@ -176,7 +197,7 @@ export function generateMarkdown(report: ValidationReport): string {
         sections.push(
           '### 🚫 Baseline Contract Violations (FAIL)',
           '',
-          "Intentional selector changes must be recorded via `npm run e2e:baseline:update`.",
+          'Intentional selector changes must be recorded via `npm run e2e:baseline:update`.',
           '',
           '| Selector | Status | Baseline | Current |',
           '|----------|--------|----------|---------|'

--- a/e2e/selectors/notify-policy.ts
+++ b/e2e/selectors/notify-policy.ts
@@ -1,0 +1,131 @@
+/**
+ * Diff-based notification policy.
+ *
+ * v1 notified on every non-pass run, which produced an identical Obsidian
+ * note daily for 100+ consecutive days — standing noise that made a NEW
+ * problem indistinguishable from the old ones. The policy is now: notify
+ * only when the observable state CHANGED since the last run (including
+ * recovery to pass). No note = nothing new.
+ *
+ * The fingerprint captures issue IDENTITIES (which selector, which target,
+ * which status), never counts, so a swapped failure (one fixed, another
+ * broken) still triggers.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { ValidationReport } from './notifier';
+
+const DEFAULT_STATE_PATH = path.join(import.meta.dirname, '..', 'results', 'notify-state.json');
+
+/** Normalized, order-insensitive, timestamp-free state of a run. */
+export interface NotifyStateFingerprint {
+  overallStatus: ValidationReport['overallStatus'];
+  platforms: Array<{
+    platform: string;
+    authStatus: string;
+    failedTargets: string[];
+    stallSkips: string[];
+    deadPrimaries: string[];
+    failures: string[];
+    baselineBlocking: string[];
+    baselineAdvisory: string[];
+  }>;
+}
+
+export interface NotifyDecision {
+  notify: boolean;
+  /** True when the state changed to a clean pass (recovery note). */
+  recovered: boolean;
+  reason: string;
+}
+
+export function buildStateFingerprint(report: ValidationReport): NotifyStateFingerprint {
+  const platforms = [...report.platforms]
+    .sort((a, b) => a.platform.localeCompare(b.platform))
+    .map(p => {
+      const c = p.classification;
+      return {
+        platform: p.platform,
+        authStatus: p.authStatus,
+        failedTargets: [...p.failedTargets].sort(),
+        stallSkips: [...p.stallSkips].sort(),
+        deadPrimaries: (c?.warn ?? [])
+          .map(w => `${w.failedPrimary.group}:${w.failedPrimary.name}:${w.failedPrimary.selector}`)
+          .sort(),
+        failures: (c?.fail ?? []).map(f => `${f.group}:${f.name}:${f.selector}`).sort(),
+        baselineBlocking: (c?.baselineBlocking ?? [])
+          .map(b => `${b.group}:${b.name}:${b.selector}:${b.status}`)
+          .sort(),
+        baselineAdvisory: (c?.baselineAdvisory ?? [])
+          .map(b => `${b.group}:${b.name}:${b.selector}`)
+          .sort(),
+      };
+    });
+
+  return { overallStatus: report.overallStatus, platforms };
+}
+
+function fingerprintsEqual(a: NotifyStateFingerprint, b: NotifyStateFingerprint): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Decide whether this run warrants a notification.
+ *
+ * - unchanged state (including standing failures) -> silent
+ * - changed state -> notify; a change TO pass is flagged as recovery
+ * - first run (no previous state) -> notify only when not pass
+ */
+export function shouldNotify(
+  current: NotifyStateFingerprint,
+  previous: NotifyStateFingerprint | undefined
+): NotifyDecision {
+  if (previous === undefined) {
+    if (current.overallStatus === 'pass') {
+      return { notify: false, recovered: false, reason: 'first run, all pass' };
+    }
+    return { notify: true, recovered: false, reason: 'first run with issues' };
+  }
+
+  if (fingerprintsEqual(current, previous)) {
+    return {
+      notify: false,
+      recovered: false,
+      reason: `state unchanged (${current.overallStatus})`,
+    };
+  }
+
+  const recovered = current.overallStatus === 'pass';
+  return {
+    notify: true,
+    recovered,
+    reason: recovered
+      ? `recovered: ${previous.overallStatus} -> pass`
+      : `state changed: ${previous.overallStatus} -> ${current.overallStatus}`,
+  };
+}
+
+export function loadNotifyState(
+  statePath = DEFAULT_STATE_PATH
+): NotifyStateFingerprint | undefined {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined;
+    return raw as NotifyStateFingerprint;
+  } catch {
+    // Missing or corrupt: treated as first run — worst case one extra note
+    return undefined;
+  }
+}
+
+export function saveNotifyState(
+  fingerprint: NotifyStateFingerprint,
+  statePath = DEFAULT_STATE_PATH
+): void {
+  const dir = path.dirname(statePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(statePath, JSON.stringify(fingerprint, null, 2));
+}

--- a/e2e/selectors/obsidian-reporter.ts
+++ b/e2e/selectors/obsidian-reporter.ts
@@ -17,6 +17,12 @@ import path from 'path';
 import dotenv from 'dotenv';
 import { notifyObsidian, type PlatformReport } from './notifier';
 import { extractPlatform, processTestResult, buildValidationReport } from './report-builder';
+import {
+  buildStateFingerprint,
+  shouldNotify,
+  loadNotifyState,
+  saveNotifyState,
+} from './notify-policy';
 
 class ObsidianReporter implements Reporter {
   private platformMap: Map<string, PlatformReport> = new Map();
@@ -52,6 +58,19 @@ class ObsidianReporter implements Reporter {
       );
     }
 
+    // Diff-based policy: notify only when the observable state changed
+    // since the previous run (standing failures stay silent; recovery to
+    // pass gets a short note). No note = nothing new.
+    const fingerprint = buildStateFingerprint(report);
+    const decision = shouldNotify(fingerprint, loadNotifyState());
+    saveNotifyState(fingerprint);
+    console.log(
+      `[ObsidianReporter] ${decision.reason} — ${decision.notify ? 'notifying' : 'no notification'}`
+    );
+    if (!decision.notify) {
+      return;
+    }
+
     const obsidianUrl = process.env.OBSIDIAN_URL ?? 'http://127.0.0.1:27123';
     const obsidianApiKey = process.env.OBSIDIAN_API_KEY;
     const vaultPath = process.env.OBSIDIAN_VAULT_PATH ?? 'AI/selector-health';
@@ -63,7 +82,11 @@ class ObsidianReporter implements Reporter {
       return;
     }
 
-    await notifyObsidian(report, { obsidianUrl, obsidianApiKey, vaultPath });
+    await notifyObsidian(
+      report,
+      { obsidianUrl, obsidianApiKey, vaultPath },
+      { recovered: decision.recovered }
+    );
   }
 
   printsToStdio(): boolean {


### PR DESCRIPTION
## Summary

R4 of the approved E2E redesign — ends the 100+-day identical-note stream:

- **`notify-policy.ts`**: order-insensitive, timestamp-free fingerprint of issue *identities* (failed targets, stall targets, dead primaries, zero-match failures, baseline blocking/advisory) — never counts, so one failure being fixed while another breaks still triggers
- **Diff-based decision**: unchanged state (including standing failures) → silent; any change → notify; change to pass → short **recovery note**; first run → notify unless pass; missing/corrupt state → safe first-run behavior
- `notifyObsidian` no longer decides *whether* (moved upstream); gains the recovery-note variant
- TDD: 12 tests RED-first (fingerprint identity/ordering/timestamp-independence, decision matrix, state persistence incl. corrupt file)

## Live verification (3 consecutive runs)

1. `first run with issues — notifying`
2. `state changed: fail -> fail — notifying` — a **real** change: gemini_dr's stall streak hit 3 and escalated to FAIL (R2), its 8 dead deep-research selectors now recorded by name in the fingerprint
3. `state unchanged (fail) — no notification` ✅

R2's escalation and R4's diff policy interlocking exactly as designed.

## Test plan

- [x] `npm run test:coverage` green (142 e2e-unit tests; global thresholds pass)
- [x] `npx tsc --noEmit` / eslint clean
- [x] Live 3-run matrix above

🤖 Generated with [Claude Code](https://claude.com/claude-code)