### PR TITLE
feat: add optional filename naming schemes (title-id / title-date)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -57,6 +57,22 @@
     "message": "Use {platform} for source (gemini, claude, chatgpt, perplexity, notebooklm) and {YYYY} {YY} {MM} {DD} for the save date (local time). Example: AI/{platform}/{YYYY}/{MM}",
     "description": "Help text explaining template variables for vault path"
   },
+  "settings_filenameScheme": {
+    "message": "Filename Scheme",
+    "description": "Label for the note filename naming scheme select"
+  },
+  "settings_filenameScheme_titleId": {
+    "message": "Title + conversation ID",
+    "description": "Filename scheme option: slug plus conversation id suffix"
+  },
+  "settings_filenameScheme_titleDate": {
+    "message": "Title + save date",
+    "description": "Filename scheme option: slug plus save date suffix"
+  },
+  "settings_filenameSchemeHelp": {
+    "message": "How note filenames are built: title-id (e.g. my-chat-a1b2c3d4) or title-date (e.g. my-chat-2026-07-07). The collision safeguard still applies.",
+    "description": "Help text for the filename scheme select"
+  },
   "settings_messageFormat": {
     "message": "Message Format",
     "description": "Label for message format select"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -43,6 +43,18 @@
   "settings_vaultPathHelp": {
     "message": "{platform} はプラットフォーム名（gemini, claude, chatgpt, perplexity, notebooklm）、{YYYY} {YY} {MM} {DD} は保存時のローカル日付に置換されます。例: AI/{platform}/{YYYY}/{MM}"
   },
+  "settings_filenameScheme": {
+    "message": "ファイル名スキーム"
+  },
+  "settings_filenameScheme_titleId": {
+    "message": "タイトル + 会話 ID"
+  },
+  "settings_filenameScheme_titleDate": {
+    "message": "タイトル + 保存日"
+  },
+  "settings_filenameSchemeHelp": {
+    "message": "ノートのファイル名の付け方: title-id（例: my-chat-a1b2c3d4）または title-date（例: my-chat-2026-07-07）。衝突回避の安全策は引き続き適用されます。"
+  },
   "settings_messageFormat": {
     "message": "メッセージ形式"
   },

--- a/src/content/markdown.ts
+++ b/src/content/markdown.ts
@@ -16,25 +16,53 @@ import type {
   ObsidianNote,
   NoteFrontmatter,
   TemplateOptions,
+  FilenameScheme,
 } from '../lib/types';
 import { formatDateWithTimezone } from '../lib/date-utils';
+import { getDateVariables } from '../lib/path-utils';
 
 // Re-exports (preserve existing import paths)
 export { htmlToMarkdown, escapeAngleBrackets, escapeUserText } from './markdown-rules';
 export { convertDeepResearchContent } from './markdown-deep-research';
 
 /**
- * Generate sanitized filename from title
+ * Generate a sanitized note filename from the title, per the chosen scheme.
+ *
+ * The title is always slugified (lowercased, non-alphanumeric runs \u2192 `-`,
+ * CJK/Hangul preserved) and truncated. The suffix depends on `scheme`:
+ * - `title-id`   \u2192 the first 8 chars of the conversation id (default).
+ * - `title-date` \u2192 the local `YYYY-MM-DD` of `date` (save date), matching the
+ *   vault-path date tokens.
+ *
+ * @param title           Conversation title.
+ * @param conversationId  Raw conversation id (used by the `title-id` scheme).
+ * @param scheme          Naming scheme (default `title-id`).
+ * @param date            Date for the `title-date` scheme (default: now).
  */
-export function generateFileName(title: string, conversationId: string): string {
-  const sanitized = title
-    .toLowerCase()
-    .replace(/[^a-z0-9\u3000-\u9fff\uac00-\ud7af]+/g, '-') // Keep Japanese/Korean chars
-    .replace(/^-+|-+$/g, '')
-    .substring(0, MAX_FILENAME_BASE_LENGTH);
+export function generateFileName(
+  title: string,
+  conversationId: string,
+  scheme: FilenameScheme = 'title-id',
+  date: Date = new Date()
+): string {
+  const slug =
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9\u3000-\u9fff\uac00-\ud7af]+/g, '-') // Keep Japanese/Korean chars
+      .replace(/^-+|-+$/g, '')
+      .substring(0, MAX_FILENAME_BASE_LENGTH) || 'conversation';
 
-  const idSuffix = conversationId.substring(0, FILENAME_ID_SUFFIX_LENGTH);
-  return `${sanitized || 'conversation'}-${idSuffix}.md`;
+  const suffix =
+    scheme === 'title-date'
+      ? dateSuffix(date)
+      : conversationId.substring(0, FILENAME_ID_SUFFIX_LENGTH);
+  return `${slug}-${suffix}.md`;
+}
+
+/** Local `YYYY-MM-DD` suffix for the `title-date` scheme. */
+function dateSuffix(date: Date): string {
+  const { YYYY, MM, DD } = getDateVariables(date);
+  return `${YYYY}-${MM}-${DD}`;
 }
 
 /**
@@ -94,7 +122,7 @@ export function conversationToNote(data: ConversationData, options: TemplateOpti
   }
 
   // Generate filename and content hash
-  const fileName = generateFileName(data.title, data.id);
+  const fileName = generateFileName(data.title, data.id, options.filenameScheme);
   const contentHash = generateContentHash(body);
 
   return {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -26,6 +26,7 @@ const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
   userCalloutType: 'QUESTION',
   assistantCalloutType: 'NOTE',
   includeQuestionHeaders: false,
+  filenameScheme: 'title-id',
 };
 
 const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -255,6 +255,13 @@ export interface ContentScriptSettings extends SyncSettings {
 }
 
 /**
+ * Note filename naming scheme (issue #328).
+ * - `title-id`   — `{slug}-{conversationId[:8]}.md` (default, current behavior)
+ * - `title-date` — `{slug}-{YYYY}-{MM}-{DD}.md` using the local save date
+ */
+export type FilenameScheme = 'title-id' | 'title-date';
+
+/**
  * Template customization options
  */
 export interface TemplateOptions {
@@ -284,6 +291,8 @@ export interface TemplateOptions {
   includeQuestionHeaders?: boolean;
   /** IANA timezone for created/modified dates (e.g., 'Asia/Tokyo'). Defaults to 'UTC'. */
   timezone?: string;
+  /** Note filename naming scheme (issue #328). Defaults to `title-id`. */
+  filenameScheme?: FilenameScheme;
 }
 
 /**

--- a/src/popup/app.ts
+++ b/src/popup/app.ts
@@ -84,6 +84,7 @@ function queryElements() {
     obsidianUrl: getElement<HTMLInputElement>('obsidianUrl'),
     vaultPath: getElement<HTMLInputElement>('vaultPath'),
     messageFormat: getElement<HTMLSelectElement>('messageFormat'),
+    filenameScheme: getElement<HTMLSelectElement>('filenameScheme'),
     calloutSettingsGroup: getElement<HTMLElement>('calloutSettingsGroup'),
     userCallout: getElement<HTMLInputElement>('userCallout'),
     assistantCallout: getElement<HTMLInputElement>('assistantCallout'),
@@ -161,6 +162,7 @@ function populateForm(settings: ExtensionSettings): void {
 
   const { templateOptions } = settings;
   elements.messageFormat.value = templateOptions.messageFormat || 'callout';
+  elements.filenameScheme.value = templateOptions.filenameScheme || 'title-id';
   elements.userCallout.value = templateOptions.userCalloutType || 'QUESTION';
   elements.assistantCallout.value = templateOptions.assistantCalloutType || 'NOTE';
   updateCalloutSettingsVisibility();
@@ -361,6 +363,7 @@ function collectSettings(): ExtensionSettings {
     includeDates: elements.includeDates.checked,
     includeMessageCount: elements.includeMessageCount.checked,
     timezone: elements.timezone.value || undefined,
+    filenameScheme: elements.filenameScheme.value === 'title-date' ? 'title-date' : 'title-id',
   };
 
   const outputOptions = collectOutputOptions();

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -216,6 +216,24 @@
               </div>
 
               <div class="form-group">
+                <label for="filenameScheme" data-i18n="settings_filenameScheme"
+                  >Filename Scheme</label
+                >
+                <select id="filenameScheme">
+                  <option value="title-id" data-i18n="settings_filenameScheme_titleId">
+                    Title + conversation ID
+                  </option>
+                  <option value="title-date" data-i18n="settings_filenameScheme_titleDate">
+                    Title + save date
+                  </option>
+                </select>
+                <p class="help" data-i18n="settings_filenameSchemeHelp">
+                  How note filenames are built: title-id (e.g. my-chat-a1b2c3d4) or title-date (e.g.
+                  my-chat-2026-07-07). The collision safeguard still applies.
+                </p>
+              </div>
+
+              <div class="form-group">
                 <label for="imageVaultPath" data-i18n="settings_imageVaultPath">Image Folder</label>
                 <input
                   type="text"

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -457,6 +457,35 @@ describe('generateFileName', () => {
   });
 });
 
+describe('generateFileName — naming scheme (#328)', () => {
+  const DATE = new Date(2026, 6, 5); // 2026-07-05, local time
+
+  it('defaults to the title-id scheme when scheme is omitted', () => {
+    expect(generateFileName('Hello World', 'abc123def456')).toBe('hello-world-abc123de.md');
+  });
+
+  it("'title-id' scheme uses the 8-char conversation id suffix", () => {
+    expect(generateFileName('Hello World', 'abc123def456', 'title-id')).toBe(
+      'hello-world-abc123de.md'
+    );
+  });
+
+  it("'title-date' scheme uses the local YYYY-MM-DD suffix instead of the id", () => {
+    expect(generateFileName('Top 5 Headlines', 'abc123def456', 'title-date', DATE)).toBe(
+      'top-5-headlines-2026-07-05.md'
+    );
+  });
+
+  it("'title-date' still sanitizes the title and applies the empty fallback", () => {
+    expect(generateFileName('', 'abc123def456', 'title-date', DATE)).toBe(
+      'conversation-2026-07-05.md'
+    );
+    expect(generateFileName('Test: Special!', 'abc123def456', 'title-date', DATE)).toBe(
+      'test-special-2026-07-05.md'
+    );
+  });
+});
+
 describe('generateContentHash', () => {
   it('returns consistent hash', () => {
     const content = 'test content';
@@ -526,6 +555,33 @@ describe('conversationToNote', () => {
   it('attaches an empty images array when the conversation has none', () => {
     const note = conversationToNote(mockData, defaultOptions);
     expect(note.images).toEqual([]);
+  });
+
+  it('uses the title-id filename scheme by default (#328)', () => {
+    const note = conversationToNote(mockData, defaultOptions);
+    expect(note.fileName).toBe('test-conversation-conv123.md');
+  });
+
+  it('uses the title-date filename scheme when configured (#328)', () => {
+    const note = conversationToNote(mockData, { ...defaultOptions, filenameScheme: 'title-date' });
+    expect(note.fileName).toMatch(/^test-conversation-\d{4}-\d{2}-\d{2}\.md$/);
+  });
+
+  it('never leaks a DOM-derived per-message id into the filename or frontmatter id', () => {
+    // ConversationMessage.id is now sourced from page-controlled DOM attributes
+    // (data-turn-id, data-index). This invariant guards it from ever reaching a
+    // sink: the filename derives from data.id and the frontmatter id is
+    // `${source}_${data.id}` — never message.id.
+    const evil = '../../etc/passwd"><script>';
+    const data: ConversationData = {
+      ...mockData,
+      messages: [{ id: evil, role: 'user', content: 'hi', index: 0 }],
+    };
+    const note = conversationToNote(data, defaultOptions);
+    expect(note.fileName).not.toContain('etc');
+    expect(note.fileName).not.toContain('script');
+    expect(note.frontmatter.id).toBe('gemini_conv123');
+    expect(note.frontmatter.id).not.toContain(evil);
   });
 
   it('generates frontmatter with required fields', () => {

--- a/test/lib/hash.test.ts
+++ b/test/lib/hash.test.ts
@@ -43,4 +43,14 @@ describe('generateHash', () => {
     const hashes2 = inputs.map(generateHash);
     expect(hashes1).toEqual(hashes2);
   });
+
+  it('always returns exactly 8 lowercase hex chars — never a sign (INT_MIN safety)', () => {
+    // Guards against a signed-overflow regression: the internal 32-bit hash can
+    // reach -2147483648, whose abs must still render as clean hex (no '-'),
+    // since the value feeds filename collision suffixes and dedup keys.
+    for (let i = 0; i < 5000; i++) {
+      const out = generateHash(`fuzz-${i}-${i * 7919}-${String.fromCharCode(i % 65535)}`);
+      expect(out).toMatch(/^[0-9a-f]{8}$/);
+    }
+  });
 });

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -110,6 +110,20 @@ describe('storage', () => {
       expect(settings.templateOptions.includeId).toBe(true); // default preserved
     });
 
+    it('defaults filenameScheme to title-id (#328)', async () => {
+      const settings = await getSettings();
+      expect(settings.templateOptions.filenameScheme).toBe('title-id');
+    });
+
+    it('round-trips a stored title-date filenameScheme (#328)', async () => {
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+        settings: { templateOptions: { filenameScheme: 'title-date' } },
+      });
+      const settings = await getSettings();
+      expect(settings.templateOptions.filenameScheme).toBe('title-date');
+      expect(settings.templateOptions.messageFormat).toBe('callout'); // default preserved
+    });
+
     it('returns default enableToolContent false when empty', async () => {
       const settings = await getSettings();
       expect(settings.enableToolContent).toBe(false);

--- a/test/popup/index.test.ts
+++ b/test/popup/index.test.ts
@@ -89,6 +89,10 @@ function buildPopupDom(): void {
       <option value="plain">plain</option>
       <option value="blockquote">blockquote</option>
     </select>
+    <select id="filenameScheme">
+      <option value="title-id">title-id</option>
+      <option value="title-date">title-date</option>
+    </select>
     <div id="calloutSettingsGroup">
       <input type="text" id="userCallout" />
       <input type="text" id="assistantCallout" />
@@ -330,6 +334,21 @@ describe('popup/app', () => {
       expect(statusEl().textContent).toBe('status_settingsSaved');
       expect(statusEl().className).toBe('status success');
       expect(el<HTMLButtonElement>('saveBtn').disabled).toBe(false);
+    });
+
+    it('collects the selected filename scheme into templateOptions (#328)', async () => {
+      await initWithDefaults();
+      vi.mocked(saveSettings).mockResolvedValue(undefined);
+
+      el<HTMLSelectElement>('filenameScheme').value = 'title-date';
+      el<HTMLButtonElement>('saveBtn').click();
+
+      await vi.waitFor(() => expect(saveSettings).toHaveBeenCalled());
+      expect(saveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateOptions: expect.objectContaining({ filenameScheme: 'title-date' }),
+        })
+      );
     });
 
     it('rejects saving when no output destination is selected', async () => {


### PR DESCRIPTION
## Summary

- Implements issue #328: a user-selectable note filename scheme.
  - `title-id` (default) — `{slug}-{conversationId[:8]}.md`, identical to current behavior.
  - `title-date` — `{slug}-{YYYY}-{MM}-{DD}.md` using the local save date (consistent with vault-path date tokens).
- Threaded `filenameScheme` through `TemplateOptions`, so it round-trips via the existing `templateOptions` merge in `getSettings`/`saveSettings` — no `scalarKeys`/`PASS_THROUGH_KEYS` changes.
- Popup: new `<select>` in the **Advanced** panel next to Vault Path, wired via `getElement`/`populateForm`/`collectSettings`, with en/ja i18n.
- Backward compatible: default unchanged; append-mode and the collision safeguard key on frontmatter `id`, not the filename, so existing notes/re-saves are unaffected.
- Security hardening (tests only): a `generateHash` invariant test (always 8 hex chars, no sign — documents INT_MIN safety) and a `conversationToNote` invariant test proving a DOM-derived per-message `id` never reaches the filename or frontmatter id. Note: the originally-planned `generateHash` "INT_MIN fix" was dropped after verifying no bug exists (JS `Math.abs` handles it correctly).

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (1194 tests)
- [x] `generateFileName` scheme unit tests + `conversationToNote` integration (default + title-date)
- [x] storage round-trip of `templateOptions.filenameScheme`
- [x] popup collects the selected scheme into `templateOptions`
- [x] Manual: toggle the scheme in the popup and confirm the saved note filename format

🤖 Generated with [Claude Code](https://claude.com/claude-code)