### PR TITLE
docs: sync store descriptions and sync-docs skill to v2.2.1 features

### DIFF
--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: sync-docs
-description: Detect user-facing feature drift and update README.md + README.ja.md in lockstep. Use when features have shipped but the READMEs are stale, or before a release. Docs-only — never touches src/.
-version: 1.0.0
+description: Detect user-facing feature drift and update README.md + README.ja.md and the Chrome Web Store descriptions in lockstep. Use when features have shipped but the docs are stale, or before a release. Docs-only — never touches src/.
+version: 1.1.0
 ---
 
 # sync-docs
 
-Keeps the user-facing documentation (`README.md` and `README.ja.md`) in sync with the
-features that have actually shipped. This skill **only edits documentation** — it never
-modifies `src/`, tests, or configuration.
+Keeps the user-facing documentation (`README.md`, `README.ja.md`, and the Chrome Web Store
+descriptions in `docs/store/`) in sync with the features that have actually shipped. This
+skill **only edits documentation** — it never modifies `src/`, tests, or configuration.
 
 ## When to use
 
@@ -19,11 +19,12 @@ modifies `src/`, tests, or configuration.
 
 ## Absolute rules
 
-- **Docs only.** Edit `README.md`, `README.ja.md`, and (if needed) `docs/`. Never edit
-  `src/`, tests, `manifest.json`, or build config.
+- **Docs only.** Edit `README.md`, `README.ja.md`, the store descriptions in `docs/store/`,
+  and (if needed) `docs/`. Never edit `src/`, tests, `manifest.json`, or build config.
 - **EN/JA parity is mandatory.** Every change to `README.md` must have an equivalent
-  change in `README.ja.md`, and vice versa. The two files must stay structurally parallel
-  (same sections, same order, same tables).
+  change in `README.ja.md`, and vice versa. The same rule applies to the store pair
+  (`docs/store/description_en.md` ⇄ `docs/store/description_ja.md`). Each language pair must
+  stay structurally parallel (same sections, same order, same tables/bullets).
 - **Verify before done.** Report what changed and prove the docs still format cleanly.
 - Follow the project rules in `CLAUDE.md`: work on a branch, never commit secrets, no
   scope creep.
@@ -32,8 +33,11 @@ modifies `src/`, tests, or configuration.
 
 ### 1. Establish the "documented" baseline
 
-Read both READMEs and list the features they currently describe (Features bullets,
-Usage subsections, settings mentioned, supported platforms).
+Read both READMEs **and** both store descriptions (`docs/store/description_en.md`,
+`docs/store/description_ja.md`) and list the features they currently describe (Features
+bullets, Usage subsections, settings mentioned, supported platforms). The store
+descriptions are a terser, Chrome-Web-Store-formatted subset — they drift the same way and
+must be checked every run.
 
 ### 2. Establish the "shipped" reality
 
@@ -70,6 +74,15 @@ style:
 - Keep tone concise and factual; mirror the English wording in natural Japanese (see
   `feedback_english_messages` applies to commits/PRs, not README.ja.md content).
 
+Then update the store descriptions (`docs/store/description_en.md` +
+`docs/store/description_ja.md`) in the same lockstep for **user-facing** drift only:
+
+- These follow the Chrome Web Store layout (WHAT IT DOES / THREE EXPORT OPTIONS / KEY
+  FEATURES / PRIVACY FIRST / REQUIREMENTS / HOW TO USE). Add or reword `KEY FEATURES`
+  bullets (`• ...`) to match; keep them shorter and more marketing-toned than the README.
+- New platform → also update the tagline, WHAT IT DOES host list, and HOW TO USE step 1.
+- Keep EN/JA bullets 1:1 and in the same order.
+
 ### 5. Verify
 
 - `nix run .#format-check` (or `npm run format:check`) — the READMEs must pass Prettier.
@@ -85,8 +98,15 @@ style:
   don't expect byte-equality.)
 - Confirm every internal anchor link (`#image-export`, `#画像エクスポート`, ADR links)
   resolves to a heading that exists.
+- Store parity: `docs/store/description_en.md` and `description_ja.md` must have the same
+  number of `•` bullets in each section, in the same order. Compare the bullet counts:
+
+  ```bash
+  grep -c '^•' docs/store/description_en.md docs/store/description_ja.md
+  ```
 
 ### 6. Report
 
-Summarize: which features were added to the docs, EN + JA both updated, format-check result.
-Do **not** commit or push — leave that to the user or `/release`.
+Summarize: which features were added to the docs, README EN + JA and store EN + JA all
+updated, format-check and store-parity results. Do **not** commit or push — leave that to
+the user or `/release`.

--- a/docs/store/description_en.md
+++ b/docs/store/description_en.md
@@ -13,12 +13,14 @@ This extension extracts conversations from Google Gemini (gemini.google.com), Cl
 • Clean Markdown formatting with YAML frontmatter
 • Obsidian callout syntax for Q&A blocks (shows correct AI name)
 • Deep Research support (Gemini, Perplexity) and Extended Thinking/Artifacts (Claude)
+• Image export - Gemini-generated images embedded in your vault, downloaded as files, or stripped for clipboard
 • Configurable timezone for frontmatter dates
 • LaTeX math formula preservation ($$...$$ and $...$) across all platforms
 • Web search results saved as collapsible callouts (Claude)
 • Append mode - only new messages are added to existing notes
 • Optional `## ` question headers for TOC navigation in long conversations
-• Auto-scroll for long Gemini conversations
+• Auto-scroll for long conversations, including virtualized (windowed) Claude and ChatGPT threads
+• Filename schemes - choose title-id (default) or title-date naming, with collision-safe overwrite protection
 • Platform organization with {platform} template variable
 • HTTPS support for secure connections to Obsidian REST API
 • Customizable API URL, save location, message format, and frontmatter fields

--- a/docs/store/description_ja.md
+++ b/docs/store/description_ja.md
@@ -13,12 +13,14 @@ Google Gemini（gemini.google.com）、Claude AI（claude.ai）、ChatGPT（chat
 • YAML フロントマター付きの整形された Markdown
 • Q&A ブロックに Obsidian コールアウト構文（正しい AI 名を表示）
 • Deep Research（Gemini、Perplexity）と Extended Thinking / Artifacts（Claude）に対応
+• 画像エクスポート - Gemini 生成画像を vault に埋め込み・ファイルとしてダウンロード・クリップボードでは除去
 • フロントマター日時のタイムゾーン設定
 • LaTeX 数式の保存（$$...$$・$...$）- 全プラットフォーム対応
 • Web 検索結果を折りたたみ可能なコールアウトとして保存（Claude）
 • 追記モード - 既存ノートに新しいメッセージのみ追加
 • 質問見出し（`## `）オプション - 長い会話で目次ナビゲーション可能
-• Gemini の長い会話の自動スクロール
+• 長い会話の自動スクロール - 仮想化（ウィンドウ化）された Claude・ChatGPT スレッドにも対応
+• ファイル名スキーム - title-id（デフォルト）または title-date を選択、衝突時の上書き防止付き
 • {platform} テンプレート変数によるプラットフォーム別整理
 • Obsidian REST API への HTTPS 接続をサポート
 • API URL、保存先パス、メッセージ形式、フロントマターフィールドをカスタマイズ可能


### PR DESCRIPTION
## Summary

- Update Chrome Web Store descriptions (`docs/store/description_en.md` + `description_ja.md`) to reflect v2.2.1 features: **Image export** (v2.0.0), broadened **Auto-scroll** for virtualized Claude/ChatGPT threads (v2.1.0), and **Filename schemes** title-id/title-date with collision-safe overwrite (v2.2.0). EN/JA kept 1:1 (26 bullets each).
- Extend the `sync-docs` skill (v1.0.0 → v1.1.0) to keep the store descriptions in sync alongside the READMEs: added `docs/store/` to the docs-only scope, baseline/diff/apply/verify/report steps, store-layout guidance, and a bullet-parity check.

## Test plan

- [x] Store bullet parity: `grep -c '^•'` → EN=JA=26
- [x] `npm run format:check` passes (Prettier scope is `src/` only; store `.md` unaffected)
- [x] Spot-check rendered store copy before pasting into the Chrome Web Store form

🤖 Generated with [Claude Code](https://claude.com/claude-code)