### PR TITLE
fix: seed virtualized accumulation at the bottom so the newest turn is captured

### DIFF
--- a/src/lib/scroll-manager.ts
+++ b/src/lib/scroll-manager.ts
@@ -245,7 +245,15 @@ export async function accumulateWhileScrolling<T>(
 
   const toItems = (): T[] => order.map(key => content.get(key) as T);
 
-  ingest(); // seed with the initial (bottom) window
+  // Seed at the true bottom so the newest turns are mounted before harvesting.
+  // Sync may start with the view scrolled up (issue #348): the last turn is then
+  // below the fold and unmounted, and because we only ever scroll *up* from the
+  // seed, an unmounted tail would be lost forever. Jumping to scrollHeight first
+  // pins the newest window; a conversation that fits has no scroll range and
+  // stays at the top, so the skip path below still applies.
+  container.scrollTop = container.scrollHeight;
+  await delay(SCROLL_ACCUMULATE_POLL_INTERVAL);
+  ingest();
 
   if (container.scrollTop <= 0) {
     console.info('[G2O] scrollTop=0 on open, conversation fits without scrolling');

--- a/test/lib/scroll-manager.test.ts
+++ b/test/lib/scroll-manager.test.ts
@@ -49,17 +49,26 @@ function createVirtualList(opts: {
   windowSize: number;
   clientHeight?: number;
   startAtTop?: boolean;
+  /**
+   * Initial scrollTop as a fraction of maxScroll (1 = bottom, default). Use a
+   * value < 1 to model Sync starting with the view scrolled up, so the newest
+   * turn is below the fold and not in the initially-mounted window.
+   */
+  startFraction?: number;
 }): {
   container: HTMLElement;
   harvest: () => Array<{ key: string; value: string }>;
 } {
   const { total, windowSize } = opts;
   const clientHeight = opts.clientHeight ?? 900;
-  const maxScroll = 10_000;
+  // A conversation that fits entirely in one window has no scroll range.
+  const fits = total <= windowSize;
+  const maxScroll = fits ? 0 : 10_000;
   const items = Array.from({ length: total }, (_, i) => ({ key: `k${i}`, value: `v${i}` }));
 
   const container = document.createElement('div');
-  let scrollTop = opts.startAtTop ? 0 : maxScroll;
+  const startFraction = opts.startAtTop ? 0 : (opts.startFraction ?? 1);
+  let scrollTop = Math.round(maxScroll * startFraction);
   Object.defineProperty(container, 'scrollTop', {
     get: () => scrollTop,
     set: (v: number) => {
@@ -75,7 +84,7 @@ function createVirtualList(opts: {
 
   const maxStart = Math.max(0, total - windowSize);
   const harvest = () => {
-    const frac = scrollTop / maxScroll; // 1 at bottom, 0 at top
+    const frac = maxScroll === 0 ? 0 : scrollTop / maxScroll; // 1 at bottom, 0 at top
     const start = Math.round(frac * maxStart);
     return items.slice(start, start + windowSize);
   };
@@ -99,6 +108,26 @@ describe('accumulateWhileScrolling', () => {
     expect(result.itemCount).toBe(12);
     // Ordered from first turn to last.
     expect(result.items).toEqual(Array.from({ length: 12 }, (_, i) => `v${i}`));
+  });
+
+  it('captures the newest turn even when Sync starts scrolled up (issue #348)', async () => {
+    // The view is scrolled up on Sync, so the last turn (v19) is below the fold
+    // and not in the initially-mounted window. Upward-only accumulation would
+    // never reach it; the engine must seed at the bottom first.
+    const { container, harvest } = createVirtualList({
+      total: 20,
+      windowSize: 6,
+      startFraction: 0.5,
+    });
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.itemCount).toBe(20);
+    expect(result.items).toEqual(Array.from({ length: 20 }, (_, i) => `v${i}`));
+    // The regression: the final turn must be present.
+    expect(result.items[result.items.length - 1]).toBe('v19');
   });
 
   it('skips scrolling when the container starts at the top (short conversation)', async () => {
@@ -128,6 +157,7 @@ describe('accumulateWhileScrolling', () => {
       configurable: true,
     });
     Object.defineProperty(container, 'clientHeight', { get: () => 900, configurable: true });
+    Object.defineProperty(container, 'scrollHeight', { get: () => 10_900, configurable: true });
     let n = 0;
     const harvest = () => [{ key: `new${n++}`, value: `val${n}` }];
 
@@ -150,6 +180,7 @@ describe('accumulateWhileScrolling', () => {
       configurable: true,
     });
     Object.defineProperty(container, 'clientHeight', { get: () => 900, configurable: true });
+    Object.defineProperty(container, 'scrollHeight', { get: () => 10_900, configurable: true });
 
     let round = 0;
     const harvest = () => {


### PR DESCRIPTION
Fixes #348.

## Summary

Long conversations dropped the newest turn on Claude (and, by the same code path, ChatGPT). With Auto-scroll **on**, an N-message thread imported N-1; with it **off**, only the initially-mounted window was captured.

**Root cause:** `accumulateWhileScrolling` seeded from the initially-mounted window and then only ever scrolled **up**. When Sync started with the view scrolled up (the reporter's Claude case: `scrollTop=9631, 6 turns mounted` → `Accumulated 18 turns` for a 19-message thread), the last turn was below the fold, unmounted, and never reachable by upward-only accumulation.

**Fix:** jump to `scrollHeight` and seed at the true bottom **before** accumulating upward, so the newest window is mounted and harvested. A conversation that fits in the viewport has no scroll range and stays at the top, so the existing skip path is unaffected. Because the fix lives in the shared engine, it covers both virtualized platforms (Claude + ChatGPT); Gemini/Perplexity/NotebookLM use different, unaffected paths.

## Changes

- `src/lib/scroll-manager.ts` — seed at the bottom before the upward pass.
- `test/lib/scroll-manager.test.ts` — regression test: Sync starting scrolled up still captures the final turn (20/20); virtual-list mock updated so `scrollHeight` reflects content.

## Test plan

- [x] `npm run test` — 1228 passed (incl. new #348 regression, platform-agnostic on the shared engine)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — tsc + vite succeed
- [x] `npm run format:check` — clean
- [x] Optional: live smoke on real Claude/ChatGPT (jsdom can't fully model virtualization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)