### PR TITLE
fix: never overwrite a different conversation on filename collision

### DIFF
--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -14,6 +14,8 @@ import {
   getSearchBasePath,
 } from '../lib/path-utils';
 import { lookupExistingFile, buildAppendContent } from '../lib/append-utils';
+import { collisionSuffix, candidateFileName } from '../lib/filename-collision';
+import { parseFrontmatter } from '../lib/frontmatter-parser';
 import { validateObsidianUrl } from '../lib/validation';
 import type { ExtensionSettings, ObsidianNote, SaveResponse } from '../lib/types';
 
@@ -139,16 +141,75 @@ export async function handleSave(
     );
     if (appendResult) return appendResult;
 
-    const existingContent = await client.getFile(fullPath);
-    const isNewFile = existingContent === null;
-    const content = generateNoteContent(note, settings);
-    await client.putFile(fullPath, content);
+    const target = await resolveCollisionFreePath(client, resolvedPath, note);
+    if ('error' in target) {
+      return { success: false, error: target.error };
+    }
 
-    return { success: true, isNewFile };
+    const content = generateNoteContent(note, settings);
+    await client.putFile(target.path, content);
+
+    return {
+      success: true,
+      isNewFile: target.isNewFile,
+      ...(target.renamed && { savedAs: target.fileName }),
+    };
   } catch (error) {
     console.error('[G2O Background] Save failed:', error);
     return { success: false, error: getErrorMessage(error) };
   }
+}
+
+/** Probe attempts: original + hash suffix + a few counters for hash collisions */
+const MAX_COLLISION_ATTEMPTS = 10;
+
+interface WritableTarget {
+  path: string;
+  fileName: string;
+  isNewFile: boolean;
+  /** True when the original name was occupied by a different conversation */
+  renamed: boolean;
+}
+
+/**
+ * Find a path this note may be written to without clobbering a DIFFERENT
+ * conversation (issue #327: identically-titled conversations, e.g.
+ * Perplexity repeating tasks, silently overwrote each other).
+ *
+ * A file is writable when it does not exist, or when its frontmatter id
+ * matches this note's id (same conversation being re-saved). Files whose
+ * frontmatter cannot be parsed are treated as foreign and protected.
+ * Alternative names are deterministic per conversation (hash of its id),
+ * so re-saves always land on the same file.
+ */
+async function resolveCollisionFreePath(
+  client: ObsidianApiClient,
+  resolvedPath: string,
+  note: ObsidianNote
+): Promise<WritableTarget | { error: string }> {
+  const suffix = collisionSuffix(note.frontmatter.id);
+
+  for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
+    const fileName = candidateFileName(note.fileName, suffix, attempt);
+    const path = resolvedPath ? `${resolvedPath}/${fileName}` : fileName;
+
+    const existing = await client.getFile(path);
+    if (existing === null) {
+      return { path, fileName, isNewFile: true, renamed: attempt > 0 };
+    }
+    const parsed = parseFrontmatter(existing);
+    if (parsed?.fields.id === note.frontmatter.id) {
+      return { path, fileName, isNewFile: false, renamed: attempt > 0 };
+    }
+    // Occupied by a different conversation (or an unparseable/foreign file):
+    // never overwrite — try the next deterministic candidate.
+  }
+
+  return {
+    error:
+      `filename collision: could not find a free name for '${note.fileName}' ` +
+      `after ${MAX_COLLISION_ATTEMPTS} attempts`,
+  };
 }
 
 /**

--- a/src/background/output-handlers.ts
+++ b/src/background/output-handlers.ts
@@ -102,6 +102,7 @@ async function handleSaveToObsidian(
       success: result.success,
       error: result.error,
       messagesAppended: result.messagesAppended,
+      savedAs: result.savedAs,
     };
   } catch (error) {
     return {

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -259,7 +259,12 @@ function displaySaveResults(
       showToast('No new messages to append', 'info', INFO_TOAST_DURATION);
     }
   } else if (saveResult.allSuccessful) {
-    showSuccessToast(fileName, true);
+    // A filename collision may have forced an alternative name (issue #327):
+    // show the name the note was actually saved under.
+    const savedAs = saveResult.results.find(
+      (r: OutputResult) => r.destination === 'obsidian'
+    )?.savedAs;
+    showSuccessToast(savedAs ?? fileName, true);
   } else if (saveResult.anySuccessful) {
     const successList = saveResult.results
       .filter((r: OutputResult) => r.success)

--- a/src/lib/filename-collision.ts
+++ b/src/lib/filename-collision.ts
@@ -1,0 +1,36 @@
+/**
+ * Filename collision helpers (issue #327).
+ *
+ * Conversations with identical titles can produce identical file names —
+ * notably Perplexity repeating tasks, whose conversation ids start with the
+ * title slug, so the id-prefix suffix in generateFileName() repeats too.
+ * When a save would land on a file holding a DIFFERENT conversation
+ * (frontmatter id mismatch), the handler probes deterministic alternatives
+ * instead of overwriting.
+ */
+
+import { generateHash } from './hash';
+
+/**
+ * Deterministic per-conversation suffix (8-hex hash of the frontmatter id).
+ * The same conversation always maps to the same alternative name, so
+ * re-saves land on their own file regardless of probe order or date.
+ */
+export function collisionSuffix(conversationId: string): string {
+  return generateHash(conversationId);
+}
+
+/**
+ * Candidate file name for a probe attempt.
+ * attempt 0 = the original name; 1 = base-suffix.md; n>=2 = base-suffix-n.md
+ * (the counter exists only for the astronomically unlikely hash collision).
+ */
+export function candidateFileName(
+  originalFileName: string,
+  suffix: string,
+  attempt: number
+): string {
+  if (attempt === 0) return originalFileName;
+  const base = originalFileName.replace(/\.md$/, '');
+  return attempt === 1 ? `${base}-${suffix}.md` : `${base}-${suffix}-${attempt}.md`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -138,6 +138,11 @@ export interface OutputResult {
   error?: string;
   /** Number of messages appended (Obsidian append mode only) */
   messagesAppended?: number;
+  /**
+   * Actual file name used when the intended name was occupied by a
+   * DIFFERENT conversation (filename collision safeguard, issue #327).
+   */
+  savedAs?: string;
 }
 
 /**
@@ -262,6 +267,8 @@ export interface SaveResponse {
   error?: string;
   isNewFile?: boolean;
   messagesAppended?: number;
+  /** Actual file name when a collision forced an alternative (issue #327) */
+  savedAs?: string;
 }
 
 /**

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import type { ObsidianNote } from '../../src/lib/types';
+import { generateHash } from '../../src/lib/hash';
 
 // Mock client instance - defined at module level
 const mockClient = {
@@ -756,6 +757,101 @@ describe('background/index', () => {
       },
     };
 
+    describe('filename collision safeguard (issue #327)', () => {
+      const suffix = generateHash('test-id');
+      const collisionPath = `AI/Gemini/test-${suffix}.md`;
+      const otherConversation = '---\nid: other_id\n---\nSomeone else';
+      const send = (sendResponse: ReturnType<typeof vi.fn>) =>
+        capturedListener(
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+      it('saves a DIFFERENT conversation under a collision-free name instead of overwriting', async () => {
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(path === 'AI/Gemini/test.md' ? otherConversation : null)
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+        expect(mockClient.putFile).toHaveBeenCalledTimes(1);
+        expect(mockClient.putFile).toHaveBeenCalledWith(collisionPath, expect.any(String));
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            allSuccessful: true,
+            results: [
+              expect.objectContaining({
+                destination: 'obsidian',
+                success: true,
+                savedAs: `test-${suffix}.md`,
+              }),
+            ],
+          })
+        );
+      });
+
+      it('still overwrites the SAME conversation at its original path (no savedAs)', async () => {
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(path === 'AI/Gemini/test.md' ? '---\nid: test-id\n---\nMine' : null)
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+        expect(mockClient.putFile).toHaveBeenCalledWith('AI/Gemini/test.md', expect.any(String));
+        const result = sendResponse.mock.calls[0][0].results[0];
+        expect(result.savedAs).toBeUndefined();
+      });
+
+      it('re-saves land on the SAME collision-free name (deterministic)', async () => {
+        mockClient.getFile.mockImplementation((path: string) => {
+          if (path === 'AI/Gemini/test.md') return Promise.resolve(otherConversation);
+          if (path === collisionPath) return Promise.resolve('---\nid: test-id\n---\nMine');
+          return Promise.resolve(null);
+        });
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+        expect(mockClient.putFile).toHaveBeenCalledWith(collisionPath, expect.any(String));
+      });
+
+      it('protects existing files whose frontmatter cannot be parsed', async () => {
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(path === 'AI/Gemini/test.md' ? 'Just a hand-written note' : null)
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+        expect(mockClient.putFile).toHaveBeenCalledWith(collisionPath, expect.any(String));
+      });
+
+      it('fails with a clear error when no collision-free name is found', async () => {
+        mockClient.getFile.mockResolvedValue(otherConversation); // every candidate occupied
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+        expect(mockClient.putFile).not.toHaveBeenCalled();
+        const result = sendResponse.mock.calls[0][0].results[0];
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('collision');
+      });
+    });
+
     it('saves new file successfully', async () => {
       mockClient.getFile.mockResolvedValue(null);
       mockClient.putFile.mockResolvedValue(undefined);
@@ -777,8 +873,8 @@ describe('background/index', () => {
       );
     });
 
-    it('updates existing file', async () => {
-      mockClient.getFile.mockResolvedValue('# Old Content');
+    it('updates existing file (same conversation id)', async () => {
+      mockClient.getFile.mockResolvedValue('---\nid: test-id\n---\n# Old Content');
       mockClient.putFile.mockResolvedValue(undefined);
 
       const sendResponse = vi.fn();

--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -330,6 +330,21 @@ describe('content/bootstrap', () => {
       expect(setButtonLoading).toHaveBeenLastCalledWith(false);
     });
 
+    it('shows the ACTUAL file name when a collision forced a rename (issue #327)', async () => {
+      loadGeminiConversation();
+      mockMessaging({
+        save: {
+          results: [{ destination: 'obsidian', success: true, savedAs: 'hello-a1b2c3d4.md' }],
+          allSuccessful: true,
+          anySuccessful: true,
+        },
+      });
+
+      await handleSync();
+
+      expect(showSuccessToast).toHaveBeenCalledWith('hello-a1b2c3d4.md', true);
+    });
+
     it('shows the appended-message toast when messages were appended', async () => {
       loadGeminiConversation();
       mockMessaging({ save: { ...okSave, messagesAppended: 2 } });

--- a/test/lib/filename-collision.test.ts
+++ b/test/lib/filename-collision.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { collisionSuffix, candidateFileName } from '../../src/lib/filename-collision';
+import { generateHash } from '../../src/lib/hash';
+
+describe('collisionSuffix', () => {
+  it('is the deterministic 8-hex hash of the conversation id', () => {
+    const suffix = collisionSuffix('perplexity_top-5-headlines-vRujSvdQ');
+    expect(suffix).toBe(generateHash('perplexity_top-5-headlines-vRujSvdQ'));
+    expect(suffix).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('differs for different conversations sharing a title', () => {
+    expect(collisionSuffix('perplexity_top-5-headlines-aaa')).not.toBe(
+      collisionSuffix('perplexity_top-5-headlines-bbb')
+    );
+  });
+});
+
+describe('candidateFileName', () => {
+  it('returns the original name for attempt 0', () => {
+    expect(candidateFileName('daily-news.md', 'a1b2c3d4', 0)).toBe('daily-news.md');
+  });
+
+  it('appends the collision suffix on attempt 1', () => {
+    expect(candidateFileName('daily-news.md', 'a1b2c3d4', 1)).toBe('daily-news-a1b2c3d4.md');
+  });
+
+  it('adds a counter for further attempts', () => {
+    expect(candidateFileName('daily-news.md', 'a1b2c3d4', 2)).toBe('daily-news-a1b2c3d4-2.md');
+    expect(candidateFileName('daily-news.md', 'a1b2c3d4', 5)).toBe('daily-news-a1b2c3d4-5.md');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #327 — identically-titled conversations (notably Perplexity repeating tasks) silently overwrote each other.

**Root cause**: `generateFileName()` suffixes the FIRST 8 chars of the conversation id, but Perplexity ids are `/search/` slugs that START with the title text — same title ⇒ same suffix ⇒ same file name, every day.

**Fix — ownership check before every overwrite**:

- A file may only be overwritten when its frontmatter `id` matches the note being saved (same conversation being updated)
- Occupied by a different conversation → deterministic alternative `{base}-{hash8(id)}.md` (bounded counter for the ~impossible hash collision); unparseable/foreign files are protected too
- Re-saves of the same conversation always land on the same file (suffix is a hash of the conversation id, not probe-order or date dependent)
- Success toast shows the name actually used (`savedAs` threaded through `SaveResponse` → `OutputResult` → content toast) — the "feedback" half of the issue
- Same-conversation updates, append mode, and all existing vault file names unchanged; `file` downloads were already safe via Chrome's `uniquify`

**Follow-up**: optional naming schemes (name-date / name-id) tracked in #328.

TDD: 10 tests RED-first (collision rename + savedAs, same-id overwrite, deterministic re-save, foreign-file protection, exhaustion error, toast rename display; unit tests for suffix/candidates).

## Test plan

- [x] `npm run test:coverage` passes (1105/1105; 90.2% stmts / 84.8% branch)
- [x] `npx tsc --noEmit` / eslint clean; `npm run build` succeeds
- [x] Manual smoke: save two identically-titled Perplexity conversations → two files in the vault, toast shows the hash-suffixed name for the second

🤖 Generated with [Claude Code](https://claude.com/claude-code)