### PR TITLE
fix: repair rotted selectors against the live 2026-07 DOMs

### DIFF
--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -85,6 +85,15 @@ const READY_TIMEOUT_MS = 15_000;
 /** Consecutive stall-skips before a stall is treated as a real failure. */
 const MAX_CONSECUTIVE_STALLS = 3;
 
+/**
+ * The extension runs in desktop Chrome, so selectors must be validated
+ * against the DESKTOP DOM. At the CDP daemon's default window size (~800px)
+ * ChatGPT serves its mobile-web fallback (?mweb_fallback=1) whose DOM lacks
+ * section[data-turn-id], and Gemini switches to is-mobile layouts —
+ * validating those would test the wrong site.
+ */
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 } as const;
+
 // --- Helper Functions ---
 
 async function validateSelectors(
@@ -120,6 +129,8 @@ async function runPlatformValidation(
 
   const page = await context.newPage();
   try {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+
     // Auth pre-flight
     const authStatus: AuthStatus = await checkAuthStatus(page, platform, url!);
     const mode: TargetDetail['mode'] = process.env.UPDATE_BASELINE === '1' ? 'update' : 'validate';

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -6,7 +6,7 @@
 import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { extractErrorMessage } from '../../lib/error-utils';
-import { MAX_CONVERSATION_TITLE_LENGTH, SCROLL_TIMEOUT } from '../../lib/constants';
+import { SCROLL_TIMEOUT } from '../../lib/constants';
 import { ensureAllElementsLoaded, type ScrollResult } from '../../lib/scroll-manager';
 import type {
   SyncSettings,
@@ -142,19 +142,13 @@ export class GeminiExtractor extends BaseExtractor {
   }
 
   /**
-   * Get conversation title from top bar, first user query, or sidebar
+   * Get conversation title from the first user query.
+   *
+   * Gemini stopped rendering a conversation-title element by 2026-03 (the
+   * old top-bar selector group never matched again), so the first query has
+   * been the de-facto title source ever since; the dead path was removed.
    */
   getTitle(): string {
-    // Priority 1: Top bar title ([data-test-id="conversation-title"] or sidebar)
-    const topBarTitle = this.queryWithFallback<HTMLElement>(SELECTORS.conversationTitle);
-    if (topBarTitle?.textContent) {
-      const title = this.sanitizeText(topBarTitle.textContent);
-      if (title) {
-        return title.substring(0, MAX_CONVERSATION_TITLE_LENGTH);
-      }
-    }
-
-    // Priority 2: First user query text
     return this.getFirstMessageTitle(SELECTORS.queryTextLine, 'Untitled Gemini Conversation');
   }
 

--- a/src/content/extractors/selectors/chatgpt.ts
+++ b/src/content/extractors/selectors/chatgpt.ts
@@ -10,19 +10,18 @@ import type { SelectorGroup } from './types';
 
 export const SELECTORS = {
   // Conversation turn (each Q&A pair)
-  // ChatGPT changed from <article> to <section> in 2026-03
+  // ChatGPT changed from <article> to <section> in 2026-03; the article
+  // variants matched nothing on the live site by 2026-07 and were removed
+  // (the baseline contract rejects zero-match entries).
   conversationTurn: [
     'section[data-turn-id]', // Current structure (HIGH)
     'section[data-testid^="conversation-turn"]', // Current test attr (MEDIUM)
-    'article[data-turn-id]', // Legacy fallback (LOW)
-    'article[data-testid^="conversation-turn"]', // Legacy fallback (LOW)
   ],
 
   // User message
   userMessage: [
     '[data-message-author-role="user"] .whitespace-pre-wrap', // Structure (HIGH)
     'section[data-turn="user"] .whitespace-pre-wrap', // Current structure (HIGH)
-    'article[data-turn="user"] .whitespace-pre-wrap', // Legacy fallback (LOW)
     '.user-message-bubble-color .whitespace-pre-wrap', // Style (MEDIUM)
   ],
 
@@ -30,7 +29,6 @@ export const SELECTORS = {
   assistantResponse: [
     '[data-message-author-role="assistant"] .markdown.prose', // Structure (HIGH)
     'section[data-turn="assistant"] .markdown.prose', // Current structure (HIGH)
-    'article[data-turn="assistant"] .markdown.prose', // Legacy fallback (LOW)
     '.markdown.prose.dark\\:prose-invert', // Style (MEDIUM)
   ],
 

--- a/src/content/extractors/selectors/claude.ts
+++ b/src/content/extractors/selectors/claude.ts
@@ -35,8 +35,10 @@ export const SELECTORS = {
   ],
 
   // User message wrapper (for date extraction)
+  // 2026-07: py-2.5 became py-[var(--msg-bubble-py,...)] on the live site,
+  // killing the old .pl-2.5.py-2.5 primary (baseline contract caught it)
   userWrapper: [
-    '.rounded-xl.pl-2\\.5.py-2\\.5', // Style attribute (HIGH)
+    '.bg-bg-300.rounded-xl', // Style composite (HIGH)
     '.bg-bg-300', // Tailwind (MEDIUM)
     '[class*="bg-bg-300"]', // Partial match (MEDIUM)
   ],
@@ -49,9 +51,10 @@ export const SELECTORS = {
   ],
 
   // Markdown content selectors
+  // 2026-07: .progressive-markdown disappeared from the live site (removed
+  // under the zero-match baseline contract)
   markdownContent: [
     '.standard-markdown', // Semantic (HIGH)
-    '.progressive-markdown', // Semantic (HIGH)
     '[class*="markdown"]', // Partial match (MEDIUM)
   ],
 
@@ -90,9 +93,10 @@ export const DEEP_RESEARCH_SELECTORS = {
   ],
 
   // Inline citation links
+  // 2026-07: the group/tag class moved from a wrapper onto the <a> itself
   inlineCitation: [
     'span.inline-flex a[href^="http"]', // Structure (HIGH)
-    '.group\\/tag a[href]', // Class (MEDIUM)
+    'a[class~="group/tag"][href^="http"]', // Class on the anchor (MEDIUM)
     'a[target="_blank"][href^="http"]', // Attribute (MEDIUM)
   ],
 } as const satisfies SelectorGroup;

--- a/src/content/extractors/selectors/gemini.ts
+++ b/src/content/extractors/selectors/gemini.ts
@@ -28,13 +28,10 @@ export const SELECTORS = {
     '.model-response-text',
   ],
 
-  // Conversation title (top bar + sidebar)
-  conversationTitle: [
-    '[data-test-id="conversation-title"]',
-    '.conversation-title.gds-title-m',
-    '.conversation-title',
-    '[class*="conversation-title"]',
-  ],
+  // NOTE: the former conversationTitle group was removed 2026-07. No
+  // conversation-title element has existed in Gemini's DOM since at least
+  // 2026-03 (the v1 baseline recorded 0 matches from day one); titles come
+  // from the first user query (see GeminiExtractor.getTitle).
 
   // Scroll container for lazy-load detection
   // infinite-scroller (data-test-id="chat-history-container") is the actual

--- a/src/content/extractors/selectors/perplexity.ts
+++ b/src/content/extractors/selectors/perplexity.ts
@@ -10,9 +10,11 @@ import type { SelectorGroup } from './types';
 
 export const SELECTORS = {
   // User query text
+  // 2026-07: the bubble class bg-offset became bg-subtle; the group/query
+  // ancestor is the stabler anchor
   userQuery: [
     'span.select-text', // Semantic (HIGH)
-    'div.bg-offset.rounded-2xl span.select-text', // Style (MEDIUM)
+    'div[class~="group/query"] span.select-text', // Query container (MEDIUM)
   ],
 
   // Assistant response content container
@@ -26,10 +28,13 @@ export const SELECTORS = {
     '.prose', // Fallback (LOW)
   ],
 
-  // Deep Research report card container
+  // Deep Research report card container. Matches generic raised panels too;
+  // the extractor only tags a card as a report when deepResearchProse is
+  // found inside it (perplexity.ts collectTaggedElements).
+  // 2026-07: the border-borderMain token disappeared site-wide (removed
+  // under the zero-match baseline contract).
   deepResearchCard: [
     'div.bg-raised.rounded-lg', // Style (HIGH)
-    'div.border-borderMain.bg-raised', // Alternative (MEDIUM)
   ],
 
   // Prose content within a Deep Research report card (max-w-none distinguishes it)

--- a/test/extractors/chatgpt.test.ts
+++ b/test/extractors/chatgpt.test.ts
@@ -356,23 +356,17 @@ describe('ChatGPTExtractor', () => {
       expect(messages.length).toBe(2);
     });
 
-    it('conversationTurn legacy fallback (article[data-turn-id])', async () => {
+    it('no longer matches the retired article-based DOM (removed 2026-07)', async () => {
+      // The 2026-03-era <article> variants matched nothing on the live site
+      // by 2026-07 and were removed under the zero-match baseline contract.
       setChatGPTLocation('test-123');
       loadFixture(`
         <article data-turn-id="turn-1" data-turn="user">
-          <div data-message-author-role="user">
-            <div class="whitespace-pre-wrap">Legacy user message</div>
-          </div>
-        </article>
-        <article data-turn-id="turn-2" data-turn="assistant">
-          <div data-message-author-role="assistant">
-            <div class="markdown prose">Legacy response</div>
-          </div>
+          <div class="whitespace-pre-wrap">Legacy user message</div>
         </article>
       `);
       const result = await extractor.extract();
-      expect(result.success).toBe(true);
-      expect(result.data?.messages.length).toBe(2);
+      expect(result.success).toBe(false);
     });
 
     it('userMessage primary selector ([data-message-author-role])', async () => {

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -94,14 +94,6 @@ describe('GeminiExtractor', () => {
       expect(extractor.getTitle().length).toBe(100);
     });
 
-    it('falls back to sidebar title', () => {
-      setGeminiLocation('test123');
-      loadFixture(`
-        <div class="conversation-title">Sidebar Title</div>
-      `);
-      expect(extractor.getTitle()).toBe('Sidebar Title');
-    });
-
     it('returns default title when nothing found', () => {
       setGeminiLocation('test123');
       loadFixture('<div>Empty page</div>');
@@ -116,46 +108,23 @@ describe('GeminiExtractor', () => {
       expect(extractor.getTitle()).toBe('Multiple spaces');
     });
 
-    it('extracts title from data-test-id="conversation-title" element', () => {
-      setGeminiLocation('test123');
-      loadFixture(`
-        <span data-test-id="conversation-title" class="gds-title-m">Top Bar Title</span>
-      `);
-      expect(extractor.getTitle()).toBe('Top Bar Title');
-    });
-
-    it('data-test-id="conversation-title" takes priority over query text', () => {
+    it('ignores legacy conversation-title elements (dead path removed 2026-07)', () => {
+      // Gemini stopped rendering conversation-title by 2026-03; the first
+      // user query has been the de-facto title source ever since.
       setGeminiLocation('test123');
       loadFixture(`
         <span data-test-id="conversation-title" class="gds-title-m">Top Bar Title</span>
         <p class="query-text-line">Query text</p>
       `);
-      expect(extractor.getTitle()).toBe('Top Bar Title');
+      expect(extractor.getTitle()).toBe('Query text');
     });
 
-    it('falls back to query text when conversation-title is empty', () => {
-      setGeminiLocation('test123');
-      loadFixture(`
-        <span data-test-id="conversation-title" class="gds-title-m">   </span>
-        <p class="query-text-line">Query text fallback</p>
-      `);
-      expect(extractor.getTitle()).toBe('Query text fallback');
-    });
-
-    it('falls back to query text when no conversation-title element', () => {
+    it('uses query text as the title source', () => {
       setGeminiLocation('test123');
       loadFixture(`
         <p class="query-text-line">Query text fallback</p>
       `);
       expect(extractor.getTitle()).toBe('Query text fallback');
-    });
-
-    it('sanitizes whitespace in top bar title', () => {
-      setGeminiLocation('test123');
-      loadFixture(`
-        <span data-test-id="conversation-title" class="gds-title-m">  Spaced   Title  </span>
-      `);
-      expect(extractor.getTitle()).toBe('Spaced Title');
     });
   });
 
@@ -1115,12 +1084,10 @@ describe('GeminiExtractor', () => {
       `);
       loadFixture(scrollableHTML);
 
-      let turnCounter = 1;
       mockScrollContainer(1000, () => {
         // Keep adding assistant-only turns (never stabilizes)
         const scroller = document.querySelector('infinite-scroller');
         if (!scroller) return;
-        turnCounter++;
         scroller.insertAdjacentHTML(
           'afterbegin',
           `<div class="conversation-container">


### PR DESCRIPTION
## Summary
Follow-up A from the E2E redesign — every selector the baseline contract refused was verified against the live sites (CDP daemon, desktop viewport) and repaired:

| Target | Root cause | Fix |
|---|---|---|
| e2e harness | ~800px viewport made ChatGPT serve its **mobile-web fallback** (`?mweb_fallback=1`, no `section[data-turn-id]`) and Gemini render `is-mobile` layouts | Force 1440×900 on validation pages (the extension targets desktop Chrome) |
| chatgpt | 2026-03-era `article[data-turn*]` variants dead | Removed (4 variants); `section` variants are current |
| claude conv | `py-2.5` → `py-[var(--msg-bubble-py,…)]`; `.progressive-markdown` gone | New wrapper primary `.bg-bg-300.rounded-xl`; dead variant removed |
| claude DR | `group/tag` class moved from wrapper onto the `<a>` | `a[class~="group/tag"][href^="http"]` |
| perplexity | `bg-offset` → `bg-subtle`; `border-borderMain` token vanished site-wide | Re-anchored fallback on `group/query`; dead variant removed (extraction stays guarded by `deepResearchProse`) |
| gemini | `conversationTitle` **never matched once** since the March v1 baseline; no such element exists today | Group + dead `getTitle()` Priority-1 branch removed — first user query has been the de-facto title source all along |

Obsolete unit tests of the removed paths were replaced with negative tests documenting the removals.

## Live verification
`e2e:baseline:update` now records v2 baselines for **claude (conv+DR), chatgpt, perplexity, notebooklm** ✅. Remaining gemini reds are test-data/site-loading (the pinned DR conversation never restores on cold load — turn count 0 after 8s; surfaced by the stall counter, not masked).

## Test plan
- [x] `npm run test:coverage` passes (1094/1094; 90.1% stmts / 84.7% branch)
- [x] `npx tsc --noEmit` / eslint clean
- [x] Live `e2e:baseline:update`: 5/7 targets green incl. all repaired ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)