### PR TITLE
docs: refresh READMEs for v2 features and add sync-docs skill

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -44,6 +44,18 @@ If `$ARGUMENTS` does NOT start with a `type:` prefix (or is empty), auto-detect 
 | UI-only changes (popup, CSS) | `ui` |
 | Mixed categories | Use the type covering the most impactful files; default to `feat` if new functionality exists, otherwise `chore` |
 
+### Documentation sync check (suggestion only)
+
+If the detected type is `feat` or the change set contains a **breaking / user-facing**
+change (new platform, new setting, changed output behavior), and `README.md` /
+`README.ja.md` are **not** already part of this change set, note it and suggest:
+
+> This looks like a user-facing change but the READMEs aren't updated. Consider running
+> `/sync-docs` first to keep the docs in sync.
+
+This is a **suggestion only** — do not run `/sync-docs` automatically and do not block the
+release. Proceed with the release regardless of the user's choice.
+
 ---
 
 ## Step 3: Generate commit message

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: sync-docs
+description: Detect user-facing feature drift and update README.md + README.ja.md in lockstep. Use when features have shipped but the READMEs are stale, or before a release. Docs-only — never touches src/.
+version: 1.0.0
+---
+
+# sync-docs
+
+Keeps the user-facing documentation (`README.md` and `README.ja.md`) in sync with the
+features that have actually shipped. This skill **only edits documentation** — it never
+modifies `src/`, tests, or configuration.
+
+## When to use
+
+- Features have landed but the READMEs haven't been updated.
+- Before cutting a release (invoked manually; `/release` suggests it — the two are
+  deliberately decoupled).
+- After adding a new platform, setting, or output behavior.
+
+## Absolute rules
+
+- **Docs only.** Edit `README.md`, `README.ja.md`, and (if needed) `docs/`. Never edit
+  `src/`, tests, `manifest.json`, or build config.
+- **EN/JA parity is mandatory.** Every change to `README.md` must have an equivalent
+  change in `README.ja.md`, and vice versa. The two files must stay structurally parallel
+  (same sections, same order, same tables).
+- **Verify before done.** Report what changed and prove the docs still format cleanly.
+- Follow the project rules in `CLAUDE.md`: work on a branch, never commit secrets, no
+  scope creep.
+
+## Workflow
+
+### 1. Establish the "documented" baseline
+
+Read both READMEs and list the features they currently describe (Features bullets,
+Usage subsections, settings mentioned, supported platforms).
+
+### 2. Establish the "shipped" reality
+
+Gather the real feature set from these sources (do not assume — read them):
+
+- `CHANGELOG.md` — the `Features` / `BREAKING CHANGES` entries since the last version the
+  README reflects. `git log --oneline -- README.md` shows when the README was last touched;
+  everything after that commit is a drift candidate.
+- `src/lib/types.ts` — `SyncSettings` / `TemplateOptions` describe every user-facing
+  setting. Any setting not mentioned in the README is a drift candidate.
+- `src/lib/platform-registry.ts` — the source of truth for supported platforms.
+- `src/popup/index.html` + `src/_locales/en/messages.json` — the settings UI surface and
+  its labels.
+
+### 3. Compute the diff
+
+Produce a concrete list: "shipped but undocumented" and "documented but removed/renamed".
+Present it to the user as a short table before editing if the drift is large (5+ items);
+for small drift, proceed and report afterward.
+
+Scope filter: only **user-facing** changes belong in the README (new platforms, settings,
+output behaviors, guards). Internal refactors, ADRs, and test/CI changes do **not**.
+
+### 4. Apply edits in lockstep
+
+For each drift item, edit `README.md` and `README.ja.md` together, matching the existing
+style:
+
+- Terse Features bullets (`- **Name**: one-line description`).
+- New settings → mention in the relevant section; add a table row if the file already uses
+  a table for that area.
+- New platform → add to the intro tagline, the platform Features bullet, the Usage section,
+  the Vault Path token list, and the Key Components table.
+- Keep tone concise and factual; mirror the English wording in natural Japanese (see
+  `feedback_english_messages` applies to commits/PRs, not README.ja.md content).
+
+### 5. Verify
+
+- `nix run .#format-check` (or `npm run format:check`) — the READMEs must pass Prettier.
+- Parity check: the two files have the same set of `##`/`###` headings in the same order.
+  A quick diff of the heading lists catches missed mirroring:
+
+  ```bash
+  diff <(grep -nE '^#{2,3} ' README.md    | sed 's/[0-9].*: //') \
+       <(grep -nE '^#{2,3} ' README.ja.md | sed 's/[0-9].*: //')
+  ```
+
+  (Heading *text* differs by language, but the *count and structure* must match — inspect,
+  don't expect byte-equality.)
+- Confirm every internal anchor link (`#image-export`, `#画像エクスポート`, ADR links)
+  resolves to a heading that exists.
+
+### 6. Report
+
+Summarize: which features were added to the docs, EN + JA both updated, format-check result.
+Do **not** commit or push — leave that to the user or `/release`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
+Google Gemini、Claude AI、ChatGPT、Perplexity、NotebookLM の会話を Obsidian に保存する Chrome 拡張機能です。Local REST API を使用してローカル環境で動作します。
 
 [English version](README.md)
 
@@ -9,19 +9,24 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 
 ## 機能
 
-- **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity からエクスポート
+- **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity、NotebookLM からエクスポート
 - **ワンクリック保存**: 対応 AI ページに表示される「Sync」ボタンで即座に保存
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
 - **Deep Research 対応**: Gemini Deep Research、Claude Extended Thinking、Perplexity Deep Research レポートを保存
 - **Artifact 対応**: Claude Artifacts をインライン引用とソース付きで抽出
-- **タイムゾーン設定**: フロントマターの日時（created/modified）にタイムゾーンを指定可能
-- **ツールコンテンツ対応**: Claude の Web 検索結果やツール活動を折りたたみ可能な `[!ABSTRACT]` コールアウトとして保存（オプション）
+- **画像エクスポート**: Gemini が生成した画像を会話と一緒に保存 — vault への埋め込み、ファイルダウンロード、クリップボード時は除去
+- **ソース引用**: NotebookLM のチャット引用を footnote 形式でエクスポート
+- **自動スクロール**: 長い会話で全メッセージを自動的に読み込み。仮想化（windowing）された Claude・ChatGPT のスレッドにも対応
 - **追記モード**: 既存ノートには新しいメッセージのみを追加
+- **ファイル名スキーム**: エクスポートするノートの命名を `title-id`（デフォルト）または `title-date` から選択
+- **Vault パステンプレート**: `{platform}` と日付トークン（`{YYYY}`、`{MM}` など）で自動分類
+- **ファイル名衝突対策**: 別の会話に属するノートを絶対に上書きしない
+- **ツールコンテンツ対応**: Claude の Web 検索結果やツール活動を折りたたみ可能な `[!ABSTRACT]` コールアウトとして保存（オプション）
 - **質問見出し（オプション）**: 長い会話で目次から飛べるように、各ユーザーメッセージの前に `## ` 見出し（質問冒頭60文字）を追加
+- **長大コールアウトの平坦化**: Obsidian 保存時に非常に長いメッセージをプレーンテキスト化し、レンダラーの遅延を回避（オプション）
+- **タイムゾーン設定**: フロントマターの日時（created/modified）にタイムゾーンを指定可能
 - **Obsidian コールアウト**: `[!QUESTION]` と `[!NOTE]` による見やすいフォーマット
 - **YAML フロントマター**: タイトル、ソース、URL、日時、タグなどのメタデータを自動生成
-- **自動スクロール**: Gemini の長い会話で全メッセージを自動的に読み込み
-- **プラットフォーム別整理**: Vault パスに `{platform}` テンプレートを使用して自動分類
 - **カスタマイズ可能**: 保存先パス、テンプレート、フロントマターの設定が可能
 - **多言語対応**: 英語・日本語 UI をサポート
 
@@ -81,6 +86,8 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
    - **ファイル**: Markdown ファイルとしてダウンロード
    - **クリップボード**: クリップボードにコピー（どこにでも貼り付け可能）
 
+Gemini が生成した画像は自動的に捕捉・エクスポートされます（[画像エクスポート](#画像エクスポート)を参照）。
+
 ### Claude
 
 1. [claude.ai](https://claude.ai) で会話を開く
@@ -89,7 +96,7 @@ Google Gemini、Claude AI、ChatGPT、Perplexity の会話を Obsidian に保存
 
 ### ChatGPT
 
-1. [chatgpt.com](https://chatgpt.com) で会話を開く
+1. [chatgpt.com](https://chatgpt.com) で会話を開く（通常のチャットと `/g/` URL のカスタム GPT の両方に対応）
 2. 右下に表示される紫色の「Sync」ボタンをクリック
 3. Gemini と同じ出力オプションで会話がエクスポートされます
 
@@ -196,6 +203,41 @@ message_count: 1
 詳細な分析セクション...
 ```
 
+## Vault パスとファイル名
+
+### Vault パステンプレート
+
+**Vault Path** 設定は保存時に解決されるテンプレートトークンに対応しており、ノートを自動整理できます。デフォルトは `AI/{platform}` です。
+
+| トークン     | 解決される値                                                             |
+| ------------ | ------------------------------------------------------------------------ |
+| `{platform}` | ソース名（`gemini`、`claude`、`chatgpt`、`perplexity`、`notebooklm`）     |
+| `{YYYY}`     | 4桁の年（ローカル時間、例: `2026`）                                       |
+| `{YY}`       | 2桁の年（ローカル時間、例: `26`）                                         |
+| `{MM}`       | 2桁のゼロ埋め月（例: `07`）                                               |
+| `{DD}`       | 2桁のゼロ埋め日（例: `08`）                                               |
+
+例: `AI/{platform}/{YYYY}/{MM}` は月別フォルダにノートを振り分けます。日付トークンはローカルのタイムゾーンを使用します。追記モードでは、月をまたいでも既存の会話は元のファイルを更新し続けます。
+
+### ファイル名スキーム
+
+エクスポートするノートのファイル名の組み立て方を選べます（詳細設定 → **ファイル名スキーム**）:
+
+- **`title-id`**（デフォルト）: `{title}-{会話ID}.md` — 会話タイトルが変わっても安定。
+- **`title-date`**: `{title}-{YYYY}-{MM}-{DD}.md` — ローカルの保存日を使用。
+
+意図したファイル名が**別の**会話に既に使われている場合、拡張機能は上書きせず安全な代替名で保存します。
+
+## 画像エクスポート
+
+Gemini が生成した画像は会話と一緒にエクスポートされます（デフォルトで有効。詳細設定の **画像をエクスポート** で切り替え）。Gemini はページ側でしか読めない `blob:` URL で画像を配信するため、各画像はコンテンツスクリプト内で base64 として捕捉され、出力先ごとに解決されます:
+
+- **Obsidian**: 画像は **画像フォルダ**（デフォルト `AI/{platform}/images`、vault パスと同じテンプレートトークンに対応）配下の vault に書き込まれ、本文は `![[filename]]` ウィキリンクで埋め込みます。
+- **ファイルダウンロード**: Markdown ファイルと各画像を別々のファイルとしてダウンロードします。
+- **クリップボード**: 画像プレースホルダは除去されます（バイナリはコピーされません）。
+
+ガード: 1ノートあたり最大20画像、1画像あたり最大10MB。追記モードでは画像プレースホルダを除去します（追記モードでの画像処理は今後対応）。
+
 ## 開発
 
 開発環境は Nix が管理します（[ADR-010](docs/adr/010-nix-only-dev-environment.md) 参照）。`direnv` + `nix-direnv` を入れていればディレクトリ移動時に自動で環境が読み込まれます。そうでない場合は `nix develop` を実行してください。
@@ -243,7 +285,10 @@ Obsidian Local REST API (デフォルト: http://127.0.0.1:27123)
 | `src/content/extractors/claude.ts` | Claude 会話 & Artifact 抽出 |
 | `src/content/extractors/chatgpt.ts` | ChatGPT 会話抽出 |
 | `src/content/extractors/perplexity.ts` | Perplexity 会話抽出 |
+| `src/content/extractors/notebooklm.ts` | NotebookLM チャット & ソース引用抽出 |
+| `src/content/image-capture.ts` | Gemini 生成画像をページコンテキストで base64 捕捉 |
 | `src/background/` | API 通信用のサービスワーカー |
+| `src/lib/image-output.ts` | 出力先ごとに画像プレースホルダを解決 |
 | `src/popup/` | 設定 UI |
 | `src/lib/` | 共有ユーティリティと型定義 |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Obsidian AI Exporter
 
-Chrome Extension that exports AI conversations from Google Gemini, Claude AI, ChatGPT, and Perplexity to Obsidian via the Local REST API.
+Chrome Extension that exports AI conversations from Google Gemini, Claude AI, ChatGPT, Perplexity, and NotebookLM to Obsidian via the Local REST API.
 
 [日本語版はこちら](README.ja.md)
 
@@ -9,19 +9,24 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 
 ## Features
 
-- **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, and Perplexity
+- **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, Perplexity, and NotebookLM
 - **One-click export**: Floating "Sync" button on supported AI pages
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
 - **Deep Research support**: Export Gemini Deep Research, Claude Extended Thinking, and Perplexity Deep Research reports
 - **Artifact support**: Extract Claude Artifacts with inline citations and sources
-- **Configurable timezone**: Set timezone for frontmatter dates (created/modified)
-- **Tool content support**: Optionally include Claude's web search results and tool activity as collapsible `[!ABSTRACT]` callouts
+- **Image export**: Gemini-generated images are saved alongside the conversation — embedded in your vault, downloaded as files, or stripped for clipboard
+- **Source citations**: NotebookLM chat citations are exported as footnotes
+- **Auto-scroll**: Automatically loads all messages in long conversations, including virtualized (windowed) Claude and ChatGPT threads
 - **Append mode**: Only new messages are added to existing notes
+- **Filename schemes**: Choose `title-id` (default) or `title-date` naming for exported notes
+- **Vault path templates**: Organize with `{platform}` and date tokens (`{YYYY}`, `{MM}`, …) for auto-sorting
+- **Filename collision safety**: Never overwrites a note belonging to a different conversation
+- **Tool content support**: Optionally include Claude's web search results and tool activity as collapsible `[!ABSTRACT]` callouts
 - **Question headers (optional)**: Prepend a `## ` heading (first 60 chars of the question) before each user message for TOC navigation in long conversations
+- **Large-callout flattening**: Optionally flatten very long messages to plain text when saving to Obsidian, avoiding renderer slowdowns
+- **Configurable timezone**: Set timezone for frontmatter dates (created/modified)
 - **Obsidian callouts**: Formatted output with `[!QUESTION]` and `[!NOTE]` callouts
 - **YAML frontmatter**: Metadata including title, source, URL, dates, and tags
-- **Auto-scroll**: Automatically loads all messages in long Gemini conversations
-- **Platform-based organization**: Use `{platform}` template in vault path for auto-sorting
 - **Configurable**: Customizable vault path, template options, and frontmatter fields
 - **Localized**: English and Japanese UI support
 
@@ -81,6 +86,8 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
    - **File**: Downloaded as a Markdown file
    - **Clipboard**: Copied to clipboard for pasting anywhere
 
+Gemini-generated images are captured and exported automatically (see [Image Export](#image-export)).
+
 ### Claude
 
 1. Open a conversation on [claude.ai](https://claude.ai)
@@ -89,7 +96,7 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 
 ### ChatGPT
 
-1. Open a conversation on [chatgpt.com](https://chatgpt.com)
+1. Open a conversation on [chatgpt.com](https://chatgpt.com) (regular chats and custom GPTs via `/g/` URLs are both supported)
 2. Click the purple "Sync" button in the bottom-right corner
 3. The conversation will be exported with the same output options as Gemini
 
@@ -196,6 +203,41 @@ The report content with original headings...
 Detailed analysis sections...
 ```
 
+## Vault Path & Filenames
+
+### Vault Path Templates
+
+The **Vault Path** setting supports template tokens that are resolved at save time, so notes can be auto-organized. The default is `AI/{platform}`.
+
+| Token        | Resolves to                                                              |
+| ------------ | ------------------------------------------------------------------------ |
+| `{platform}` | Source name (`gemini`, `claude`, `chatgpt`, `perplexity`, `notebooklm`)  |
+| `{YYYY}`     | 4-digit year, local time (e.g. `2026`)                                   |
+| `{YY}`       | 2-digit year, local time (e.g. `26`)                                     |
+| `{MM}`       | 2-digit month, zero-padded (e.g. `07`)                                   |
+| `{DD}`       | 2-digit day, zero-padded (e.g. `08`)                                     |
+
+Example: `AI/{platform}/{YYYY}/{MM}` sorts notes into per-month folders. Date tokens use your local time zone. In append mode, existing conversations continue updating their original file even after the month rolls over.
+
+### Filename Schemes
+
+Choose how exported note filenames are built (Advanced Settings → **Filename scheme**):
+
+- **`title-id`** (default): `{title}-{conversationId}.md` — stable across renames of the conversation.
+- **`title-date`**: `{title}-{YYYY}-{MM}-{DD}.md` — uses the local save date.
+
+If the intended filename is already occupied by a *different* conversation, the extension writes to a safe alternative name instead of overwriting it.
+
+## Image Export
+
+Gemini-generated images are exported alongside the conversation (enabled by default; toggle with **Export images** in Advanced Settings). Because Gemini serves images from `blob:` URLs that only the page can read, each image is captured as base64 in the content script and resolved per output destination:
+
+- **Obsidian**: images are written to your vault under **Image Folder** (default `AI/{platform}/images`, supports the same template tokens as the vault path); the note body embeds them with `![[filename]]` wikilinks.
+- **File download**: the Markdown file and each image are downloaded as separate files.
+- **Clipboard**: image placeholders are stripped (no binary is copied).
+
+Guards: up to 20 images per note and 10 MB per image. Append mode strips image placeholders (image handling in append mode is deferred).
+
 ## Development
 
 The dev environment is provisioned by Nix (see [ADR-010](docs/adr/010-nix-only-dev-environment.md)). With `direnv` and `nix-direnv` installed, entering the directory loads the environment automatically; otherwise run `nix develop`.
@@ -243,7 +285,10 @@ Obsidian Local REST API (default: http://127.0.0.1:27123)
 | `src/content/extractors/claude.ts` | Claude conversation & Artifact extractor |
 | `src/content/extractors/chatgpt.ts` | ChatGPT conversation extractor |
 | `src/content/extractors/perplexity.ts` | Perplexity conversation extractor |
+| `src/content/extractors/notebooklm.ts` | NotebookLM chat & source-citation extractor |
+| `src/content/image-capture.ts` | Captures Gemini-generated images as base64 in the page context |
 | `src/background/` | Service worker for API communication |
+| `src/lib/image-output.ts` | Resolves image placeholders per output destination |
 | `src/popup/` | Settings UI |
 | `src/lib/` | Shared utilities and types |
 


### PR DESCRIPTION
## Summary

The READMEs had drifted since the v2 releases. This is a docs-only change (no `src/` changes).

- **README.md / README.ja.md — feature refresh (EN/JA in lockstep):**
  - Add **NotebookLM** to the tagline, platform bullet, and Key Components table
  - Document **image export** (v2.0.0, #186): new Features bullet + dedicated section covering per-destination behavior, `imageVaultPath` template, `![[...]]` embeds, and the 20-image / 10 MB guards
  - Correct the **auto-scroll** bullet — now covers virtualized Claude & ChatGPT (v2.1.0, #338), not just Gemini
  - Document **filename schemes** `title-id` / `title-date` (v2.2.0, #340) and the filename-collision safeguard (#327)
  - Add a **Vault Path Templates** table (`{platform}` / `{YYYY}` / `{YY}` / `{MM}` / `{DD}`)
  - Add **large-callout flattening** bullet; note custom-GPT `/g/` URLs and Gem conversations in Usage
  - Key Components table gains `notebooklm.ts`, `image-capture.ts`, `lib/image-output.ts`
- **New `/sync-docs` skill** (`.claude/skills/sync-docs/SKILL.md`): standalone, docs-only skill that diffs shipped reality (CHANGELOG, `types.ts` settings, platform registry, popup) against the READMEs and updates both in lockstep with mandatory EN/JA parity + format verification. Never touches `src/`.
- **`/release` wiring** (`.claude/commands/release.md`): suggestion-only doc-sync check — when a change is `feat`/breaking and the READMEs aren't staged, it recommends running `/sync-docs` first. No auto-run, never blocks the release.

## Verification

- EN/JA parity: 33 headings each, identical section order
- Anchor links (`#image-export` / `#画像エクスポート`) resolve to existing headings
- Markdown is not in the project's Prettier scope (`src/**/*` only) and the README already diverged from Prettier defaults before this change, so `--write` was intentionally not run to avoid churning unrelated pre-existing lines

## Test plan

- [x] READMEs render correctly on GitHub (tables, anchor links, callouts)
- [x] `/sync-docs` skill is discoverable and scoped to docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)