### PR TITLE
chore: update nixpkgs flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781808320,
-        "narHash": "sha256-ZbpXI28KgYhiWUd9sXg8Z4s5aue7B9hDT9rfqEkSDP4=",
+        "lastModified": 1782904953,
+        "narHash": "sha256-ESJ4VgytmAt+98YLM8466luln4HyEZ9Q36b9+Bb4P5w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eac1fb92704677086e94543f4d150105d5aea622",
+        "rev": "0921fdb3e13e40fe25fbc52b89661a9d6d32ac68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bump the `nixpkgs` flake input to `0921fdb` (2026-07-01) from `eac1fb9`

## Test plan

- [x] `nix develop` enters the dev shell successfully
- [x] `nix run .#build` succeeds with the updated toolchain
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)