### PR TITLE
feat: add auto-scroll for virtualized Claude and ChatGPT conversations

### DIFF
--- a/docs/adr/017-autoscroll-virtualized-platforms.md
+++ b/docs/adr/017-autoscroll-virtualized-platforms.md
@@ -1,0 +1,109 @@
+# ADR-017: Auto-scroll for virtualized platforms (Claude & ChatGPT)
+
+- Status: Proposed
+- Date: 2026-07-06
+- Related: [ADR-016](016-e2e-baseline-contract-and-reporting.md), issue TBD
+- Supersedes/extends: Gemini auto-scroll (`src/lib/scroll-manager.ts`)
+
+## Context
+
+Claude and ChatGPT extract only the most-recently-rendered subset of a long
+conversation (reported: ChatGPT 5/13 messages, Claude 6/12). Gemini already has
+an auto-scroll pass (`ensureAllElementsLoaded`) that scrolls its
+`infinite-scroller` to the top and re-arms an edge-trigger until the turn **count**
+stabilizes — it assumes turns **accumulate and stay** in the DOM.
+
+Before designing a fix we verified the actual DOM behavior of both platforms
+against live, authenticated sessions via the CDP daemon (`e2e-daemon`), because
+the claude-in-chrome automation browser degraded both apps (ChatGPT → mobile-web
+fallback `?mweb_fallback=1`; Claude → a `chat-stale-nav-*` state) and produced
+false negatives.
+
+## Findings (Phase 1 spike, 2026-07-06)
+
+Measured on the daemon's real logged-in Chrome (`Chrome/150`):
+
+**Both platforms use true DOM virtualization (windowing).** Only a small moving
+window of turns is ever mounted; off-screen turns are **evicted**.
+
+|                       | Claude                                                                                                                                        | ChatGPT (mweb proxy)                                                      |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Initial mounted       | 3 turns (at bottom)                                                                                                                           | 6 messages (at bottom)                                                    |
+| After scrolling up    | grows to 5→7; `scrollHeight` 27310→30616                                                                                                      | 14 mounted at top                                                         |
+| Scroll back to bottom | back to 3; earlier turns **evicted**                                                                                                          | back to 6; earlier 8 **evicted**                                          |
+| Verdict               | **VIRTUALIZE**                                                                                                                                | **VIRTUALIZE**                                                            |
+| Scroll container      | `div.overflow-y-auto.overflow-x-hidden.[scrollbar-gutter:stable].flex-1`                                                                      | `div[class*="scroll-gutter"]` (desktop selector TBD — see Open questions) |
+| Stable per-turn id    | **`data-index`** on the row wrapper (monotonic; user=20, asst=21), alongside `data-test-render-count` / `data-sizer-excess` windowing markers | **`data-message-id`** / **`data-turn-id`** (uuid)                         |
+
+Key consequence: **you can never hold all turns in the DOM at once.** Gemini's
+count-based "scroll to top, then `extractMessages()` once" approach cannot work
+here — by the time the top is loaded, the bottom turns are gone.
+
+Scrolling **does** load earlier turns in a real authenticated session (the
+earlier automation-browser "nothing loads" result was an artifact of the
+degraded stale-nav state). Claude loads earlier turns via incremental
+window-sized upward scroll; `scrollHeight` grows as history is measured in.
+
+## Decision
+
+Extract **incrementally while scrolling**, accumulating turns keyed by a stable
+per-turn id, rather than scrolling first and extracting once.
+
+1. Add an **accumulation loader** to `scroll-manager.ts` (dual-mode: keep the
+   existing count-based path for Gemini; add an id-keyed accumulation path).
+   Loop: scroll the container upward by ~one window, let the virtual list mount
+   the newly-visible turns, extract + dedupe them into a `Map<id, Message>`,
+   repeat until `scrollTop === 0` and no new ids appear for N stable iterations
+   (or `SCROLL_TIMEOUT`).
+2. Dedupe/order:
+   - **Claude** — key by `data-index` (monotonic → also gives ordering and a
+     completeness signal: contiguous from 0).
+   - **ChatGPT** — key by `data-message-id`/`data-turn-id`; order by capture/DOM
+     order; stop on stable-no-new-ids.
+3. Expose the mechanism through a `getScrollConfig(): ScrollConfig | null` hook on
+   `BaseExtractor` (default `null`). `BaseExtractor.extract()` runs the
+   accumulation pass when a config is present. Gemini keeps its own `extract()`
+   override (image capture) unchanged — no scope creep.
+4. Gate behind the existing `enableAutoScroll` setting for both platforms; emit
+   the existing "auto-scroll timed out / N loaded" warning on incomplete loads.
+
+The dual-mode-defaulting-to-accumulation choice was confirmed with the user; the
+spike proves accumulation is not merely safer but **required** for both
+platforms.
+
+## Consequences
+
+- More invasive than Gemini's pre-pass: extraction interleaves with scrolling and
+  must reconstruct full message content per window, then stitch. Assistant
+  content on Claude (Extended Thinking, artifacts, tool blocks) must be captured
+  correctly at each window.
+- Robust to virtualization and future window-size changes.
+- Testable with jsdom fixtures that simulate a windowed list (mount/evict rows by
+  `data-index` on scroll), mirroring `createGeminiScrollableDOM`.
+
+## ChatGPT scroll-container selector (resolved 2026-07-07)
+
+First shipped as `.flex-1.flex-col[class*="overflow-y-auto"]`, which was wrong:
+ChatGPT's **sidebar `<nav>`** also carries `flex-1 flex-col overflow-y-auto` and
+sits earlier in the DOM, so `queryWithFallback` returned the nav (scrollTop 0) →
+`accumulateWhileScrolling` saw scrollTop 0 and **skipped**, extracting only the
+initially-mounted window (user-reported: no scrolling, no history). Confirmed
+via a DevTools snippet in the user's real (non-mweb) Chrome:
+
+- Sidebar `<nav>`: `overflow-y-auto`, scrollTop 0 — **decoy**.
+- Thread scroller: `div[data-scroll-root]` with `not-print:overflow-y-auto`,
+  scrollTop 4341/scrollHeight 10605, all 13 turns inside.
+
+Fix: anchor on the semantic `[data-scroll-root]`; secondary
+`[class*="not-print:overflow-y-auto"]` (the `not-print:` token is unique to the
+thread scroller — the nav uses plain `overflow-y-auto`). Regression covered by a
+decoy-nav fixture in `test/extractors/chatgpt-autoscroll.test.ts`.
+
+## Open questions
+
+- **Live desktop ChatGPT end-to-end**: both automated Chromes force the mweb
+  layout, so accumulation on desktop ChatGPT is verified only by unit tests + the
+  desktop fixture, not a live automated run. Claude's live run (daemon) captured
+  all 26 turns; ChatGPT relies on the user's manual smoke test.
+- Exact stop-condition tuning (stable-iteration threshold, per-window scroll
+  delta) per platform.

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -20,7 +20,22 @@ import {
   MAX_CONVERSATION_TITLE_LENGTH,
   MAX_DEEP_RESEARCH_TITLE_LENGTH,
   PLATFORM_LABELS,
+  SCROLL_TIMEOUT,
 } from '../../lib/constants';
+import { accumulateWhileScrolling, type HarvestEntry } from '../../lib/scroll-manager';
+
+/**
+ * Per-platform configuration for accumulating a virtualized conversation
+ * (ADR-017). Platforms whose DOM windows/evicts turns return this from
+ * getScrollConfig() so the base extract() flow scrolls up and harvests each
+ * window instead of reading the DOM once.
+ */
+export interface ScrollConfig {
+  /** Scroll container selectors, priority order (HIGH → LOW). */
+  readonly container: readonly string[];
+  /** Harvest the currently-mounted window as keyed messages, in DOM order. */
+  harvest(): HarvestEntry<ConversationMessage>[];
+}
 
 /**
  * Abstract base class for conversation extractors
@@ -28,6 +43,9 @@ import {
  */
 export abstract class BaseExtractor implements IConversationExtractor {
   abstract readonly platform: AIPlatform;
+
+  /** Whether to auto-scroll to load lazily-rendered history (set from settings). */
+  enableAutoScroll = false;
 
   abstract canExtract(): boolean;
   abstract getConversationId(): string | null;
@@ -68,10 +86,14 @@ export abstract class BaseExtractor implements IConversationExtractor {
       }
 
       console.info(`[G2O] Extracting ${this.platformLabel} conversation`);
-      const messages = this.extractMessages();
+      const { messages, warning } = await this.collectMessages();
       const conversationId = this.getConversationId() || `${this.platform}-${Date.now()}`;
       const title = this.getTitle();
-      return this.buildConversationResult(messages, conversationId, title, this.platform);
+      const result = this.buildConversationResult(messages, conversationId, title, this.platform);
+      if (warning && result.success) {
+        return { ...result, warnings: [...(result.warnings ?? []), warning] };
+      }
+      return result;
     } catch (error) {
       console.error(`[G2O] ${this.platformLabel} extraction error:`, error);
       return {
@@ -101,6 +123,50 @@ export abstract class BaseExtractor implements IConversationExtractor {
    */
   protected isDeepResearchVisible(): boolean {
     return false;
+  }
+
+  /**
+   * Hook: auto-scroll configuration for virtualized platforms (ADR-017).
+   * Return null (default) for platforms that render all turns eagerly or that
+   * handle scrolling in their own extract() override (Gemini).
+   */
+  protected getScrollConfig(): ScrollConfig | null {
+    return null;
+  }
+
+  /**
+   * Collect conversation messages, auto-scrolling first when the platform is
+   * virtualized and the user enabled auto-scroll. Falls back to a single-pass
+   * extractMessages() when disabled, unconfigured, or the container is missing.
+   */
+  protected async collectMessages(): Promise<{
+    messages: ConversationMessage[];
+    warning?: string;
+  }> {
+    const config = this.getScrollConfig();
+    if (!this.enableAutoScroll || !config) {
+      return { messages: this.extractMessages() };
+    }
+
+    const container = this.queryWithFallback<HTMLElement>(config.container);
+    if (!container) {
+      console.info('[G2O] No scroll container found, skipping auto-scroll');
+      return { messages: this.extractMessages() };
+    }
+
+    const result = await accumulateWhileScrolling(container, () => config.harvest());
+    // Re-index into contiguous conversation order after de-duplication.
+    const messages = result.items.map((message, index) => ({ ...message, index }));
+
+    if (result.fullyLoaded || result.skipped) {
+      return { messages };
+    }
+    return {
+      messages,
+      warning:
+        `Auto-scroll timed out after ${SCROLL_TIMEOUT / 1000}s. ` +
+        `Some earlier messages may be missing (${result.itemCount} turns loaded).`,
+    };
   }
 
   // ========== Settings ==========

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -7,9 +7,11 @@
  * @see docs/design/DES-003-chatgpt-extractor.md
  */
 
-import { BaseExtractor } from './base';
+import { BaseExtractor, type ScrollConfig } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
-import type { ConversationMessage } from '../../lib/types';
+import { generateHash } from '../../lib/hash';
+import type { HarvestEntry } from '../../lib/scroll-manager';
+import type { ConversationMessage, SyncSettings } from '../../lib/types';
 
 import { SELECTORS } from './selectors/chatgpt';
 
@@ -21,6 +23,13 @@ import { SELECTORS } from './selectors/chatgpt';
  */
 export class ChatGPTExtractor extends BaseExtractor {
   readonly platform = 'chatgpt';
+
+  /**
+   * Apply user settings: enable/disable auto-scroll for virtualized history.
+   */
+  applySettings(settings: SyncSettings): void {
+    this.enableAutoScroll = settings.enableAutoScroll ?? false;
+  }
 
   // ========== Platform Detection ==========
 
@@ -88,12 +97,7 @@ export class ChatGPTExtractor extends BaseExtractor {
 
     // Process each turn
     turns.forEach((turn, index) => {
-      // Determine role from data-turn attribute or data-message-author-role
-      const turnRole = turn.getAttribute('data-turn');
-      const messageEl = turn.querySelector('[data-message-author-role]');
-      const authorRole = messageEl?.getAttribute('data-message-author-role');
-
-      const role = turnRole || authorRole;
+      const role = this.turnRole(turn);
 
       if (role === 'user') {
         const content = this.extractUserContent(turn);
@@ -120,6 +124,66 @@ export class ChatGPTExtractor extends BaseExtractor {
     });
 
     return messages;
+  }
+
+  /**
+   * Determine a turn's role from data-turn or a nested data-message-author-role.
+   */
+  private turnRole(turn: Element): string | null {
+    const turnRole = turn.getAttribute('data-turn');
+    const authorRole = turn
+      .querySelector('[data-message-author-role]')
+      ?.getAttribute('data-message-author-role');
+    return turnRole || authorRole || null;
+  }
+
+  /**
+   * Auto-scroll config: ChatGPT virtualizes the conversation (ADR-017).
+   */
+  protected getScrollConfig(): ScrollConfig {
+    return {
+      container: SELECTORS.scrollContainer,
+      harvest: () => this.harvestWindow(),
+    };
+  }
+
+  /**
+   * Harvest the currently-mounted window as keyed messages.
+   *
+   * Keyed by the turn's stable uuid (data-turn-id, then data-message-id),
+   * hashing content only as a last resort, so turns de-duplicate correctly as
+   * scroll windows overlap.
+   */
+  private harvestWindow(): HarvestEntry<ConversationMessage>[] {
+    const entries: HarvestEntry<ConversationMessage>[] = [];
+    const turns = this.queryAllWithFallback<HTMLElement>(SELECTORS.conversationTurn);
+
+    turns.forEach(turn => {
+      const role = this.turnRole(turn);
+      if (role !== 'user' && role !== 'assistant') return;
+
+      const content =
+        role === 'user' ? this.extractUserContent(turn) : this.extractAssistantContent(turn);
+      if (!content) return;
+
+      const key =
+        turn.getAttribute('data-turn-id') ??
+        turn.querySelector('[data-message-id]')?.getAttribute('data-message-id') ??
+        `${role}-${generateHash(content)}`;
+
+      entries.push({
+        key,
+        value: {
+          id: key,
+          role,
+          content,
+          htmlContent: role === 'assistant' ? content : undefined,
+          index: 0, // re-indexed after accumulation
+        },
+      });
+    });
+
+    return entries;
   }
 
   /**

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -7,9 +7,11 @@
  * @see docs/design/DES-002-claude-extractor.md
  */
 
-import { BaseExtractor } from './base';
+import { BaseExtractor, type ScrollConfig } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { htmlToMarkdownRaw } from '../markdown-rules';
+import { generateHash } from '../../lib/hash';
+import type { HarvestEntry } from '../../lib/scroll-manager';
 import type { ConversationMessage, DeepResearchSource, SyncSettings } from '../../lib/types';
 import { SELECTORS, DEEP_RESEARCH_SELECTORS, JOINED_SELECTORS } from './selectors/claude';
 
@@ -25,10 +27,11 @@ export class ClaudeExtractor extends BaseExtractor {
   enableToolContent = false;
 
   /**
-   * Apply user settings: enable/disable tool content extraction
+   * Apply user settings: enable/disable tool content extraction and auto-scroll
    */
   applySettings(settings: SyncSettings): void {
     this.enableToolContent = settings.enableToolContent ?? false;
+    this.enableAutoScroll = settings.enableAutoScroll ?? false;
   }
 
   // ========== Platform Detection ==========
@@ -102,25 +105,7 @@ export class ClaudeExtractor extends BaseExtractor {
    * @see FR-002 in design document
    */
   extractMessages(): ConversationMessage[] {
-    // Collect all message elements
-    const allElements: Array<{ element: Element; type: 'user' | 'assistant' }> = [];
-
-    // Find user messages (skip nested content inside assistant responses)
-    const userMessages = this.queryAllWithFallback<HTMLElement>(SELECTORS.userMessage);
-    userMessages.forEach(el => {
-      const assistantParent = el.closest('.font-claude-response, [class*="font-claude-response"]');
-      if (!assistantParent) {
-        allElements.push({ element: el, type: 'user' });
-      }
-    });
-
-    // Find assistant responses
-    const assistantResponses = this.queryAllWithFallback<HTMLElement>(SELECTORS.assistantResponse);
-    assistantResponses.forEach(el => {
-      allElements.push({ element: el, type: 'assistant' });
-    });
-
-    const sortedElements = this.sortByDomPosition(allElements);
+    const sortedElements = this.collectSortedElements();
 
     // Pre-extract tool content keyed by message ID (matches buildMessagesFromElements format)
     const toolContentById = new Map<string, string>();
@@ -146,6 +131,89 @@ export class ClaudeExtractor extends BaseExtractor {
       const tc = toolContentById.get(msg.id);
       return tc ? { ...msg, toolContent: tc } : msg;
     });
+  }
+
+  /**
+   * Collect user/assistant message elements in DOM order.
+   *
+   * User messages nested inside an assistant response (e.g. quoted content) are
+   * skipped. Shared by extractMessages() (single pass) and harvestWindow()
+   * (per-scroll-window pass for virtualized conversations).
+   */
+  private collectSortedElements(): Array<{ element: Element; type: 'user' | 'assistant' }> {
+    const allElements: Array<{ element: Element; type: 'user' | 'assistant' }> = [];
+
+    const userMessages = this.queryAllWithFallback<HTMLElement>(SELECTORS.userMessage);
+    userMessages.forEach(el => {
+      const assistantParent = el.closest('.font-claude-response, [class*="font-claude-response"]');
+      if (!assistantParent) {
+        allElements.push({ element: el, type: 'user' });
+      }
+    });
+
+    const assistantResponses = this.queryAllWithFallback<HTMLElement>(SELECTORS.assistantResponse);
+    assistantResponses.forEach(el => {
+      allElements.push({ element: el, type: 'assistant' });
+    });
+
+    return this.sortByDomPosition(allElements);
+  }
+
+  /**
+   * Auto-scroll config: Claude virtualizes the conversation (ADR-017).
+   */
+  protected getScrollConfig(): ScrollConfig {
+    return {
+      container: SELECTORS.scrollContainer,
+      harvest: () => this.harvestWindow(),
+    };
+  }
+
+  /**
+   * Harvest the currently-mounted window as keyed messages.
+   *
+   * The key is the virtual-row `data-index` (stable per turn across windows),
+   * falling back to a content hash when the wrapper is absent, so turns are
+   * de-duplicated correctly as windows overlap during scrolling.
+   */
+  private harvestWindow(): HarvestEntry<ConversationMessage>[] {
+    const entries: HarvestEntry<ConversationMessage>[] = [];
+    this.collectSortedElements().forEach(item => {
+      const content =
+        item.type === 'user'
+          ? this.extractUserContent(item.element)
+          : this.extractAssistantContent(item.element);
+      if (!content) return;
+
+      const key = this.turnKey(item.element, item.type, content);
+      const message: ConversationMessage = {
+        id: key,
+        role: item.type,
+        content,
+        htmlContent: item.type === 'assistant' ? content : undefined,
+        index: 0, // re-indexed after accumulation
+      };
+
+      if (this.enableToolContent && item.type === 'assistant') {
+        const tc = this.extractToolContentFromElement(item.element);
+        if (tc) {
+          entries.push({ key, value: { ...message, toolContent: tc } });
+          return;
+        }
+      }
+      entries.push({ key, value: message });
+    });
+    return entries;
+  }
+
+  /**
+   * Stable per-turn key for de-duplication across scroll windows.
+   * Prefers the virtual-list `data-index`; hashes content otherwise.
+   */
+  private turnKey(element: Element, type: 'user' | 'assistant', content: string): string {
+    const dataIndex = element.closest('[data-index]')?.getAttribute('data-index');
+    if (dataIndex) return `idx-${dataIndex}`;
+    return `${type}-${generateHash(content)}`;
   }
 
   /**

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -22,9 +22,6 @@ import { SELECTORS, DEEP_RESEARCH_SELECTORS, COMPUTED_SELECTORS } from './select
 export class GeminiExtractor extends BaseExtractor {
   readonly platform = 'gemini';
 
-  /** Whether auto-scroll is enabled (set from settings before extract()) */
-  enableAutoScroll = false;
-
   /** Whether generated images are captured (set from settings before extract()) */
   enableImageExport = true;
 

--- a/src/content/extractors/selectors/chatgpt.ts
+++ b/src/content/extractors/selectors/chatgpt.ts
@@ -37,4 +37,16 @@ export const SELECTORS = {
     '.markdown.prose', // Semantic (HIGH)
     '.markdown-new-styling', // Style (MEDIUM)
   ],
+
+  // Scroll container for virtualized-conversation auto-scroll (ADR-017).
+  // ChatGPT windows/evicts turns; the thread scroller carries data-scroll-root
+  // and uses the `not-print:overflow-y-auto` token. IMPORTANT: the sidebar <nav>
+  // also has `flex-1 flex-col overflow-y-auto` (plain, scrollTop 0), so a
+  // class-only `overflow-y-auto` selector picks the nav and skips auto-scroll
+  // (verified live 2026-07). Anchor on data-scroll-root; the `not-print:` prefix
+  // uniquely distinguishes the thread scroller from the nav.
+  scrollContainer: [
+    '[data-scroll-root]', // Semantic scroll root (HIGH)
+    '[class*="not-print:overflow-y-auto"]', // Thread-only overflow token (MEDIUM)
+  ],
 } as const satisfies SelectorGroup;

--- a/src/content/extractors/selectors/claude.ts
+++ b/src/content/extractors/selectors/claude.ts
@@ -64,6 +64,16 @@ export const SELECTORS = {
     '.text-text-500.text-xs', // Tailwind (MEDIUM)
     '[class*="text-text-500"]', // Partial match (LOW)
   ],
+
+  // Scroll container for virtualized-conversation auto-scroll (ADR-017).
+  // Claude windows/evicts turns; this is the overflow-y-auto element that
+  // scrolls the message list (observed live 2026-07: the div also carries
+  // overflow-x-hidden, flex-1, and [scrollbar-gutter:stable]).
+  scrollContainer: [
+    '.overflow-y-auto.overflow-x-hidden.flex-1', // Composite (HIGH)
+    '.overflow-y-auto.overflow-x-hidden', // Style pair (MEDIUM)
+    'div[class*="overflow-y-auto"]', // Partial match (LOW)
+  ],
 } as const satisfies SelectorGroup;
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -168,3 +168,24 @@ export const SCROLL_STABILITY_THRESHOLD = 3;
 
 /** Brief pause after re-arm scroll to bottom before scrolling back to top (milliseconds) */
 export const SCROLL_REARM_DELAY = 200;
+
+// ============================================================
+// Auto-Scroll Configuration (virtualized platforms — Claude, ChatGPT)
+// ============================================================
+//
+// Claude and ChatGPT virtualize the conversation (windowing): only a small
+// moving window of turns is ever mounted and off-screen turns are evicted
+// (ADR-017). Unlike Gemini's accumulate-and-stay infinite-scroller, we cannot
+// scroll to the top once and read everything — we must scroll up in steps and
+// harvest each window, accumulating turns by a stable key.
+
+/** Pause after each upward scroll step before harvesting the newly-mounted window (ms) */
+export const SCROLL_ACCUMULATE_POLL_INTERVAL = 400;
+
+/** Fraction of the container's clientHeight to scroll up per step; <1 keeps
+ *  windows overlapping so no virtualized turn slips between two harvests. */
+export const SCROLL_ACCUMULATE_STEP_FACTOR = 0.6;
+
+/** Floor for the per-step scroll distance (px). Guards environments where
+ *  clientHeight reads 0 (e.g. jsdom, which has no layout engine). */
+export const SCROLL_ACCUMULATE_MIN_STEP = 400;

--- a/src/lib/scroll-manager.ts
+++ b/src/lib/scroll-manager.ts
@@ -10,6 +10,9 @@ import {
   SCROLL_TIMEOUT,
   SCROLL_STABILITY_THRESHOLD,
   SCROLL_REARM_DELAY,
+  SCROLL_ACCUMULATE_POLL_INTERVAL,
+  SCROLL_ACCUMULATE_STEP_FACTOR,
+  SCROLL_ACCUMULATE_MIN_STEP,
 } from './constants';
 
 /**
@@ -126,4 +129,194 @@ export async function ensureAllElementsLoaded(
     scrollIterations: iterations,
     skipped: false,
   };
+}
+
+// ============================================================
+// Accumulation engine for virtualized platforms (Claude, ChatGPT)
+// ============================================================
+
+/** One turn harvested from the currently-mounted window. */
+export interface HarvestEntry<T> {
+  /** Stable per-turn identity used for de-duplication across windows. */
+  key: string;
+  /** The extracted value (e.g. a ConversationMessage). */
+  value: T;
+}
+
+/** Result of accumulating a virtualized conversation via scrolling. */
+export interface AccumulateResult<T> {
+  /** De-duplicated values in conversation order (first turn → last turn). */
+  items: T[];
+  /** Whether harvesting stabilized at the top before timing out. */
+  fullyLoaded: boolean;
+  /** Number of distinct turns captured. */
+  itemCount: number;
+  /** Upward scroll/harvest iterations performed. */
+  iterations: number;
+  /** Whether scrolling was unnecessary (already at the top). */
+  skipped: boolean;
+}
+
+/**
+ * Merge a newly-harvested window of keys into the accumulated ordering.
+ *
+ * Windows are captured while scrolling **up**, so each new window's tail
+ * overlaps the accumulated head. We align on that overlap and prepend the
+ * non-overlapping prefix. With no detectable overlap we fall back to prepending
+ * the window's not-yet-seen keys, so ordering degrades gracefully rather than
+ * dropping turns. The result never contains duplicate keys.
+ *
+ * @param accumulated Keys gathered so far, in conversation order.
+ * @param window Keys from the current window, in DOM (top→bottom) order.
+ */
+export function mergeWindow(accumulated: readonly string[], window: readonly string[]): string[] {
+  if (accumulated.length === 0) return dedupeKeys(window);
+  if (window.length === 0) return [...accumulated];
+
+  // Largest k where the window's last k keys equal the accumulated first k keys.
+  let overlap = 0;
+  const maxK = Math.min(window.length, accumulated.length);
+  for (let k = maxK; k >= 1; k--) {
+    let matches = true;
+    for (let i = 0; i < k; i++) {
+      if (window[window.length - k + i] !== accumulated[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      overlap = k;
+      break;
+    }
+  }
+
+  const prefix = window.slice(0, window.length - overlap);
+  return dedupeKeys([...prefix, ...accumulated]);
+}
+
+/** Remove duplicate keys, keeping first occurrence. */
+function dedupeKeys(keys: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const key of keys) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(key);
+    }
+  }
+  return out;
+}
+
+/**
+ * Accumulate all turns of a virtualized conversation by scrolling upward.
+ *
+ * The container mounts only a small window of turns at a time (older turns are
+ * evicted as you scroll away), so we cannot read the whole conversation in one
+ * pass. Instead we harvest the current window, scroll up by a fraction of the
+ * viewport (keeping windows overlapping), harvest again, and merge — repeating
+ * until the top is reached and no new turns appear for
+ * {@link SCROLL_STABILITY_THRESHOLD} consecutive iterations, or until
+ * {@link SCROLL_TIMEOUT} elapses.
+ *
+ * De-duplication is by {@link HarvestEntry.key}; the most recently harvested
+ * value for a key wins, so a turn that was mid-stream on first sight is replaced
+ * by its final content if re-harvested.
+ *
+ * @param container The scrollable, virtualized conversation container.
+ * @param harvest Returns the currently-mounted window in DOM (top→bottom) order.
+ */
+export async function accumulateWhileScrolling<T>(
+  container: HTMLElement,
+  harvest: () => HarvestEntry<T>[]
+): Promise<AccumulateResult<T>> {
+  const content = new Map<string, T>();
+  let order: string[] = [];
+
+  const ingest = (): void => {
+    const window = harvest();
+    for (const entry of window) {
+      content.set(entry.key, entry.value); // last write wins → freshest content
+    }
+    order = mergeWindow(
+      order,
+      window.map(e => e.key)
+    );
+  };
+
+  const toItems = (): T[] => order.map(key => content.get(key) as T);
+
+  ingest(); // seed with the initial (bottom) window
+
+  if (container.scrollTop <= 0) {
+    console.info('[G2O] scrollTop=0 on open, conversation fits without scrolling');
+    return {
+      items: toItems(),
+      fullyLoaded: true,
+      itemCount: content.size,
+      iterations: 0,
+      skipped: true,
+    };
+  }
+
+  console.info(
+    `[G2O] Virtualized conversation — scrollTop=${container.scrollTop}, ` +
+      `${content.size} turns mounted, accumulating by scrolling up`
+  );
+
+  const step = Math.max(
+    SCROLL_ACCUMULATE_MIN_STEP,
+    Math.floor(container.clientHeight * SCROLL_ACCUMULATE_STEP_FACTOR)
+  );
+
+  const { iterations, fullyLoaded } = await scrollUpUntilStable(container, step, () => {
+    const before = content.size;
+    ingest();
+    return content.size > before;
+  });
+
+  if (fullyLoaded) {
+    console.info(`[G2O] Accumulated ${content.size} turns after ${iterations} scroll iterations`);
+  } else {
+    console.warn(
+      `[G2O] Auto-scroll accumulation timed out after ${SCROLL_TIMEOUT}ms with ${content.size} turns`
+    );
+  }
+
+  return { items: toItems(), fullyLoaded, itemCount: content.size, iterations, skipped: false };
+}
+
+/**
+ * Scroll a container upward one step per iteration until harvesting stops
+ * yielding new turns while pinned at the top, or {@link SCROLL_TIMEOUT} elapses.
+ *
+ * Stability is only counted once already at the top, so a mid-scroll window that
+ * happens to mount nothing new doesn't end accumulation prematurely.
+ *
+ * @param onWindow Ingest the freshly-mounted window; return true if it grew the
+ *   accumulated set. Invoked once per iteration after each scroll settles.
+ */
+async function scrollUpUntilStable(
+  container: HTMLElement,
+  step: number,
+  onWindow: () => boolean
+): Promise<{ iterations: number; fullyLoaded: boolean }> {
+  let stable = 0;
+  let iterations = 0;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < SCROLL_TIMEOUT) {
+    const wasAtTop = container.scrollTop <= 0;
+    container.scrollTop = Math.max(0, container.scrollTop - step);
+    await delay(SCROLL_ACCUMULATE_POLL_INTERVAL);
+
+    const grew = onWindow();
+    iterations++;
+
+    if (grew) {
+      stable = 0;
+    } else if (wasAtTop && ++stable >= SCROLL_STABILITY_THRESHOLD) {
+      return { iterations, fullyLoaded: true };
+    }
+  }
+  return { iterations, fullyLoaded: false };
 }

--- a/test/extractors/chatgpt-autoscroll.test.ts
+++ b/test/extractors/chatgpt-autoscroll.test.ts
@@ -78,6 +78,11 @@ function settings(overrides: Partial<SyncSettings> = {}): SyncSettings {
   return { enableAutoScroll: true, ...overrides } as SyncSettings;
 }
 
+/** Plain text of a message body via the DOM (avoids regex HTML stripping). */
+function plainText(html: string): string {
+  return new DOMParser().parseFromString(html, 'text/html').body.textContent?.trim() ?? '';
+}
+
 describe('ChatGPTExtractor auto-scroll (virtualization)', () => {
   let extractor: ChatGPTExtractor;
 
@@ -109,7 +114,7 @@ describe('ChatGPTExtractor auto-scroll (virtualization)', () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.messages).toHaveLength(8);
-    expect(result.data?.messages.map(m => m.content.replace(/<[^>]+>/g, '').trim())).toEqual([
+    expect(result.data?.messages.map(m => plainText(m.content))).toEqual([
       'Q1',
       'A1',
       'Q2',

--- a/test/extractors/chatgpt-autoscroll.test.ts
+++ b/test/extractors/chatgpt-autoscroll.test.ts
@@ -1,0 +1,152 @@
+/**
+ * ChatGPT auto-scroll (virtualization) integration tests — ADR-017.
+ *
+ * ChatGPT mounts only a window of turns and evicts off-screen ones. These tests
+ * drive the extractor against a simulated virtual list (turns keyed by
+ * data-turn-id) and assert the full history is accumulated in order.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { ChatGPTExtractor } from '../../src/content/extractors/chatgpt';
+import { SELECTORS } from '../../src/content/extractors/selectors/chatgpt';
+import {
+  clearFixture,
+  loadFixture,
+  setChatGPTLocation,
+  resetLocation,
+} from '../fixtures/dom-helpers';
+import type { SyncSettings } from '../../src/lib/types';
+
+const MAX_SCROLL = 10_000;
+
+interface Turn {
+  role: 'user' | 'assistant';
+  content: string;
+  id: string;
+}
+
+function renderTurn(turn: Turn): string {
+  const body =
+    turn.role === 'user'
+      ? `<div class="whitespace-pre-wrap">${turn.content}</div>`
+      : `<div class="markdown prose"><p>${turn.content}</p></div>`;
+  return `<section data-turn-id="${turn.id}" data-turn="${turn.role}">
+    <div data-message-author-role="${turn.role}" data-message-id="${turn.id}">${body}</div>
+  </section>`;
+}
+
+function mountVirtualizedChatGPT(turns: Turn[], windowSize: number): void {
+  // Mirror real ChatGPT: a sidebar <nav> that also matches overflow-y-auto class
+  // selectors (scrollTop 0), plus the actual thread scroller marked
+  // data-scroll-root. The container selector must pick the scroll-root, not the
+  // nav — otherwise accumulation is skipped (regression guard for the nav bug).
+  document.body.innerHTML = `
+    <nav class="flex-1 flex-col overflow-y-auto" id="sidebar"></nav>
+    <div data-scroll-root="" class="flex-1 flex-col not-print:overflow-y-auto" id="scroller"></div>`;
+  const scroller = document.getElementById('scroller') as HTMLElement;
+
+  let scrollTop = MAX_SCROLL;
+  const maxStart = Math.max(0, turns.length - windowSize);
+
+  const render = (): void => {
+    const frac = scrollTop / MAX_SCROLL;
+    const start = Math.round(frac * maxStart);
+    const mounted = turns.slice(start, start + windowSize);
+    scroller.innerHTML = mounted.map(renderTurn).join('');
+  };
+
+  Object.defineProperty(scroller, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = Math.max(0, Math.min(MAX_SCROLL, v));
+      render();
+    },
+    configurable: true,
+  });
+  Object.defineProperty(scroller, 'clientHeight', { get: () => 900, configurable: true });
+  Object.defineProperty(scroller, 'scrollHeight', {
+    get: () => MAX_SCROLL + 900,
+    configurable: true,
+  });
+
+  render();
+}
+
+function settings(overrides: Partial<SyncSettings> = {}): SyncSettings {
+  return { enableAutoScroll: true, ...overrides } as SyncSettings;
+}
+
+describe('ChatGPTExtractor auto-scroll (virtualization)', () => {
+  let extractor: ChatGPTExtractor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    extractor = new ChatGPTExtractor();
+    setChatGPTLocation('6789abcd-ef01-2345-6789-abcdef012345');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearFixture();
+    resetLocation();
+  });
+
+  const conversation: Turn[] = Array.from({ length: 8 }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    content: i % 2 === 0 ? `Q${i / 2 + 1}` : `A${(i - 1) / 2 + 1}`,
+    id: `turn-${i}`,
+  }));
+
+  it('accumulates all virtualized turns in order when enabled', async () => {
+    mountVirtualizedChatGPT(conversation, 3);
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.data?.messages).toHaveLength(8);
+    expect(result.data?.messages.map(m => m.content.replace(/<[^>]+>/g, '').trim())).toEqual([
+      'Q1',
+      'A1',
+      'Q2',
+      'A2',
+      'Q3',
+      'A3',
+      'Q4',
+      'A4',
+    ]);
+    expect(result.data?.messages.map(m => m.index)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('extracts only the mounted window when auto-scroll is disabled', async () => {
+    mountVirtualizedChatGPT(conversation, 3);
+    extractor.applySettings(settings({ enableAutoScroll: false }));
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.data?.messages).toHaveLength(3);
+  });
+
+  it('scroll-container selector matches the real captured desktop DOM', () => {
+    // The daemon serves ChatGPT's mweb layout, so this fixture (captured desktop
+    // DOM, same conversation) is how we validate the container selector against
+    // real markup. See ADR-017 open questions.
+    vi.useRealTimers();
+    const html = readFileSync(
+      resolve(__dirname, '../fixtures/html/chatgpt/chat-simple.html'),
+      'utf-8'
+    );
+    loadFixture(html);
+
+    const container = extractor['queryWithFallback']<HTMLElement>(SELECTORS.scrollContainer);
+    expect(container).not.toBeNull();
+  });
+});

--- a/test/extractors/claude-autoscroll.test.ts
+++ b/test/extractors/claude-autoscroll.test.ts
@@ -68,6 +68,11 @@ function settings(overrides: Partial<SyncSettings> = {}): SyncSettings {
   return { enableAutoScroll: true, ...overrides } as SyncSettings;
 }
 
+/** Plain text of a message body via the DOM (avoids regex HTML stripping). */
+function plainText(html: string): string {
+  return new DOMParser().parseFromString(html, 'text/html').body.textContent?.trim() ?? '';
+}
+
 describe('ClaudeExtractor auto-scroll (virtualization)', () => {
   let extractor: ClaudeExtractor;
 
@@ -102,7 +107,7 @@ describe('ClaudeExtractor auto-scroll (virtualization)', () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.messages).toHaveLength(6);
-    expect(result.data?.messages.map(m => m.content.replace(/<[^>]+>/g, '').trim())).toEqual([
+    expect(result.data?.messages.map(m => plainText(m.content))).toEqual([
       'Q1',
       'A1',
       'Q2',

--- a/test/extractors/claude-autoscroll.test.ts
+++ b/test/extractors/claude-autoscroll.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Claude auto-scroll (virtualization) integration tests — ADR-017.
+ *
+ * Claude mounts only a small window of turns; scrolling up loads earlier turns
+ * while evicting later ones. These tests drive the extractor against a
+ * simulated virtual list (turns rendered with `data-index`, mounted/evicted by
+ * scrollTop) and assert the full history is accumulated in order.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ClaudeExtractor } from '../../src/content/extractors/claude';
+import { clearFixture, setClaudeLocation, resetLocation } from '../fixtures/dom-helpers';
+import type { SyncSettings } from '../../src/lib/types';
+
+const MAX_SCROLL = 10_000;
+
+interface Turn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** Render one turn wrapped in a `data-index` virtual-row wrapper. */
+function renderTurn(turn: Turn, index: number): string {
+  const inner =
+    turn.role === 'user'
+      ? `<div class="bg-bg-300 rounded-xl"><div data-testid="user-message">${turn.content}</div></div>`
+      : `<div class="font-claude-response"><div class="standard-markdown"><p>${turn.content}</p></div></div>`;
+  return `<div data-index="${index}"><div data-test-render-count="2">${inner}</div></div>`;
+}
+
+/**
+ * Install a virtualized Claude conversation into the DOM. Only `windowSize`
+ * consecutive turns are mounted at once, chosen by the current scrollTop
+ * (bottom on open). Returns nothing; sets up document.body.
+ */
+function mountVirtualizedClaude(turns: Turn[], windowSize: number): void {
+  document.body.innerHTML = `<div class="overflow-y-auto overflow-x-hidden flex-1" id="scroller"></div>`;
+  const scroller = document.getElementById('scroller') as HTMLElement;
+
+  let scrollTop = MAX_SCROLL; // opens at the bottom
+  const maxStart = Math.max(0, turns.length - windowSize);
+
+  const render = (): void => {
+    const frac = scrollTop / MAX_SCROLL;
+    const start = Math.round(frac * maxStart);
+    const mounted = turns.slice(start, start + windowSize);
+    scroller.innerHTML = mounted.map((t, i) => renderTurn(t, start + i)).join('');
+  };
+
+  Object.defineProperty(scroller, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = Math.max(0, Math.min(MAX_SCROLL, v));
+      render();
+    },
+    configurable: true,
+  });
+  Object.defineProperty(scroller, 'clientHeight', { get: () => 900, configurable: true });
+  Object.defineProperty(scroller, 'scrollHeight', {
+    get: () => MAX_SCROLL + 900,
+    configurable: true,
+  });
+
+  render();
+}
+
+function settings(overrides: Partial<SyncSettings> = {}): SyncSettings {
+  return { enableAutoScroll: true, ...overrides } as SyncSettings;
+}
+
+describe('ClaudeExtractor auto-scroll (virtualization)', () => {
+  let extractor: ClaudeExtractor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    extractor = new ClaudeExtractor();
+    setClaudeLocation('1fbb8252-2bec-4ef2-bf1f-88393dd9bb5f');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearFixture();
+    resetLocation();
+  });
+
+  const conversation: Turn[] = [
+    { role: 'user', content: 'Q1' },
+    { role: 'assistant', content: 'A1' },
+    { role: 'user', content: 'Q2' },
+    { role: 'assistant', content: 'A2' },
+    { role: 'user', content: 'Q3' },
+    { role: 'assistant', content: 'A3' },
+  ];
+
+  it('accumulates all virtualized turns in order when enabled', async () => {
+    mountVirtualizedClaude(conversation, 3); // only 3 of 6 mounted at a time
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.data?.messages).toHaveLength(6);
+    expect(result.data?.messages.map(m => m.content.replace(/<[^>]+>/g, '').trim())).toEqual([
+      'Q1',
+      'A1',
+      'Q2',
+      'A2',
+      'Q3',
+      'A3',
+    ]);
+    // Indices are contiguous after accumulation.
+    expect(result.data?.messages.map(m => m.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('extracts only the mounted window when auto-scroll is disabled', async () => {
+    mountVirtualizedClaude(conversation, 3);
+    extractor.applySettings(settings({ enableAutoScroll: false }));
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    // Without scrolling, only the bottom window (last 3 turns) is visible.
+    expect(result.data?.messages).toHaveLength(3);
+  });
+
+  it('warns when accumulation times out without ever reaching the top', async () => {
+    // A container that mounts a brand-new turn on every scroll and never
+    // reaches scrollTop 0 — accumulation can never stabilize.
+    document.body.innerHTML = `<div class="overflow-y-auto overflow-x-hidden flex-1" id="scroller"></div>`;
+    const scroller = document.getElementById('scroller') as HTMLElement;
+    let scrollTop = MAX_SCROLL;
+    let counter = 0;
+    const renderNext = (): void => {
+      counter++;
+      scroller.innerHTML = renderTurn({ role: 'user', content: `Q${counter}` }, counter);
+    };
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = Math.max(1, v); // never pins at the top
+        renderNext();
+      },
+      configurable: true,
+    });
+    Object.defineProperty(scroller, 'clientHeight', { get: () => 900, configurable: true });
+    renderNext();
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.warnings?.some(w => w.includes('Auto-scroll timed out'))).toBe(true);
+  });
+});

--- a/test/lib/scroll-manager.test.ts
+++ b/test/lib/scroll-manager.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the auto-scroll accumulation engine (ADR-017).
+ *
+ * Claude and ChatGPT virtualize the conversation: only a small moving window
+ * of turns is ever mounted, and off-screen turns are evicted. The engine must
+ * scroll upward, harvest each window, and accumulate/dedupe turns by a stable
+ * key so the full history is captured despite never holding it all at once.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mergeWindow, accumulateWhileScrolling } from '../../src/lib/scroll-manager';
+
+describe('mergeWindow', () => {
+  it('returns the window verbatim when nothing is accumulated yet', () => {
+    expect(mergeWindow([], ['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('leaves the accumulation unchanged when the window is fully contained', () => {
+    // We scrolled up but the same window re-mounted (no new turns).
+    expect(mergeWindow(['c', 'd', 'e'], ['c', 'd'])).toEqual(['c', 'd', 'e']);
+  });
+
+  it('prepends the non-overlapping prefix, aligning on the shared suffix', () => {
+    // Scrolling up: new window [a,b,c,d] overlaps accumulated head [c,d].
+    expect(mergeWindow(['c', 'd'], ['a', 'b', 'c', 'd'])).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('aligns on a single-element overlap', () => {
+    expect(mergeWindow(['c', 'd', 'e'], ['a', 'b', 'c'])).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('falls back to prepending de-duplicated keys when there is no overlap', () => {
+    expect(mergeWindow(['d', 'e'], ['a', 'b'])).toEqual(['a', 'b', 'd', 'e']);
+  });
+
+  it('never emits duplicate keys', () => {
+    expect(mergeWindow(['b', 'c'], ['a', 'b'])).toEqual(['a', 'b', 'c']);
+  });
+});
+
+/**
+ * Build a fake virtualized scroll container: a full list of `total` items, of
+ * which only `windowSize` are ever "mounted" (returned by harvest), positioned
+ * by the current scrollTop. scrollTop starts at the bottom, mirroring how
+ * Claude/ChatGPT open a conversation.
+ */
+function createVirtualList(opts: {
+  total: number;
+  windowSize: number;
+  clientHeight?: number;
+  startAtTop?: boolean;
+}): {
+  container: HTMLElement;
+  harvest: () => Array<{ key: string; value: string }>;
+} {
+  const { total, windowSize } = opts;
+  const clientHeight = opts.clientHeight ?? 900;
+  const maxScroll = 10_000;
+  const items = Array.from({ length: total }, (_, i) => ({ key: `k${i}`, value: `v${i}` }));
+
+  const container = document.createElement('div');
+  let scrollTop = opts.startAtTop ? 0 : maxScroll;
+  Object.defineProperty(container, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = Math.max(0, Math.min(maxScroll, v));
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, 'clientHeight', { get: () => clientHeight, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', {
+    get: () => maxScroll + clientHeight,
+    configurable: true,
+  });
+
+  const maxStart = Math.max(0, total - windowSize);
+  const harvest = () => {
+    const frac = scrollTop / maxScroll; // 1 at bottom, 0 at top
+    const start = Math.round(frac * maxStart);
+    return items.slice(start, start + windowSize);
+  };
+
+  return { container, harvest };
+}
+
+describe('accumulateWhileScrolling', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('accumulates every turn across windows despite eviction', async () => {
+    const { container, harvest } = createVirtualList({ total: 12, windowSize: 4 });
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.skipped).toBe(false);
+    expect(result.fullyLoaded).toBe(true);
+    expect(result.itemCount).toBe(12);
+    // Ordered from first turn to last.
+    expect(result.items).toEqual(Array.from({ length: 12 }, (_, i) => `v${i}`));
+  });
+
+  it('skips scrolling when the container starts at the top (short conversation)', async () => {
+    const { container, harvest } = createVirtualList({
+      total: 3,
+      windowSize: 5,
+      startAtTop: true,
+    });
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.skipped).toBe(true);
+    expect(result.items).toEqual(['v0', 'v1', 'v2']);
+  });
+
+  it('reports fullyLoaded=false when the DOM never stabilizes (timeout)', async () => {
+    // Harvest that always yields a brand-new unique key → never stabilizes.
+    const container = document.createElement('div');
+    let scrollTop = 10_000;
+    Object.defineProperty(container, 'scrollTop', {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = Math.max(0, v);
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, 'clientHeight', { get: () => 900, configurable: true });
+    let n = 0;
+    const harvest = () => [{ key: `new${n++}`, value: `val${n}` }];
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.fullyLoaded).toBe(false);
+    expect(result.skipped).toBe(false);
+  });
+
+  it('keeps the freshest content when a key re-appears in a later window', async () => {
+    const container = document.createElement('div');
+    let scrollTop = 10_000;
+    Object.defineProperty(container, 'scrollTop', {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = Math.max(0, v);
+      },
+      configurable: true,
+    });
+    Object.defineProperty(container, 'clientHeight', { get: () => 900, configurable: true });
+
+    let round = 0;
+    const harvest = () => {
+      round++;
+      // First harvest: key "a" has stale (streaming) content; later: final content.
+      if (round === 1) return [{ key: 'a', value: 'partial' }];
+      return [{ key: 'a', value: 'final' }];
+    };
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.items).toEqual(['final']);
+  });
+});


### PR DESCRIPTION
## Summary

- Claude and ChatGPT virtualize the conversation (windowing): only a small moving window of turns is ever mounted and off-screen turns are evicted, so single-pass extraction captured only the recent subset (reported: ChatGPT 5/13, Claude 6/12).
- Add an accumulation engine (`accumulateWhileScrolling` + `mergeWindow` in `src/lib/scroll-manager.ts`): scroll up by ~one viewport, harvest each mounted window, and dedupe/order turns by a stable key until the full history is captured or a timeout elapses. Gemini's existing count-based path is untouched.
- New `BaseExtractor.getScrollConfig()` hook + `collectMessages()`; the default `extract()` runs accumulation only when `enableAutoScroll` is set and a config exists. Gemini keeps its own `extract()` override.
- Claude/ChatGPT extractors gain `harvestWindow()` (keyed messages) + scroll-container selectors, and gate on the existing `enableAutoScroll` setting. Keys: Claude `data-index`, ChatGPT `data-turn-id`/`data-message-id`.
- ChatGPT container anchored on the semantic `[data-scroll-root]` — the class-only selector matched the sidebar `<nav>` (scrollTop 0) and skipped scrolling; regression covered by a decoy-nav fixture.
- Verified on the live Claude DOM (CDP daemon): all 26 turns captured contiguously from an initial 3-turn mount. ADR-017 documents the investigation and decision.

## Test plan

* [x] `npm run build` succeeds
* [x] `npm run lint` passes (0 errors)
* [x] `npm run test` passes (1183 tests)
* [x] New unit tests for the accumulation engine + `mergeWindow`
* [x] Claude/ChatGPT virtualization integration tests (incl. timeout-warning and ChatGPT nav-decoy regression)
* [x] ChatGPT container selector validated against the real captured desktop fixture
* [x] Manual smoke test: live desktop ChatGPT conversation extracts full history (automated Chromes force the mweb layout, so this needs a real browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)