### PR TITLE
feat: support Gemini Gem conversations with correct per-conversation ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ source: gemini
 
 ## Supported Platforms
 
-- **Gemini** (`gemini.google.com`): Conversations and Deep Research reports
+- **Gemini** (`gemini.google.com`): Conversations, Deep Research reports, and Gem conversations (`/gem/{gemId}/{conversationId}` — the conversation id is the second path segment)
 - **Claude** (`claude.ai`): Conversations, Extended Thinking, and Artifacts with inline citations
 - **ChatGPT** (`chatgpt.com`): Conversations (including custom GPTs via `/g/` URLs)
 - **Perplexity** (`www.perplexity.ai`): Conversations

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 
 ### Gemini
 
-1. Open a conversation on [gemini.google.com](https://gemini.google.com)
+1. Open a conversation on [gemini.google.com](https://gemini.google.com) (regular chats and Gem conversations are both supported)
 2. Click the purple "Sync" button in the bottom-right corner
 3. The conversation will be exported based on your selected output method:
    - **Obsidian** (default): Saved directly to your vault via Local REST API

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -132,13 +132,25 @@ export class GeminiExtractor extends BaseExtractor {
   }
 
   /**
-   * Get conversation ID from URL
-   * URL format: https://gemini.google.com/app/{conversationId}
-   *          or https://gemini.google.com/gem/{conversationId}
+   * Get conversation ID from URL.
+   *
+   * URL formats (issue #331):
+   *   https://gemini.google.com/app/{conversationId}
+   *   https://gemini.google.com/gem/{gemId}/{conversationId}
+   *
+   * Gem URLs carry TWO ids; the conversation id is the SECOND segment.
+   * The first segment is the Gem's own id, shared by every conversation
+   * of that Gem — using it would give all of them the same note id and
+   * let them overwrite each other. A freshly opened Gem chat sits at
+   * /gem/{gemId} with no conversation yet: return null so the caller
+   * falls back to a timestamp id, same as a fresh /app chat.
    */
   getConversationId(): string | null {
-    const match = window.location.pathname.match(/\/(app|gem)\/([a-f0-9]+)/i);
-    return match ? match[2] : null;
+    const path = window.location.pathname;
+    const gem = path.match(/\/gem\/[a-f0-9]+\/([a-f0-9]+)/i);
+    if (gem) return gem[1];
+    const app = path.match(/\/app\/([a-f0-9]+)/i);
+    return app ? app[1] : null;
   }
 
   /**

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -11,6 +11,7 @@ import {
   loadFixture,
   clearFixture,
   setGeminiLocation,
+  setGeminiGemLocation,
   setNonGeminiLocation,
   createGeminiConversationDOM,
   createGeminiScrollableDOM,
@@ -73,6 +74,43 @@ describe('GeminiExtractor', () => {
     it('returns null when no ID in path', () => {
       setNonGeminiLocation('gemini.google.com', '/settings');
       expect(extractor.getConversationId()).toBeNull();
+    });
+
+    // Gemini Gems (issue #331): /gem/{gemId}/{conversationId} — the
+    // conversation id is the SECOND segment; the first is the Gem's id,
+    // shared by every conversation of that Gem.
+    it('extracts the CONVERSATION id (second segment) from a Gem URL', () => {
+      setGeminiGemLocation('60d5b0d7ce06', '221ddad4c4c30f69');
+      expect(extractor.getConversationId()).toBe('221ddad4c4c30f69');
+    });
+
+    it('returns null for a fresh Gem chat (/gem/{gemId} only, no conversation yet)', () => {
+      setGeminiGemLocation('60d5b0d7ce06');
+      expect(extractor.getConversationId()).toBeNull();
+    });
+
+    it('two conversations of the same Gem get DIFFERENT ids', () => {
+      setGeminiGemLocation('60d5b0d7ce06', '221ddad4c4c30f69');
+      const first = extractor.getConversationId();
+      setGeminiGemLocation('60d5b0d7ce06', 'a9e20a2fa59abb8a');
+      const second = extractor.getConversationId();
+      expect(first).not.toBe(second);
+    });
+
+    it('extract() on a Gem page uses the conversation id, not the Gem id', async () => {
+      setGeminiGemLocation('60d5b0d7ce06', '221ddad4c4c30f69');
+      loadFixture(
+        createGeminiConversationDOM([
+          { role: 'user', content: 'Hello Gem' },
+          { role: 'assistant', content: '<p>Hi!</p>' },
+        ])
+      );
+
+      const result = await extractor.extract();
+
+      expect(result.success).toBe(true);
+      expect(result.data?.id).toBe('221ddad4c4c30f69');
+      expect(result.data?.id).not.toContain('60d5b0d7ce06');
     });
   });
 

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -94,6 +94,29 @@ export function setGeminiLocation(conversationId: string): void {
 }
 
 /**
+ * Set window.location for a Gemini Gem conversation.
+ * Gem URLs have TWO path segments: /gem/{gemId}/{conversationId};
+ * a freshly opened Gem chat sits at /gem/{gemId} (pass conversationId='').
+ */
+export function setGeminiGemLocation(gemId: string, conversationId = ''): void {
+  const pathname = conversationId ? `/gem/${gemId}/${conversationId}` : `/gem/${gemId}`;
+  Object.defineProperty(window, 'location', {
+    value: {
+      hostname: 'gemini.google.com',
+      pathname,
+      href: `https://gemini.google.com${pathname}`,
+      origin: 'https://gemini.google.com',
+      protocol: 'https:',
+      host: 'gemini.google.com',
+      search: '',
+      hash: '',
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
  * Set window.location for non-Gemini URL
  */
 export function setNonGeminiLocation(hostname: string, pathname = '/'): void {


### PR DESCRIPTION
## Summary

Fixes #331 — Gem conversations (`/gem/{gemId}/{conversationId}`) all received the **Gem's id** as their conversation id, because `getConversationId()` assumed a single-segment `/gem/{conversationId}` scheme. Consequences confirmed in the report: shared note ids and filename suffixes across every conversation of a Gem, which **inverted the #329 collision guard** (identical frontmatter ids authorize overwrites) and let append mode merge messages across conversations.

- Parse the two URL shapes explicitly: `/gem/{gemId}/{cid}` → **second segment**; `/app/{id}` unchanged
- Fresh Gem chat (`/gem/{gemId}`, no conversation yet) → `null` → existing timestamp-id fallback, identical to a fresh `/app` chat (per plan decision)
- Old gem-derived notes need no migration: their ids no longer match, so the #329 guard writes new exports as **separate files** rather than overwriting
- Docs: CLAUDE.md / README note Gem support; no manifest/registry changes (same host)
- TDD: 4 tests RED-first (second-segment extraction, fresh-gem null, distinct ids per Gem conversation, `extract()` integration) + `setGeminiGemLocation` fixture helper

URL-scheme evidence: reporter's real vault saves (12-hex gem id + 16-hex conversation id); the daemon account has no Gems for a live probe — noted per plan P0.

## Test plan

- [x] `npm run test:coverage` passes (1109/1109; 90.2% stmts / 84.9% branch)
- [x] `npx tsc --noEmit` clean; touched files lint clean (3 pre-existing dom-helpers warnings out of scope)
- [x] `npm run build` succeeds
- [ ] Reporter-side confirmation on real Gem conversations after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)