### PR TITLE
fix: harden image, math, settings, and migration input handling

### DIFF
--- a/src/background/validation.ts
+++ b/src/background/validation.ts
@@ -13,6 +13,7 @@ import {
   MAX_TAG_LENGTH,
   MAX_IMAGES_PER_NOTE,
   MAX_IMAGE_DATA_LENGTH,
+  MAX_TOTAL_IMAGE_DATA_LENGTH,
   ALLOWED_ORIGINS,
   VALID_MESSAGE_ACTIONS,
   VALID_OUTPUT_DESTINATIONS,
@@ -21,6 +22,7 @@ import {
 import type { ExtensionMessage, ExtractedImage, ObsidianNote } from '../lib/types';
 import { containsPathTraversal } from '../lib/path-utils';
 import { isHttpUrl } from '../lib/validation';
+import { isAllowedImageMime, isLikelyBase64 } from '../lib/image-utils';
 
 /**
  * Validate message sender (M-02)
@@ -161,22 +163,33 @@ function validateFrontmatter(frontmatter: ObsidianNote['frontmatter'] | undefine
 
 /**
  * Validate attached image data (DoS guard). Content scripts are semi-trusted,
- * so bound the image count and per-image base64 size, and require well-formed
- * string fields on each entry.
+ * so bound the image count, per-image base64 size, and combined base64 size,
+ * restrict MIME types to a shared allow-list, and require each entry to carry
+ * well-formed base64 data.
  */
 function validateImages(images: unknown): boolean {
   if (!Array.isArray(images) || images.length > MAX_IMAGES_PER_NOTE) {
     return false;
   }
-  return images.every((image: Partial<ExtractedImage> | null | undefined) => {
-    return (
+  let totalDataLength = 0;
+  for (const image of images as Array<Partial<ExtractedImage> | null | undefined>) {
+    const wellFormed =
       !!image &&
       typeof image === 'object' &&
       typeof image.id === 'string' &&
       typeof image.mimeType === 'string' &&
       typeof image.alt === 'string' &&
       typeof image.data === 'string' &&
-      image.data.length <= MAX_IMAGE_DATA_LENGTH
-    );
-  });
+      image.data.length <= MAX_IMAGE_DATA_LENGTH &&
+      isAllowedImageMime(image.mimeType) &&
+      isLikelyBase64(image.data);
+    if (!wellFormed) {
+      return false;
+    }
+    totalDataLength += image.data.length;
+    if (totalDataLength > MAX_TOTAL_IMAGE_DATA_LENGTH) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -247,11 +247,13 @@ turndown.addRule('footnoteDef', {
  * Multi-line LaTeX is left intact — real KaTeX inline formulas (e.g. matrices
  * with `\\` row breaks) legitimately span lines.
  *
- * On fallback, `$` is escaped to `\$` so the plain text is not re-parsed as math.
+ * On fallback, backslashes are escaped first, then `$` → `\$`, so the plain
+ * text is not re-parsed as math (escaping the escape character prevents a
+ * preceding `\` from pairing with the inserted one and re-opening a delimiter).
  */
 function formatMath(latex: string, display: boolean): string {
   if (latex.length > MAX_MATH_LENGTH || latex.includes('$')) {
-    const plain = latex.replace(/\$/g, '\\$');
+    const plain = latex.replace(/\\/g, '\\\\').replace(/\$/g, '\\$');
     return display ? `\n${plain}\n` : plain;
   }
   return display ? `\n$$\n${latex}\n$$\n` : `$${latex}$`;

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -6,7 +6,7 @@
  */
 
 import TurndownService from 'turndown';
-import { MAX_LANG_HINT_LENGTH } from '../lib/constants';
+import { MAX_LANG_HINT_LENGTH, MAX_MATH_LENGTH } from '../lib/constants';
 
 /** Leading blockquote prefix (one or more `> ` markers) to preserve as-is. */
 const BLOCKQUOTE_PREFIX_PATTERN = /^(\s*>\s*)+/;
@@ -238,6 +238,24 @@ turndown.addRule('footnoteDef', {
   },
 });
 
+/**
+ * Render a page-derived LaTeX value as Markdown math, or fall back to plain
+ * text when the value would degrade or break Obsidian's math rendering:
+ * - longer than {@link MAX_MATH_LENGTH} (malformed/abusive input), or
+ * - contains a literal `$` (breaks the `$…$` / `$$…$$` delimiters), or
+ * - (inline only) contains a newline, which cannot live inside `$…$`.
+ *
+ * On fallback, `$` is escaped to `\$` so the plain text is not re-parsed as math.
+ */
+function formatMath(latex: string, display: boolean): string {
+  const breaksDelimiter = latex.includes('$') || (!display && /[\r\n]/.test(latex));
+  if (latex.length > MAX_MATH_LENGTH || breaksDelimiter) {
+    const plain = latex.replace(/\$/g, '\\$');
+    return display ? `\n${plain}\n` : plain;
+  }
+  return display ? `\n$$\n${latex}\n$$\n` : `$${latex}$`;
+}
+
 // Custom rule for display math blocks (Gemini KaTeX: <div data-math="...">)
 turndown.addRule('mathBlock', {
   filter: node => {
@@ -246,7 +264,7 @@ turndown.addRule('mathBlock', {
   replacement: (_content, node) => {
     const latex = (node as HTMLElement).getAttribute('data-math');
     if (!latex) return _content;
-    return `\n$$\n${latex}\n$$\n`;
+    return formatMath(latex, true);
   },
 });
 
@@ -262,7 +280,7 @@ turndown.addRule('mathInline', {
   replacement: (_content, node) => {
     const latex = (node as HTMLElement).getAttribute('data-math');
     if (!latex) return _content;
-    return `$${latex}$`;
+    return formatMath(latex, false);
   },
 });
 

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -242,14 +242,15 @@ turndown.addRule('footnoteDef', {
  * Render a page-derived LaTeX value as Markdown math, or fall back to plain
  * text when the value would degrade or break Obsidian's math rendering:
  * - longer than {@link MAX_MATH_LENGTH} (malformed/abusive input), or
- * - contains a literal `$` (breaks the `$…$` / `$$…$$` delimiters), or
- * - (inline only) contains a newline, which cannot live inside `$…$`.
+ * - contains a literal `$` (breaks the `$…$` / `$$…$$` delimiters).
+ *
+ * Multi-line LaTeX is left intact — real KaTeX inline formulas (e.g. matrices
+ * with `\\` row breaks) legitimately span lines.
  *
  * On fallback, `$` is escaped to `\$` so the plain text is not re-parsed as math.
  */
 function formatMath(latex: string, display: boolean): string {
-  const breaksDelimiter = latex.includes('$') || (!display && /[\r\n]/.test(latex));
-  if (latex.length > MAX_MATH_LENGTH || breaksDelimiter) {
+  if (latex.length > MAX_MATH_LENGTH || latex.includes('$')) {
     const plain = latex.replace(/\$/g, '\\$');
     return display ? `\n${plain}\n` : plain;
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -85,6 +85,14 @@ export const MAX_IMAGES_PER_NOTE = 20;
 /** Maximum base64 length for a single image's data (~10MB binary + overhead). */
 export const MAX_IMAGE_DATA_LENGTH = 14 * 1024 * 1024;
 
+/**
+ * Maximum combined base64 length across all images in one note (DoS guard).
+ * Independent of the per-image and per-count caps: 20 × 14 MiB would otherwise
+ * let a single message reach ~280 MiB. 48 MiB (~36 MB binary) comfortably fits
+ * a realistic Gemini image set while bounding worker memory.
+ */
+export const MAX_TOTAL_IMAGE_DATA_LENGTH = 48 * 1024 * 1024;
+
 // ============================================================
 // UI Timing
 // ============================================================

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -93,6 +93,14 @@ export const MAX_IMAGE_DATA_LENGTH = 14 * 1024 * 1024;
  */
 export const MAX_TOTAL_IMAGE_DATA_LENGTH = 48 * 1024 * 1024;
 
+/**
+ * Maximum length of a single LaTeX formula rendered into `$…$` / `$$…$$`.
+ * Page-derived `data-math` values above this fall back to plain text so a
+ * malicious or malformed formula cannot degrade Obsidian's math rendering.
+ * Real KaTeX expressions are well under 1000 characters.
+ */
+export const MAX_MATH_LENGTH = 1000;
+
 // ============================================================
 // UI Timing
 // ============================================================

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -22,13 +22,43 @@ const MIME_TO_EXT: Readonly<Record<string, string>> = {
 };
 
 /**
+ * Allow-list of accepted image MIME types (SSOT: derived from {@link MIME_TO_EXT}).
+ * Used at the background input boundary to reject unexpected types.
+ */
+export const ALLOWED_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set(Object.keys(MIME_TO_EXT));
+
+/** Normalize a MIME type the same way {@link mimeToExtension} does. */
+function normalizeMime(mimeType: string): string {
+  return mimeType.split(';')[0].trim().toLowerCase();
+}
+
+/**
  * Map an image MIME type to a file extension.
  * Case-insensitive; ignores parameters (e.g. `; charset=binary`).
  * Falls back to `png` for empty or unrecognized types.
  */
 export function mimeToExtension(mimeType: string): string {
-  const normalized = mimeType.split(';')[0].trim().toLowerCase();
-  return MIME_TO_EXT[normalized] ?? 'png';
+  return MIME_TO_EXT[normalizeMime(mimeType)] ?? 'png';
+}
+
+/**
+ * True when `mimeType` (after case/parameter normalization) is on the image
+ * allow-list. Empty or unknown types return false.
+ */
+export function isAllowedImageMime(mimeType: string): boolean {
+  return ALLOWED_IMAGE_MIME_TYPES.has(normalizeMime(mimeType));
+}
+
+/** Base64 character set with optional `=` padding (0–2 chars). */
+const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/**
+ * Cheap structural check that a string is well-formed standard base64
+ * (no `data:` prefix): valid charset and a length that is a multiple of 4.
+ * The empty string is treated as a valid zero-length payload.
+ */
+export function isLikelyBase64(data: string): boolean {
+  return data.length % 4 === 0 && BASE64_PATTERN.test(data);
 }
 
 /** Chunk size for base64 encoding — bounds the String.fromCharCode arg count. */

--- a/src/lib/settings-schema.ts
+++ b/src/lib/settings-schema.ts
@@ -1,0 +1,155 @@
+/**
+ * Runtime schema validation & normalization for synced settings.
+ *
+ * `chrome.storage.sync` values are untrusted at load time: they may be stale,
+ * cross-device, or corrupted. `normalizeSyncSettings()` coerces a raw stored
+ * object into a well-typed {@link SyncSettings}, resetting only the fields that
+ * fail validation to their defaults (valid fields are preserved).
+ */
+
+import type { SyncSettings, TemplateOptions, OutputOptions } from './types';
+import { DEFAULT_OBSIDIAN_URL, DEFAULT_MAX_CALLOUT_LINES } from './constants';
+
+const MESSAGE_FORMATS = ['callout', 'plain', 'blockquote'] as const;
+const FILENAME_SCHEMES = ['title-id', 'title-date'] as const;
+
+export const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
+  includeId: true,
+  includeTitle: true,
+  includeTags: true,
+  includeSource: true,
+  includeDates: true,
+  includeMessageCount: true,
+  messageFormat: 'callout',
+  userCalloutType: 'QUESTION',
+  assistantCalloutType: 'NOTE',
+  includeQuestionHeaders: false,
+  filenameScheme: 'title-id',
+};
+
+export const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {
+  obsidian: true, // Default true for backward compatibility
+  file: false,
+  clipboard: false,
+};
+
+export const DEFAULT_SYNC_SETTINGS: SyncSettings = {
+  obsidianUrl: DEFAULT_OBSIDIAN_URL,
+  vaultPath: 'AI/{platform}',
+  templateOptions: DEFAULT_TEMPLATE_OPTIONS,
+  outputOptions: DEFAULT_OUTPUT_OPTIONS,
+  enableAutoScroll: false,
+  enableAppendMode: false,
+  enableToolContent: false,
+  enableImageExport: true,
+  imageVaultPath: 'AI/{platform}/images',
+  flattenLargeCallouts: true,
+  maxCalloutLines: DEFAULT_MAX_CALLOUT_LINES,
+};
+
+// --- Field coercion helpers ---
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asPositiveInt(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function asEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof value === 'string' && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeTemplateOptions(raw: unknown): TemplateOptions {
+  const d = DEFAULT_TEMPLATE_OPTIONS;
+  if (!isRecord(raw)) {
+    return { ...d };
+  }
+  const result: TemplateOptions = {
+    includeId: asBoolean(raw.includeId, d.includeId),
+    includeTitle: asBoolean(raw.includeTitle, d.includeTitle),
+    includeTags: asBoolean(raw.includeTags, d.includeTags),
+    includeSource: asBoolean(raw.includeSource, d.includeSource),
+    includeDates: asBoolean(raw.includeDates, d.includeDates),
+    includeMessageCount: asBoolean(raw.includeMessageCount, d.includeMessageCount),
+    messageFormat: asEnum(raw.messageFormat, MESSAGE_FORMATS, d.messageFormat),
+    userCalloutType: asString(raw.userCalloutType, d.userCalloutType),
+    assistantCalloutType: asString(raw.assistantCalloutType, d.assistantCalloutType),
+    includeQuestionHeaders: asBoolean(
+      raw.includeQuestionHeaders,
+      d.includeQuestionHeaders ?? false
+    ),
+    filenameScheme: asEnum(raw.filenameScheme, FILENAME_SCHEMES, d.filenameScheme ?? 'title-id'),
+  };
+  // Optional string field: include only when a valid value is present.
+  if (typeof raw.timezone === 'string') {
+    result.timezone = raw.timezone;
+  }
+  return result;
+}
+
+function normalizeOutputOptions(raw: unknown): OutputOptions {
+  const d = DEFAULT_OUTPUT_OPTIONS;
+  if (!isRecord(raw)) {
+    return { ...d };
+  }
+  return {
+    obsidian: asBoolean(raw.obsidian, d.obsidian),
+    file: asBoolean(raw.file, d.file),
+    clipboard: asBoolean(raw.clipboard, d.clipboard),
+  };
+}
+
+/**
+ * Resolve `obsidianUrl`, honoring the legacy `obsidianPort` field for settings
+ * saved before the URL migration. A valid stored URL wins; otherwise a legacy
+ * port is expanded to a localhost URL; otherwise the default.
+ */
+function resolveObsidianUrl(raw: Record<string, unknown>): string {
+  if (typeof raw.obsidianUrl === 'string') {
+    return raw.obsidianUrl;
+  }
+  if (raw.obsidianPort) {
+    return `http://127.0.0.1:${String(raw.obsidianPort)}`;
+  }
+  return DEFAULT_SYNC_SETTINGS.obsidianUrl;
+}
+
+/**
+ * Coerce a raw stored sync object into a valid {@link SyncSettings}.
+ * Invalid or missing fields fall back to their defaults; valid fields are kept.
+ */
+export function normalizeSyncSettings(raw: unknown): SyncSettings {
+  const d = DEFAULT_SYNC_SETTINGS;
+  if (!isRecord(raw)) {
+    return {
+      ...d,
+      templateOptions: { ...DEFAULT_TEMPLATE_OPTIONS },
+      outputOptions: { ...DEFAULT_OUTPUT_OPTIONS },
+    };
+  }
+  return {
+    obsidianUrl: resolveObsidianUrl(raw),
+    vaultPath: asString(raw.vaultPath, d.vaultPath),
+    templateOptions: normalizeTemplateOptions(raw.templateOptions),
+    outputOptions: normalizeOutputOptions(raw.outputOptions),
+    enableAutoScroll: asBoolean(raw.enableAutoScroll, d.enableAutoScroll),
+    enableAppendMode: asBoolean(raw.enableAppendMode, d.enableAppendMode),
+    enableToolContent: asBoolean(raw.enableToolContent, d.enableToolContent),
+    enableImageExport: asBoolean(raw.enableImageExport, d.enableImageExport),
+    imageVaultPath: asString(raw.imageVaultPath, d.imageVaultPath),
+    flattenLargeCallouts: asBoolean(raw.flattenLargeCallouts, d.flattenLargeCallouts),
+    maxCalloutLines: asPositiveInt(raw.maxCalloutLines, d.maxCalloutLines),
+  };
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,51 +6,16 @@
  * - storage.sync: Non-sensitive settings - synced across devices
  */
 
-import type {
-  ExtensionSettings,
-  SecureSettings,
-  SyncSettings,
-  TemplateOptions,
-  OutputOptions,
-} from './types';
-import { DEFAULT_OBSIDIAN_URL, DEFAULT_MAX_CALLOUT_LINES } from './constants';
-
-const DEFAULT_TEMPLATE_OPTIONS: TemplateOptions = {
-  includeId: true,
-  includeTitle: true,
-  includeTags: true,
-  includeSource: true,
-  includeDates: true,
-  includeMessageCount: true,
-  messageFormat: 'callout',
-  userCalloutType: 'QUESTION',
-  assistantCalloutType: 'NOTE',
-  includeQuestionHeaders: false,
-  filenameScheme: 'title-id',
-};
-
-const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {
-  obsidian: true, // Default true for backward compatibility
-  file: false,
-  clipboard: false,
-};
+import type { ExtensionSettings, SecureSettings, SyncSettings } from './types';
+import {
+  DEFAULT_TEMPLATE_OPTIONS,
+  DEFAULT_OUTPUT_OPTIONS,
+  DEFAULT_SYNC_SETTINGS,
+  normalizeSyncSettings,
+} from './settings-schema';
 
 const DEFAULT_SECURE_SETTINGS: SecureSettings = {
   obsidianApiKey: '',
-};
-
-const DEFAULT_SYNC_SETTINGS: SyncSettings = {
-  obsidianUrl: DEFAULT_OBSIDIAN_URL,
-  vaultPath: 'AI/{platform}',
-  templateOptions: DEFAULT_TEMPLATE_OPTIONS,
-  outputOptions: DEFAULT_OUTPUT_OPTIONS,
-  enableAutoScroll: false,
-  enableAppendMode: false,
-  enableToolContent: false,
-  enableImageExport: true,
-  imageVaultPath: 'AI/{platform}/images',
-  flattenLargeCallouts: true,
-  maxCalloutLines: DEFAULT_MAX_CALLOUT_LINES,
 };
 
 const DEFAULT_SETTINGS: ExtensionSettings = {
@@ -73,35 +38,22 @@ export async function getSettings(): Promise<ExtensionSettings> {
 
     const stored = syncResult.settings ?? {};
 
-    // Migrate legacy obsidianPort → obsidianUrl
-    const obsidianUrl =
-      stored.obsidianUrl ??
-      (stored.obsidianPort
-        ? `http://127.0.0.1:${stored.obsidianPort}`
-        : DEFAULT_SYNC_SETTINGS.obsidianUrl);
+    // Schema-validate/normalize untrusted sync values (L-1): corrupted fields
+    // fall back to defaults; valid fields are preserved. Also resolves the
+    // legacy obsidianPort → obsidianUrl migration.
+    const sync = normalizeSyncSettings(stored);
 
-    // Scalar fields fall back to their defaults when absent.
-    const scalarKeys = [
-      'vaultPath',
-      'imageVaultPath',
-      'enableAutoScroll',
-      'enableAppendMode',
-      'enableToolContent',
-      'enableImageExport',
-      'flattenLargeCallouts',
-      'maxCalloutLines',
-    ] as const;
-    const scalars = Object.fromEntries(
-      scalarKeys.map(key => [key, stored[key] ?? DEFAULT_SYNC_SETTINGS[key]])
-    ) as Pick<SyncSettings, (typeof scalarKeys)[number]>;
+    // API key lives in local storage after migration. Before migration
+    // completes (fire-and-forget on worker startup), fall back to the legacy
+    // sync location so an early request is not misread as "key not set" (L-2).
+    const obsidianApiKey =
+      localResult.secureSettings?.obsidianApiKey ||
+      (typeof stored.obsidianApiKey === 'string' ? stored.obsidianApiKey : '') ||
+      DEFAULT_SECURE_SETTINGS.obsidianApiKey;
 
     return {
-      obsidianApiKey:
-        localResult.secureSettings?.obsidianApiKey ?? DEFAULT_SECURE_SETTINGS.obsidianApiKey,
-      obsidianUrl,
-      templateOptions: { ...DEFAULT_TEMPLATE_OPTIONS, ...stored.templateOptions },
-      outputOptions: { ...DEFAULT_OUTPUT_OPTIONS, ...stored.outputOptions },
-      ...scalars,
+      obsidianApiKey,
+      ...sync,
     };
   } catch (error) {
     console.error('[G2O] Failed to get settings:', error);

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -48,8 +48,11 @@ chrome.runtime.onMessage.addListener(
     sender: chrome.runtime.MessageSender,
     sendResponse: (response: ClipboardWriteResponse) => void
   ) => {
-    // Security: Only accept messages from the background service worker
-    // sender.tab is undefined for background context, defined for content scripts
+    // Security: only accept messages from this extension's own non-content-script
+    // contexts (service worker or popup). `sender.tab` is undefined for those and
+    // defined for content scripts, so this rejects any page-injected sender. In
+    // practice only the background worker sends `clipboardWrite`; the action +
+    // `target === 'offscreen'` gate below scopes it further.
     if (sender.id !== chrome.runtime.id || sender.tab !== undefined) {
       return false;
     }

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -379,6 +379,96 @@ describe('background/index', () => {
         });
       });
 
+      it('rejects images whose combined base64 size exceeds the total cap', () => {
+        const sendResponse = vi.fn();
+        // One ~13 MiB base64 string reused across 4 entries: each is under the
+        // per-image cap (14 MiB) but the sum (~52 MiB) exceeds the 48 MiB total.
+        const big = 'A'.repeat(13 * 1024 * 1024); // valid base64 charset, length % 4 === 0
+        const images = Array.from({ length: 4 }, (_, i) => ({
+          id: `img-${i}`,
+          mimeType: 'image/png',
+          data: big,
+          alt: 'a',
+        }));
+        capturedListener(
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: { ...validNote, images } },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects an image with a MIME type outside the allow-list', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: {
+              ...validNote,
+              images: [{ id: 'img-1', mimeType: 'image/tiff', data: 'UE5H', alt: 'a' }],
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('rejects an image with malformed base64 data', () => {
+        const sendResponse = vi.fn();
+        capturedListener(
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            // '@@@@' is length % 4 === 0 but contains non-base64 characters.
+            data: {
+              ...validNote,
+              images: [{ id: 'img-1', mimeType: 'image/png', data: '@@@@', alt: 'a' }],
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+        expect(sendResponse).toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
+      it('accepts multiple valid images within the total cap', () => {
+        const sendResponse = vi.fn();
+        mockClient.getFile.mockResolvedValue(null);
+        mockClient.putFile.mockResolvedValue(undefined);
+        mockClient.putBinaryFile.mockResolvedValue(undefined);
+        capturedListener(
+          {
+            action: 'saveToOutputs',
+            outputs: ['obsidian'],
+            data: {
+              ...validNote,
+              images: [
+                { id: 'img-1', mimeType: 'image/png', data: 'UE5H', alt: 'a' },
+                { id: 'img-2', mimeType: 'image/jpeg', data: 'AAAA', alt: 'b' },
+                { id: 'img-3', mimeType: 'image/webp', data: 'BBBB', alt: 'c' },
+              ],
+            },
+          },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+        expect(sendResponse).not.toHaveBeenCalledWith({
+          success: false,
+          error: 'Invalid message content',
+        });
+      });
+
       it('rejects fileName with path traversal (DES-014 H-1)', () => {
         const sendResponse = vi.fn();
         capturedListener(

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -314,6 +314,13 @@ describe('htmlToMarkdown', () => {
         const result = htmlToMarkdown(`<span data-math="${latex}">x</span>`);
         expect(result).toBe(`$${latex}$`);
       });
+
+      it('escapes backslashes before $ so a preceding \\ cannot re-open math', () => {
+        // data-math value is `\a$b`: the backslash must be escaped first, else the
+        // inserted `\` before `$` pairs with it and leaves the $ unescaped.
+        const result = htmlToMarkdown('<span data-math="\\a$b">x</span>');
+        expect(result).toBe('\\\\a\\$b');
+      });
     });
   });
 

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -9,6 +9,7 @@ import {
   convertDeepResearchContent,
 } from '../../src/content/markdown';
 import { sanitizeHtml } from '../../src/lib/sanitize';
+import { MAX_MATH_LENGTH } from '../../src/lib/constants';
 import type { ConversationData, TemplateOptions, DeepResearchLinks } from '../../src/lib/types';
 
 describe('escapeUserText — math dollar escaping (Obsidian hang fix)', () => {
@@ -274,6 +275,46 @@ describe('htmlToMarkdown', () => {
       expect(result).toContain('Before');
       expect(result).toContain('$$\nE = mc^2\n$$');
       expect(result).toContain('After');
+    });
+
+    describe('size limit & fallback (M-2)', () => {
+      it('keeps a formula exactly at the length limit as math', () => {
+        const latex = 'a'.repeat(MAX_MATH_LENGTH);
+        const result = htmlToMarkdown(`<span data-math="${latex}">x</span>`);
+        expect(result).toBe(`$${latex}$`);
+      });
+
+      it('falls back to plain text for an oversized inline formula', () => {
+        const latex = 'a'.repeat(MAX_MATH_LENGTH + 1);
+        const result = htmlToMarkdown(`<span data-math="${latex}">x</span>`);
+        expect(result).not.toContain('$');
+        expect(result).toContain(latex);
+      });
+
+      it('falls back to plain text for an oversized display formula', () => {
+        const latex = 'b'.repeat(MAX_MATH_LENGTH + 1);
+        const result = htmlToMarkdown(`<div data-math="${latex}">x</div>`);
+        expect(result).not.toContain('$$');
+        expect(result).toContain(latex);
+      });
+
+      it('escapes a literal $ in an inline value instead of emitting math', () => {
+        const result = htmlToMarkdown('<span data-math="a$b">x</span>');
+        expect(result).toBe('a\\$b');
+      });
+
+      it('escapes literal $ in a display value instead of emitting a math block', () => {
+        const result = htmlToMarkdown('<div data-math="a$$b">x</div>');
+        expect(result).not.toContain('$$\na');
+        expect(result).toContain('a\\$\\$b');
+      });
+
+      it('falls back for an inline formula containing a newline', () => {
+        const result = htmlToMarkdown('<span data-math="a&#10;b">x</span>');
+        expect(result.startsWith('$')).toBe(false);
+        expect(result).toContain('a');
+        expect(result).toContain('b');
+      });
     });
   });
 

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -309,11 +309,10 @@ describe('htmlToMarkdown', () => {
         expect(result).toContain('a\\$\\$b');
       });
 
-      it('falls back for an inline formula containing a newline', () => {
-        const result = htmlToMarkdown('<span data-math="a&#10;b">x</span>');
-        expect(result.startsWith('$')).toBe(false);
-        expect(result).toContain('a');
-        expect(result).toContain('b');
+      it('keeps multi-line inline LaTeX as math (real KaTeX matrices span lines)', () => {
+        const latex = '\\det\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}';
+        const result = htmlToMarkdown(`<span data-math="${latex}">x</span>`);
+        expect(result).toBe(`$${latex}$`);
       });
     });
   });

--- a/test/lib/image-utils.test.ts
+++ b/test/lib/image-utils.test.ts
@@ -4,6 +4,9 @@ import {
   base64ToBytes,
   bytesToBase64,
   MAX_IMAGE_SIZE_BYTES,
+  ALLOWED_IMAGE_MIME_TYPES,
+  isAllowedImageMime,
+  isLikelyBase64,
 } from '../../src/lib/image-utils';
 
 describe('mimeToExtension', () => {
@@ -64,5 +67,59 @@ describe('bytesToBase64', () => {
 describe('MAX_IMAGE_SIZE_BYTES', () => {
   it('is a positive limit (10MB)', () => {
     expect(MAX_IMAGE_SIZE_BYTES).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe('ALLOWED_IMAGE_MIME_TYPES', () => {
+  it('is the SSOT allow-list derived from the MIME→extension map', () => {
+    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/png')).toBe(true);
+    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/jpeg')).toBe(true);
+    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/webp')).toBe(true);
+    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/svg+xml')).toBe(true);
+    // Every allowed type maps to a non-empty extension (SSOT parity)
+    for (const mime of ALLOWED_IMAGE_MIME_TYPES) {
+      expect(mimeToExtension(mime).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isAllowedImageMime', () => {
+  it('accepts allow-listed types', () => {
+    expect(isAllowedImageMime('image/png')).toBe(true);
+    expect(isAllowedImageMime('image/jpeg')).toBe(true);
+  });
+
+  it('normalizes case and strips parameters', () => {
+    expect(isAllowedImageMime('IMAGE/PNG')).toBe(true);
+    expect(isAllowedImageMime('image/jpeg; charset=binary')).toBe(true);
+    expect(isAllowedImageMime('  image/webp  ')).toBe(true);
+  });
+
+  it('rejects types outside the allow-list', () => {
+    expect(isAllowedImageMime('image/tiff')).toBe(false);
+    expect(isAllowedImageMime('application/pdf')).toBe(false);
+    expect(isAllowedImageMime('')).toBe(false);
+    expect(isAllowedImageMime('text/html')).toBe(false);
+  });
+});
+
+describe('isLikelyBase64', () => {
+  it('accepts well-formed base64 strings', () => {
+    expect(isLikelyBase64('UE5H')).toBe(true); // "PNG"
+    expect(isLikelyBase64('AAAA')).toBe(true);
+    expect(isLikelyBase64('aGVsbG8=')).toBe(true); // "hello"
+    expect(isLikelyBase64('YWI=')).toBe(true);
+    expect(isLikelyBase64('')).toBe(true); // empty is a valid (0-length) payload
+  });
+
+  it('rejects strings with non-base64 characters', () => {
+    expect(isLikelyBase64('@@@@')).toBe(false);
+    expect(isLikelyBase64('not valid!!')).toBe(false);
+    expect(isLikelyBase64('AA AA')).toBe(false);
+  });
+
+  it('rejects strings whose length is not a multiple of 4', () => {
+    expect(isLikelyBase64('ABC')).toBe(false);
+    expect(isLikelyBase64('AAAAA')).toBe(false);
   });
 });

--- a/test/lib/settings-schema.test.ts
+++ b/test/lib/settings-schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSyncSettings,
+  DEFAULT_SYNC_SETTINGS,
+  DEFAULT_TEMPLATE_OPTIONS,
+  DEFAULT_OUTPUT_OPTIONS,
+} from '../../src/lib/settings-schema';
+
+describe('normalizeSyncSettings', () => {
+  it('returns full defaults for an empty object', () => {
+    expect(normalizeSyncSettings({})).toEqual(DEFAULT_SYNC_SETTINGS);
+  });
+
+  it('returns full defaults for a non-object input', () => {
+    expect(normalizeSyncSettings(null)).toEqual(DEFAULT_SYNC_SETTINGS);
+    expect(normalizeSyncSettings('corrupt')).toEqual(DEFAULT_SYNC_SETTINGS);
+    expect(normalizeSyncSettings(undefined)).toEqual(DEFAULT_SYNC_SETTINGS);
+  });
+
+  it('preserves valid custom values', () => {
+    const raw = {
+      obsidianUrl: 'https://192.168.1.5:27123',
+      vaultPath: 'Custom/Path',
+      enableAppendMode: true,
+      maxCalloutLines: 50,
+    };
+    const result = normalizeSyncSettings(raw);
+    expect(result.obsidianUrl).toBe('https://192.168.1.5:27123');
+    expect(result.vaultPath).toBe('Custom/Path');
+    expect(result.enableAppendMode).toBe(true);
+    expect(result.maxCalloutLines).toBe(50);
+  });
+
+  it('resets only the corrupted boolean field to its default', () => {
+    const result = normalizeSyncSettings({
+      enableAppendMode: 'yes',
+      enableImageExport: false,
+    });
+    expect(result.enableAppendMode).toBe(DEFAULT_SYNC_SETTINGS.enableAppendMode); // false
+    expect(result.enableImageExport).toBe(false); // valid → preserved
+  });
+
+  it('resets an out-of-range or non-integer maxCalloutLines to default', () => {
+    expect(normalizeSyncSettings({ maxCalloutLines: 'abc' }).maxCalloutLines).toBe(200);
+    expect(normalizeSyncSettings({ maxCalloutLines: -5 }).maxCalloutLines).toBe(200);
+    expect(normalizeSyncSettings({ maxCalloutLines: 0 }).maxCalloutLines).toBe(200);
+    expect(normalizeSyncSettings({ maxCalloutLines: 1.5 }).maxCalloutLines).toBe(200);
+  });
+
+  it('resets an invalid messageFormat enum but keeps sibling template fields', () => {
+    const result = normalizeSyncSettings({
+      templateOptions: { messageFormat: 'weird', userCalloutType: 'TIP' },
+    });
+    expect(result.templateOptions.messageFormat).toBe('callout');
+    expect(result.templateOptions.userCalloutType).toBe('TIP');
+  });
+
+  it('resets an invalid filenameScheme enum to default', () => {
+    const result = normalizeSyncSettings({ templateOptions: { filenameScheme: 'bogus' } });
+    expect(result.templateOptions.filenameScheme).toBe('title-id');
+  });
+
+  it('falls back to default templateOptions when the value is not an object', () => {
+    const result = normalizeSyncSettings({ templateOptions: 'corrupt' });
+    expect(result.templateOptions).toEqual(DEFAULT_TEMPLATE_OPTIONS);
+  });
+
+  it('coerces corrupted outputOptions booleans to defaults', () => {
+    const result = normalizeSyncSettings({ outputOptions: { obsidian: 'true', file: 1 } });
+    expect(result.outputOptions).toEqual(DEFAULT_OUTPUT_OPTIONS);
+  });
+
+  it('migrates legacy obsidianPort into obsidianUrl', () => {
+    const result = normalizeSyncSettings({ obsidianPort: 27124 });
+    expect(result.obsidianUrl).toBe('http://127.0.0.1:27124');
+  });
+
+  it('preserves a valid optional timezone but drops a non-string one', () => {
+    expect(
+      normalizeSyncSettings({ templateOptions: { timezone: 'Asia/Tokyo' } }).templateOptions.timezone
+    ).toBe('Asia/Tokyo');
+    expect(
+      normalizeSyncSettings({ templateOptions: { timezone: 123 } }).templateOptions.timezone
+    ).toBeUndefined();
+  });
+});

--- a/test/lib/storage.test.ts
+++ b/test/lib/storage.test.ts
@@ -115,6 +115,52 @@ describe('storage', () => {
       expect(settings.templateOptions.filenameScheme).toBe('title-id');
     });
 
+    it('normalizes corrupted sync values to defaults (L-1)', async () => {
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+        settings: {
+          maxCalloutLines: 'not-a-number',
+          enableAppendMode: 'yes',
+          templateOptions: { messageFormat: 'weird' },
+        },
+      });
+
+      const settings = await getSettings();
+      expect(settings.maxCalloutLines).toBe(200);
+      expect(settings.enableAppendMode).toBe(false);
+      expect(settings.templateOptions.messageFormat).toBe('callout');
+    });
+
+    it('falls back to the legacy sync API key before migration completes (L-2)', async () => {
+      // Simulate the race: migration has not yet moved the key to local storage.
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({ secureSettings: undefined });
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+        settings: { obsidianApiKey: 'legacy-sync-key' },
+      });
+
+      const settings = await getSettings();
+      expect(settings.obsidianApiKey).toBe('legacy-sync-key');
+    });
+
+    it('prefers the migrated local API key over any legacy sync value (L-2)', async () => {
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({
+        secureSettings: { obsidianApiKey: 'local-key' },
+      });
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+        settings: { obsidianApiKey: 'legacy-sync-key' },
+      });
+
+      const settings = await getSettings();
+      expect(settings.obsidianApiKey).toBe('local-key');
+    });
+
+    it('returns an empty API key when neither store has one (L-2)', async () => {
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({ secureSettings: undefined });
+      vi.mocked(chrome.storage.sync.get).mockResolvedValue({ settings: {} });
+
+      const settings = await getSettings();
+      expect(settings.obsidianApiKey).toBe('');
+    });
+
     it('round-trips a stored title-date filenameScheme (#328)', async () => {
       vi.mocked(chrome.storage.sync.get).mockResolvedValue({
         settings: { templateOptions: { filenameScheme: 'title-date' } },


### PR DESCRIPTION
## Summary

Hardening pass from a code-quality review (Medium×2 / Low×3). TDD throughout; each finding got failing tests first.

- **M-1 — image input caps** (`validateImages`): add a combined base64 size cap (`MAX_TOTAL_IMAGE_DATA_LENGTH`, 48 MiB) on top of the existing per-count/per-image caps, a shared MIME allow-list (`ALLOWED_IMAGE_MIME_TYPES`, SSOT-derived from `MIME_TO_EXT`), and base64 format validation (`isLikelyBase64`). An unknown-MIME image now rejects the whole note (see trade-off below).
- **M-2 — math size limit** (`markdown-rules.ts` `formatMath`): cap page-derived `data-math` at `MAX_MATH_LENGTH` (1000) and fall back to `$`-escaped plain text when oversized or containing a literal `$`, so a malformed/abusive formula can't degrade Obsidian's math rendering. Multi-line inline KaTeX (matrices) is preserved.
- **L-1 — settings schema** (new `src/lib/settings-schema.ts`): `normalizeSyncSettings()` validates untrusted `chrome.storage.sync` values with per-field fallback; `storage.ts` slimmed to consume it (no new dependency).
- **L-2 — migration race** (`getSettings`): fall back to the legacy sync `obsidianApiKey` when local storage isn't yet populated by the fire-and-forget startup migration.
- **L-3 — offscreen comment**: correct the sender-restriction comment to match the implementation (no logic change).

### Trade-off (M-1)

Per the agreed design, an image whose MIME type is outside the allow-list rejects the entire note rather than saving as `.png`. Gemini-generated images are png/jpeg/webp, so real-world impact is minimal; `image-capture.ts` is unchanged.

## Test plan

- [x] `npm run test` — 1226 passed (new: total-size/MIME/base64 rejection, math size/`$`-escape/multi-line KaTeX, 11 settings-normalization cases, 3 migration-race cases)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run build` — tsc + vite succeed
- [x] Coverage thresholds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)