### PR TITLE
fix: keep the conversation when a closed Claude artifact panel lingers (#352 follow-up)

### DIFF
--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -48,14 +48,36 @@ export class ClaudeExtractor extends BaseExtractor {
   }
 
   /**
-   * Check if Deep Research mode is visible
+   * Check if a Deep Research / Artifact report is the actively-viewed panel.
    *
-   * Detects presence of #markdown-artifact element
+   * Detects the #markdown-artifact element, but presence alone is not enough:
+   * Claude keeps the artifact mounted after the panel is closed, moving the
+   * off-screen panel into an `inert` + `aria-hidden="true"` subtree (verified
+   * live 2026-07-16, w/h collapse to 0 and x is pushed past the viewport). A
+   * presence-only check therefore hijacked every save after the user had ever
+   * opened a report — returning the stale report and dropping the conversation
+   * (issue #352 follow-up). Treat an inert / aria-hidden subtree as "closed".
+   *
    * @see FR-003-3 in design document
    */
   isDeepResearchVisible(): boolean {
     const artifact = this.queryWithFallback<HTMLElement>(DEEP_RESEARCH_SELECTORS.artifact);
-    return artifact !== null;
+    if (!artifact) return false;
+    return !this.isInDismissedPanel(artifact);
+  }
+
+  /**
+   * Whether an element sits inside a dismissed (closed) panel subtree.
+   *
+   * Claude does not unmount a closed Deep Research / Artifact panel — it moves
+   * the off-screen subtree into `inert` + `aria-hidden="true"` (verified live
+   * 2026-07-16). Such content is neither the active view nor a real conversation
+   * turn, so both DR detection and message collection ignore it — otherwise the
+   * lingering report (which also carries `.font-claude-response`) would leak into
+   * the conversation as a stale extra assistant turn.
+   */
+  private isInDismissedPanel(element: Element): boolean {
+    return element.closest('[inert], [aria-hidden="true"]') !== null;
   }
 
   // ========== ID & Title Extraction ==========
@@ -137,14 +159,17 @@ export class ClaudeExtractor extends BaseExtractor {
    * Collect user/assistant message elements in DOM order.
    *
    * User messages nested inside an assistant response (e.g. quoted content) are
-   * skipped. Shared by extractMessages() (single pass) and harvestWindow()
-   * (per-scroll-window pass for virtualized conversations).
+   * skipped, as is anything inside a dismissed artifact panel (a closed report
+   * lingers with `.font-claude-response`; see {@link isInDismissedPanel}).
+   * Shared by extractMessages() (single pass) and harvestWindow() (per-scroll-
+   * window pass for virtualized conversations).
    */
   private collectSortedElements(): Array<{ element: Element; type: 'user' | 'assistant' }> {
     const allElements: Array<{ element: Element; type: 'user' | 'assistant' }> = [];
 
     const userMessages = this.queryAllWithFallback<HTMLElement>(SELECTORS.userMessage);
     userMessages.forEach(el => {
+      if (this.isInDismissedPanel(el)) return;
       const assistantParent = el.closest('.font-claude-response, [class*="font-claude-response"]');
       if (!assistantParent) {
         allElements.push({ element: el, type: 'user' });
@@ -153,6 +178,7 @@ export class ClaudeExtractor extends BaseExtractor {
 
     const assistantResponses = this.queryAllWithFallback<HTMLElement>(SELECTORS.assistantResponse);
     assistantResponses.forEach(el => {
+      if (this.isInDismissedPanel(el)) return;
       allElements.push({ element: el, type: 'assistant' });
     });
 

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -73,6 +73,48 @@ describe('ClaudeExtractor', () => {
         );
         expect(extractor.isDeepResearchVisible()).toBe(false);
       });
+
+      // Claude keeps the artifact mounted after the panel is closed, moving the
+      // off-screen panel into an `inert` + `aria-hidden="true"` subtree (verified
+      // live 2026-07-16). Presence alone must NOT count as "visible", else every
+      // Sync after ever opening a DR/Artifact hijacks the save to report-only and
+      // discards the conversation (user report, issue #352 follow-up).
+      it('returns false when the artifact is inside an inert (closed) panel', () => {
+        setClaudeLocation('test-123');
+        loadFixture(
+          `<div inert aria-hidden="true">${createClaudeDeepResearchDOM('Closed Report', '<p>Lingering</p>')}</div>`
+        );
+        expect(extractor.isDeepResearchVisible()).toBe(false);
+      });
+
+      it('returns false when the artifact panel is aria-hidden (dismissed but mounted)', () => {
+        setClaudeLocation('test-123');
+        loadFixture(
+          `<div aria-hidden="true">${createClaudeDeepResearchDOM('Hidden', '<p>x</p>')}</div>`
+        );
+        expect(extractor.isDeepResearchVisible()).toBe(false);
+      });
+
+      it('returns true when the artifact panel is open (aria-hidden="false")', () => {
+        setClaudeLocation('test-123');
+        loadFixture(
+          `<div aria-hidden="false">${createClaudeDeepResearchDOM('Open', '<p>x</p>')}</div>`
+        );
+        expect(extractor.isDeepResearchVisible()).toBe(true);
+      });
+
+      it('still detects an open artifact when an unrelated sibling is aria-hidden', () => {
+        // Over-suppression guard: only the artifact's own ancestors count, not a
+        // hidden sibling subtree elsewhere on the page (code-review #2/#4).
+        setClaudeLocation('test-123');
+        loadFixture(`
+          <div>
+            <div aria-hidden="true"><p>an unrelated dismissed dialog</p></div>
+            ${createClaudeDeepResearchDOM('Open', '<p>x</p>')}
+          </div>
+        `);
+        expect(extractor.isDeepResearchVisible()).toBe(true);
+      });
     });
   });
 
@@ -465,6 +507,54 @@ describe('ClaudeExtractor', () => {
       const result = await extractor.extract();
       expect(result.success).toBe(true);
       expect(result.data?.type).toBe('deep-research');
+    });
+
+    it('extracts the conversation (not DR) when a lingering artifact panel is closed', async () => {
+      // Regression: once a DR/Artifact has been opened, #markdown-artifact stays
+      // mounted in an inert/aria-hidden subtree. The save must return the
+      // conversation, not hijack to the stale report (issue #352 follow-up).
+      setClaudeLocation('test-123');
+      loadFixture(`
+        <div class="app-container">
+          ${createClaudeConversationDOM([
+            { role: 'user', content: 'What is the weather?' },
+            { role: 'assistant', content: '<p>It is sunny.</p>' },
+          ])}
+          <div inert aria-hidden="true">
+            ${createClaudeDeepResearchDOM('Stale Report', '<p>lingering</p>')}
+          </div>
+        </div>
+      `);
+      const result = await extractor.extract();
+      expect(result.success).toBe(true);
+      expect(result.data?.type).not.toBe('deep-research');
+      expect(
+        result.data?.messages.some(m => m.role === 'user' && m.content.includes('weather'))
+      ).toBe(true);
+    });
+
+    it('excludes a lingering closed artifact from the conversation messages', async () => {
+      // The closed #markdown-artifact still carries .font-claude-response, so
+      // conversation extraction must not pull the stale report in as an extra
+      // assistant turn (code-review #1 of the DR-visibility fix).
+      setClaudeLocation('test-123');
+      loadFixture(`
+        <div class="app-container">
+          ${createClaudeConversationDOM([
+            { role: 'user', content: 'What is the weather?' },
+            { role: 'assistant', content: '<p>It is sunny.</p>' },
+          ])}
+          <div inert aria-hidden="true">
+            ${createClaudeDeepResearchDOM('Stale Report Title', '<p>lingering report body</p>')}
+          </div>
+        </div>
+      `);
+      const result = await extractor.extract();
+      const joined = (result.data?.messages ?? []).map(m => m.content).join('\n');
+      expect(joined).not.toContain('Stale Report Title');
+      expect(joined).not.toContain('lingering report body');
+      // The real conversation is intact: exactly one assistant turn.
+      expect(result.data?.messages.filter(m => m.role === 'assistant')).toHaveLength(1);
     });
 
     it('deduplicates citations by URL', () => {


### PR DESCRIPTION
## Summary

- Fixes a bug found while investigating #352: once a Deep Research / Artifact panel had been opened in a Claude conversation, **every subsequent Sync saved only the stale report and dropped the whole conversation** — even when the user was viewing the conversation with the panel closed.
- Root cause (CDP-verified live): Claude does **not** unmount a closed artifact panel; it moves the off-screen `#markdown-artifact` subtree into `inert` + `aria-hidden="true"` (display stays `block`, so an offsetParent/visibility check does not work). The presence-only `isDeepResearchVisible()` therefore stayed true forever.
- Gate detection on an **active** (non-inert / non-aria-hidden) subtree via a shared `isInDismissedPanel()` helper. Live-verified: open report → save report; closed/lingering → save conversation.
- Also exclude dismissed-panel elements during message collection, so the lingering report (which still carries `.font-claude-response`) no longer leaks into the conversation as a stale extra assistant turn.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` passes
- [x] `npm run test` passes (adds isDeepResearchVisible inert/aria-hidden cases + a lingering-artifact exclusion test)
- [x] Live: with a Deep Research present but its panel closed, Sync saves the conversation; with the panel open, Sync saves the report

## Notes

- Still open (not in this PR): no way yet to save conversation **and** report together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)