### PR TITLE
fix: correct append-mode lookup, coverage scope, and vault path validation

### DIFF
--- a/docs/adr/019-coverage-measurement-scope.md
+++ b/docs/adr/019-coverage-measurement-scope.md
@@ -1,0 +1,71 @@
+# ADR-019: Coverage is measured over `src/` only, via `exclude`
+
+## Status
+
+Accepted (2026-07-25)
+
+## Context
+
+`vitest.config.ts` declared `coverage.include: ['src/**/*.ts']`, which reads as
+"measure the extension source". It did not do that.
+
+Vitest's own documentation describes `coverage.include` as the set of "covered
+and uncovered files matching this pattern", with the default being "files that
+were imported during test run". Empirically, with `vitest@4.1.8` and
+`@vitest/coverage-v8@4.1.8`, setting `include` does **not** narrow the reported
+set: the E2E selector-validation tooling under `e2e/` — imported by its own unit
+tests, which `test.include` picks up via `e2e/**/*.test.ts` — appeared in every
+report. Verified three ways, all of which still reported the `e2e/` directories:
+
+| Attempt | Result |
+| --- | --- |
+| `include: ['src/**/*.ts']` in the config file | `e2e/` present |
+| `--coverage.include='src/**/*.ts'` on the CLI | `e2e/` present |
+| `--coverage.include='**/src/**/*.ts'` (globstar-anchored, cf. ADR-012) | `e2e/` present |
+| `--coverage.exclude='e2e/**'` | `e2e/` **absent** |
+
+Only `exclude` filters.
+
+The consequence was that the thresholds gated the wrong population. E2E tooling
+sits far below product code (`e2e/tools/gemini-pick-url.ts` at 12.9%,
+`e2e/daemon/chrome-launcher.ts` at 26.0%), so it dragged the aggregate down:
+
+| Population | Stmts | Branch | Funcs | Lines |
+| --- | --- | --- | --- | --- |
+| Reported (src + e2e) | 90.85% | 84.76% | 94.45% | 91.66% |
+| src only | 96.28% | 87.20% | 98.64% | 97.40% |
+
+Against thresholds of 85/75/85/85, `src/` could have regressed by roughly eight
+points and still passed. The gate was also coupled the wrong way round: growth
+in developer tooling could fail CI for reasons unrelated to shipped code.
+
+## Decision
+
+Add `'e2e/**'` to `coverage.exclude` and raise the thresholds to match what
+`src/` actually sustains: **95 / 85 / 95 / 95** (statements / branches /
+functions / lines), a small margin under the measured 96.13 / 87.17 / 98.67 /
+97.43.
+
+`coverage.include` stays in the config with a comment recording that it does not
+narrow the set on its own. It documents intent and becomes effective if the
+upstream behaviour changes; the `exclude` entry is the mechanism that works
+today.
+
+Per-glob thresholds (`thresholds: { 'src/**': { … } }`) are supported by Vitest
+and were considered. They are not used here: once `e2e/` is excluded, the global
+thresholds already describe exactly the population we care about, and a single
+set of numbers is easier to reason about.
+
+## Consequences
+
+- Coverage numbers now describe shipped extension code. The reported figure
+  jumped from 90.85% to 96.13% statements with no test added — the earlier
+  number was measuring a different thing, so it is not comparable to history.
+- The gate is meaningfully tight: `src/` has ~1 point of statement headroom, so
+  a genuine regression fails CI instead of hiding under tooling dilution.
+- E2E tooling keeps its unit tests; they simply no longer count toward the
+  product coverage gate.
+- A new `src/` file with no test at all is still only visible once something
+  imports it, because `include` does not add uncovered files here. Every current
+  `src/` file is imported by the suite, so nothing is missing today; if that
+  assumption breaks, revisit whether `include` has started working upstream.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3996,9 +3996,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -93,14 +93,11 @@ async function tryAppendMode(
   }
 
   try {
-    const lookup = await lookupExistingFile(
-      client,
-      fullPath,
-      resolvedPath,
-      note,
+    const lookup = await lookupExistingFile(client, fullPath, resolvedPath, note, {
       searchBasePath,
-      appendPathMemo.get(note.frontmatter.id)
-    );
+      hintPath: appendPathMemo.get(note.frontmatter.id),
+      filenameScheme: settings.templateOptions.filenameScheme,
+    });
     if (!lookup.found) return null;
     rememberAppendPath(note.frontmatter.id, lookup.path);
 

--- a/src/content/image-capture.ts
+++ b/src/content/image-capture.ts
@@ -6,14 +6,28 @@
  * Captured bytes are base64-encoded for structured-clone message passing.
  */
 
-import { MAX_IMAGE_SIZE_BYTES, bytesToBase64 } from '../lib/image-utils';
+import { MAX_IMAGE_SIZE_BYTES, bytesToBase64, isAllowedImageMime } from '../lib/image-utils';
 import type { ExtractedImage } from '../lib/types';
+
+/**
+ * Resolve the MIME type to record for a captured blob, or null when the blob
+ * must not be exported.
+ *
+ * An empty `blob.type` is common for blob: URLs backing an `<img>`, so it keeps
+ * the historical `image/png` assumption. A type that IS declared must be on the
+ * shared allow-list: unsupported types would otherwise be rejected downstream by
+ * `validateImages()`, which fails the ENTIRE note rather than the one image.
+ */
+function resolveCapturedMime(blobType: string): string | null {
+  if (!blobType) return 'image/png';
+  return isAllowedImageMime(blobType) ? blobType : null;
+}
 
 /**
  * Fetch an image (typically a blob: URL) from the page and return it as an
  * {@link ExtractedImage} with base64 data. Returns `null` on any failure
- * (network error, non-OK response, oversized image) so a single bad image
- * never aborts the whole extraction.
+ * (network error, non-OK response, oversized image, unsupported type) so a
+ * single bad image never aborts the whole extraction.
  */
 export async function fetchImageAsBase64(
   url: string,
@@ -31,7 +45,11 @@ export async function fetchImageAsBase64(
       return null;
     }
 
-    const mimeType = blob.type && blob.type.startsWith('image/') ? blob.type : 'image/png';
+    const mimeType = resolveCapturedMime(blob.type);
+    if (mimeType === null) {
+      return null;
+    }
+
     const bytes = new Uint8Array(await blob.arrayBuffer());
     const data = bytesToBase64(bytes);
 

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -6,7 +6,8 @@
  */
 
 import type { ObsidianApiClient } from './obsidian-api';
-import type { ObsidianNote, ExtensionSettings } from './types';
+import type { ObsidianNote, ExtensionSettings, FilenameScheme } from './types';
+import { SCAN_MAX_REQUESTS } from './constants';
 import { parseFrontmatter, updateFrontmatter } from './frontmatter-parser';
 import { countExistingMessages, extractTailMessages } from './message-counter';
 import { formatDateWithTimezone } from './date-utils';
@@ -48,6 +49,118 @@ export function extractIdSuffix(fileName: string): string {
 const RECURSIVE_SCAN_MAX_DEPTH = 6;
 
 /**
+ * Options for {@link lookupExistingFile}.
+ */
+export interface LookupOptions {
+  /**
+   * When provided AND different from resolvedPath, triggers the recursive scan.
+   * Defaults to resolvedPath (preserves the flat-scan behaviour for templates
+   * without date variables).
+   */
+  searchBasePath?: string;
+  /**
+   * Path where this conversation's file was previously found (caller-memoized).
+   * Tried before anything else so repeat appends after a calendar rollover cost
+   * one GET instead of a directory scan.
+   */
+  hintPath?: string;
+  /**
+   * File-naming scheme in effect. Decides how scan candidates are pre-filtered;
+   * see {@link createCandidateMatcher}. Defaults to `'title-id'`.
+   */
+  filenameScheme?: FilenameScheme;
+}
+
+/** Bounded request allowance shared by a single lookup's directory scan. */
+interface ScanBudget {
+  /** Consume one request. Returns false once the allowance is exhausted. */
+  spend(): boolean;
+  /** True once the allowance is used up; lets callers stop iterating early. */
+  readonly exhausted: boolean;
+}
+
+function createScanBudget(max: number): ScanBudget {
+  let used = 0;
+  return {
+    spend(): boolean {
+      if (used >= max) return false;
+      used++;
+      return true;
+    },
+    get exhausted(): boolean {
+      return used >= max;
+    },
+  };
+}
+
+/** Uniform "no existing file" result. */
+function notFound(fullPath: string): FileLookupResult {
+  return { found: false, path: fullPath, content: '', matchType: 'none' };
+}
+
+/**
+ * Build the file-name pre-filter used to pick scan candidates.
+ *
+ * `title-id` names end in `-{idPrefix}.md`, so the suffix narrows the candidate
+ * set to (usually) a single file. `title-date` names end in the SAVE date and
+ * carry no conversation identity at all — a note written on the 3rd and
+ * re-saved on the 10th shares no file-name component beyond the title slug — so
+ * every markdown file must be considered. In both cases the frontmatter id
+ * comparison performed by the scan is what actually decides a match; this
+ * predicate only avoids reading files that cannot possibly match.
+ *
+ * Returns null when no scan is possible (a `title-id` name with no suffix).
+ */
+function createCandidateMatcher(
+  fileName: string,
+  scheme: FilenameScheme
+): ((entry: string) => boolean) | null {
+  if (scheme === 'title-date') {
+    return entry => entry.endsWith('.md');
+  }
+  const idSuffix = extractIdSuffix(fileName);
+  if (!idSuffix) return null;
+  return entry => entry.endsWith(`-${idSuffix}.md`);
+}
+
+/**
+ * Read a candidate file and return a match result when its frontmatter id is
+ * the one we are looking for. Returns null on a budget miss, a missing file, or
+ * a different conversation.
+ */
+async function readCandidate(
+  client: ObsidianApiClient,
+  candidatePath: string,
+  expectedId: string,
+  budget: ScanBudget
+): Promise<FileLookupResult | null> {
+  if (!budget.spend()) return null;
+  const content = await client.getFile(candidatePath);
+  if (content === null) return null;
+  const parsed = parseFrontmatter(content);
+  if (parsed?.fields.id !== expectedId) return null;
+  return { found: true, path: candidatePath, content, matchType: 'id-scan' };
+}
+
+/**
+ * Step 0 of {@link lookupExistingFile}: try the caller-memoized path.
+ * The id is re-verified because the memo may be stale.
+ */
+async function tryHintPath(
+  client: ObsidianApiClient,
+  hintPath: string | undefined,
+  fullPath: string,
+  expectedId: string
+): Promise<FileLookupResult | null> {
+  if (!hintPath || hintPath === fullPath) return null;
+  const content = await client.getFile(hintPath);
+  if (content === null) return null;
+  const parsed = parseFrontmatter(content);
+  if (parsed?.fields.id !== expectedId) return null;
+  return { found: true, path: hintPath, content, matchType: 'memo' };
+}
+
+/**
  * Look up an existing file for a conversation.
  *
  * Strategy (ordered by cost):
@@ -72,59 +185,50 @@ export async function lookupExistingFile(
   fullPath: string,
   resolvedPath: string,
   note: ObsidianNote,
-  searchBasePath: string = resolvedPath,
-  hintPath?: string
+  options: LookupOptions = {}
 ): Promise<FileLookupResult> {
+  const { searchBasePath = resolvedPath, hintPath, filenameScheme = 'title-id' } = options;
   const expectedId = note.frontmatter.id;
 
-  // Step 0: Caller-memoized hint (id re-verified — the memo may be stale)
-  if (hintPath && hintPath !== fullPath) {
-    const hintContent = await client.getFile(hintPath);
-    if (hintContent !== null) {
-      const parsed = parseFrontmatter(hintContent);
-      if (parsed?.fields.id === expectedId) {
-        return { found: true, path: hintPath, content: hintContent, matchType: 'memo' };
-      }
-    }
-  }
+  // Step 0: Caller-memoized hint
+  const memoHit = await tryHintPath(client, hintPath, fullPath, expectedId);
+  if (memoHit) return memoHit;
 
   // Step 1: Direct path match
   const directContent = await client.getFile(fullPath);
-  if (directContent !== null) {
-    const parsed = parseFrontmatter(directContent);
-    if (parsed?.fields.id === expectedId) {
-      return { found: true, path: fullPath, content: directContent, matchType: 'direct' };
-    }
+  if (directContent !== null && parseFrontmatter(directContent)?.fields.id === expectedId) {
+    return { found: true, path: fullPath, content: directContent, matchType: 'direct' };
   }
 
-  // Step 2: ID suffix scan
-  const idSuffix = extractIdSuffix(note.fileName);
-  if (!idSuffix) return { found: false, path: fullPath, content: '', matchType: 'none' };
+  // Step 2: Directory scan, bounded by a shared request budget
+  const matches = createCandidateMatcher(note.fileName, filenameScheme);
+  if (!matches) return notFound(fullPath);
 
+  const budget = createScanBudget(SCAN_MAX_REQUESTS);
   const useRecursive = searchBasePath !== resolvedPath && searchBasePath !== '';
 
   if (useRecursive) {
     const recursive = await recursiveIdScan(
       client,
       searchBasePath,
-      idSuffix,
+      matches,
       expectedId,
       fullPath,
-      RECURSIVE_SCAN_MAX_DEPTH
+      budget
     );
     if (recursive) return recursive;
   } else if (resolvedPath) {
-    const flat = await flatIdScan(client, resolvedPath, idSuffix, expectedId, fullPath);
+    const flat = await flatIdScan(client, resolvedPath, matches, expectedId, fullPath, budget);
     if (flat) return flat;
   }
 
   // Step 3: Not found
-  return { found: false, path: fullPath, content: '', matchType: 'none' };
+  return notFound(fullPath);
 }
 
 /**
- * Scan a single directory for any `.md` file whose name ends in `-{idSuffix}.md`
- * and whose frontmatter id matches expectedId. Returns the first match, or null.
+ * Scan a single directory for a candidate `.md` file (per {@link matches})
+ * whose frontmatter id equals expectedId. Returns the first match, or null.
  *
  * Non-recursive sibling of {@link recursiveIdScan}, used when the vault path
  * template has no date variables (legacy flat-scan behaviour).
@@ -132,62 +236,61 @@ export async function lookupExistingFile(
 async function flatIdScan(
   client: ObsidianApiClient,
   dir: string,
-  idSuffix: string,
+  matches: (entry: string) => boolean,
   expectedId: string,
-  skipPath: string
+  skipPath: string,
+  budget: ScanBudget
 ): Promise<FileLookupResult | null> {
+  if (!budget.spend()) return null;
   const files = await client.listFiles(dir);
   for (const file of files) {
-    if (!file.endsWith(`-${idSuffix}.md`)) continue;
+    if (budget.exhausted) return null;
+    if (!matches(file)) continue;
     const candidatePath = `${dir}/${file}`;
     if (candidatePath === skipPath) continue; // Already checked as direct match
-    const content = await client.getFile(candidatePath);
-    if (content === null) continue;
-    const parsed = parseFrontmatter(content);
-    if (parsed?.fields.id === expectedId) {
-      return { found: true, path: candidatePath, content, matchType: 'id-scan' };
-    }
+    const hit = await readCandidate(client, candidatePath, expectedId, budget);
+    if (hit) return hit;
   }
 
   return null;
 }
 
 /**
- * Walk subdirectories from baseDir up to maxDepth, looking for any `.md` file
- * whose name ends in `-{idSuffix}.md` and whose frontmatter id matches expectedId.
- * Returns the first match, or null when exhausted.
+ * Walk subdirectories from baseDir up to {@link RECURSIVE_SCAN_MAX_DEPTH},
+ * looking for a candidate `.md` file (per {@link matches}) whose frontmatter id
+ * equals expectedId. Returns the first match, or null when exhausted.
+ *
+ * Depth is bounded by RECURSIVE_SCAN_MAX_DEPTH; total request count is bounded
+ * by the shared {@link ScanBudget}, since breadth is not otherwise limited.
  */
 async function recursiveIdScan(
   client: ObsidianApiClient,
   baseDir: string,
-  idSuffix: string,
+  matches: (entry: string) => boolean,
   expectedId: string,
   skipPath: string,
-  maxDepth: number
+  budget: ScanBudget
 ): Promise<FileLookupResult | null> {
   type Frame = { dir: string; depth: number };
   const queue: Frame[] = [{ dir: baseDir, depth: 0 }];
 
   while (queue.length > 0) {
     const { dir, depth } = queue.shift() as Frame;
+    if (!budget.spend()) return null;
     const entries = await client.listEntries(dir);
     for (const entry of entries) {
       if (entry.endsWith('/')) {
-        if (depth + 1 <= maxDepth) {
+        if (depth + 1 <= RECURSIVE_SCAN_MAX_DEPTH) {
           const subdir = entry.slice(0, -1);
           queue.push({ dir: `${dir}/${subdir}`, depth: depth + 1 });
         }
         continue;
       }
-      if (!entry.endsWith(`-${idSuffix}.md`)) continue;
+      if (!matches(entry)) continue;
       const candidatePath = `${dir}/${entry}`;
       if (candidatePath === skipPath) continue;
-      const content = await client.getFile(candidatePath);
-      if (content === null) continue;
-      const parsed = parseFrontmatter(content);
-      if (parsed?.fields.id === expectedId) {
-        return { found: true, path: candidatePath, content, matchType: 'id-scan' };
-      }
+      const hit = await readCandidate(client, candidatePath, expectedId, budget);
+      if (hit) return hit;
     }
   }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,6 +28,22 @@ export const FILENAME_ID_SUFFIX_LENGTH = 8;
 export const MAX_LANG_HINT_LENGTH = 30;
 
 /**
+ * Upper bound on Obsidian REST API requests spent by a single append-mode
+ * existing-file lookup (directory listings + candidate reads combined).
+ *
+ * The scan is bounded in depth but not in breadth, so a deeply-foldered vault
+ * could otherwise issue an unbounded number of sequential requests on every
+ * save. 200 comfortably covers realistic layouts — five years of
+ * `{YYYY}/{MM}` folders costs 66 listings — while capping the pathological
+ * case. Requests go to 127.0.0.1, so even the worst case stays sub-second, and
+ * the caller-side path memo short-circuits repeat saves entirely.
+ *
+ * Exhausting the budget is treated as "not found", which falls through to a
+ * normal (non-append) save.
+ */
+export const SCAN_MAX_REQUESTS = 200;
+
+/**
  * Default line threshold for the Obsidian-only "flatten large callouts"
  * setting. Obsidian decorates every blockquote line, so a very long message
  * (e.g. a pasted document) rendered as one giant callout makes the note render

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -9,14 +9,22 @@
 /** Maximum accepted image size in bytes (10MB safety guard). */
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 
-/** MIME type → file extension. Unknown types fall back to `png`. */
+/**
+ * MIME type → file extension. Unknown types fall back to `png`.
+ *
+ * SVG is intentionally excluded. Captured image bytes are the only content that
+ * reaches the vault without passing through DOMPurify, and SVG is the sole
+ * format here that can carry executable markup; Obsidian accepts `.svg` embeds,
+ * so this map is the only place the format can be gated. No supported platform
+ * is known to emit SVG for generated images — such an image is skipped at
+ * capture time (see `content/image-capture.ts`) and the note still saves.
+ */
 const MIME_TO_EXT: Readonly<Record<string, string>> = {
   'image/png': 'png',
   'image/jpeg': 'jpg',
   'image/jpg': 'jpg',
   'image/gif': 'gif',
   'image/webp': 'webp',
-  'image/svg+xml': 'svg',
   'image/avif': 'avif',
   'image/bmp': 'bmp',
 };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -56,18 +56,23 @@ export function validateCalloutType(type: string, defaultType: CalloutType): Cal
  * Validate vault path
  */
 export function validateVaultPath(path: string): string {
+  // Every check below runs on the trimmed value, because that is what gets
+  // stored and later joined into a vault path. Validating the raw input instead
+  // would let leading whitespace hide an absolute or traversing path from this
+  // check while still persisting the offending trimmed form — the background
+  // re-check then rejects it on every save with no way to fix it from here.
   const trimmed = path.trim();
 
   // Empty path is allowed (saves to vault root)
   if (!trimmed) return '';
 
   // Path traversal check
-  if (containsPathTraversal(path)) {
+  if (containsPathTraversal(trimmed)) {
     throw new Error('Vault path contains invalid characters');
   }
 
   // Length limit (filesystem constraint)
-  if (path.length > MAX_VAULT_PATH_LENGTH) {
+  if (trimmed.length > MAX_VAULT_PATH_LENGTH) {
     throw new Error(`Vault path is too long (max ${MAX_VAULT_PATH_LENGTH} characters)`);
   }
 

--- a/test/content/image-capture.test.ts
+++ b/test/content/image-capture.test.ts
@@ -45,11 +45,45 @@ describe('fetchImageAsBase64', () => {
     expect(img?.data).toBe('UE5H');
   });
 
-  it('defaults to image/png when the blob type is missing or non-image', async () => {
+  it('defaults to image/png when the blob type is missing', async () => {
     mockFetchBlob(blobLike(new Uint8Array([1, 2, 3]), ''));
 
     const img = await fetchImageAsBase64('blob:x', 'img-2', 'alt');
     expect(img?.mimeType).toBe('image/png');
+  });
+
+  // The captured bytes are written to the vault verbatim — this is the only
+  // content path that never passes through DOMPurify. Anything the shared
+  // allow-list does not cover is skipped here rather than forwarded.
+
+  it('returns null for an SVG image (not on the allow-list)', async () => {
+    mockFetchBlob(blobLike(new Uint8Array([0x3c, 0x73]), 'image/svg+xml'));
+
+    const img = await fetchImageAsBase64('blob:x', 'img-svg', 'alt');
+    expect(img).toBeNull();
+  });
+
+  it('returns null for a non-image blob type', async () => {
+    mockFetchBlob(blobLike(new Uint8Array([1, 2, 3]), 'text/html'));
+
+    const img = await fetchImageAsBase64('blob:x', 'img-html', 'alt');
+    expect(img).toBeNull();
+  });
+
+  it('returns null for an image type outside the allow-list', async () => {
+    // Would otherwise reach the background, where validateImages() rejects the
+    // WHOLE note — one unsupported image must not cost the conversation.
+    mockFetchBlob(blobLike(new Uint8Array([1, 2, 3]), 'image/heic'));
+
+    const img = await fetchImageAsBase64('blob:x', 'img-heic', 'alt');
+    expect(img).toBeNull();
+  });
+
+  it('accepts an allow-listed type carrying parameters', async () => {
+    mockFetchBlob(blobLike(new Uint8Array([0x50, 0x4e, 0x47]), 'image/PNG; charset=binary'));
+
+    const img = await fetchImageAsBase64('blob:x', 'img-param', 'alt');
+    expect(img?.mimeType).toBe('image/PNG; charset=binary');
   });
 
   it('returns null when the fetch response is not ok', async () => {

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -5,6 +5,7 @@ import {
   buildAppendContent,
 } from '../../src/lib/append-utils';
 import type { ObsidianNote, ExtensionSettings, NoteFrontmatter } from '../../src/lib/types';
+import { SCAN_MAX_REQUESTS } from '../../src/lib/constants';
 
 // ========== extractIdSuffix ==========
 
@@ -190,7 +191,7 @@ describe('lookupExistingFile', () => {
       'AI/claude/2026/06/my-chat-abc12345.md', // resolvedPath = full path with date
       'AI/claude/2026/06', // resolvedPath dir
       testNote,
-      'AI/claude' // searchBasePath = template stripped of date variables
+      { searchBasePath: 'AI/claude' } // template stripped of date variables
     );
 
     expect(result.found).toBe(true);
@@ -211,7 +212,7 @@ describe('lookupExistingFile', () => {
       'AI/claude/my-chat-abc12345.md',
       'AI/claude',
       testNote,
-      'AI/claude' // identical to resolvedPath
+      { searchBasePath: 'AI/claude' } // identical to resolvedPath
     );
 
     expect(result.found).toBe(true);
@@ -230,7 +231,7 @@ describe('lookupExistingFile', () => {
       'AI/claude/2026/06/my-chat-abc12345.md',
       'AI/claude/2026/06',
       testNote,
-      'AI/claude'
+      { searchBasePath: 'AI/claude' }
     );
 
     expect(result.found).toBe(false);
@@ -250,12 +251,120 @@ describe('lookupExistingFile', () => {
       'AI/claude/2026/06/my-chat-abc12345.md',
       'AI/claude/2026/06',
       testNote,
-      'AI/claude'
+      { searchBasePath: 'AI/claude' }
     );
 
     // getFile must have been called exactly once (the direct check at step 1).
     expect(mockClient.getFile).toHaveBeenCalledTimes(1);
     expect(result.found).toBe(false);
+  });
+
+  // ----- filenameScheme: 'title-date' -----
+  // The file name embeds the SAVE date, not the conversation id, so a note
+  // re-saved on a later day has neither a matching direct path nor a usable
+  // id suffix. Without a scheme-aware scan every day produces a duplicate note.
+
+  it('finds a file saved on an earlier day when the scheme is title-date', async () => {
+    const existingContent = '---\nid: claude_abc-def-123\n---\nBody';
+    const dateNote = createTestNote({
+      fileName: 'my-chat-2026-07-10.md',
+      frontmatter: createTestFrontmatter({ id: 'claude_abc-def-123' }),
+    });
+
+    mockClient.getFile.mockResolvedValueOnce(null); // direct miss: today's name
+    mockClient.listFiles.mockResolvedValue(['my-chat-2026-07-03.md', 'unrelated-2026-07-05.md']);
+    mockClient.getFile.mockResolvedValueOnce(existingContent);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-2026-07-10.md',
+      'AI/claude',
+      dateNote,
+      { filenameScheme: 'title-date' }
+    );
+
+    expect(result.found).toBe(true);
+    expect(result.matchType).toBe('id-scan');
+    expect(result.path).toBe('AI/claude/my-chat-2026-07-03.md');
+  });
+
+  it('does not match a foreign conversation when the scheme is title-date', async () => {
+    const dateNote = createTestNote({
+      fileName: 'my-chat-2026-07-10.md',
+      frontmatter: createTestFrontmatter({ id: 'claude_abc-def-123' }),
+    });
+
+    mockClient.getFile.mockResolvedValueOnce(null); // direct miss
+    mockClient.listFiles.mockResolvedValue(['someone-elses-2026-07-03.md']);
+    mockClient.getFile.mockResolvedValueOnce('---\nid: claude_other-id\n---\nBody');
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-2026-07-10.md',
+      'AI/claude',
+      dateNote,
+      { filenameScheme: 'title-date' }
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.matchType).toBe('none');
+  });
+
+  it('finds a title-date file in a previous month folder (recursive scan)', async () => {
+    const existingContent = '---\nid: claude_abc-def-123\n---\nBody';
+    const dateNote = createTestNote({
+      fileName: 'my-chat-2026-07-10.md',
+      frontmatter: createTestFrontmatter({ id: 'claude_abc-def-123' }),
+    });
+
+    mockClient.getFile.mockResolvedValueOnce(null); // direct miss
+    mockClient.listEntries.mockResolvedValueOnce(['2026/']);
+    mockClient.listEntries.mockResolvedValueOnce(['06/', '07/']);
+    mockClient.listEntries.mockResolvedValueOnce(['my-chat-2026-06-28.md']); // June
+    mockClient.listEntries.mockResolvedValueOnce([]); // July, still empty
+    mockClient.getFile.mockResolvedValueOnce(existingContent);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/2026/07/my-chat-2026-07-10.md',
+      'AI/claude/2026/07',
+      dateNote,
+      { searchBasePath: 'AI/claude', filenameScheme: 'title-date' }
+    );
+
+    expect(result.found).toBe(true);
+    expect(result.path).toBe('AI/claude/2026/06/my-chat-2026-06-28.md');
+  });
+
+  // ----- Request budget -----
+
+  it('stops scanning once the request budget is exhausted', async () => {
+    const dateNote = createTestNote({
+      fileName: 'my-chat-2026-07-10.md',
+      frontmatter: createTestFrontmatter({ id: 'claude_abc-def-123' }),
+    });
+
+    // Far more candidates than the budget allows; none of them match.
+    const candidates = Array.from(
+      { length: SCAN_MAX_REQUESTS + 50 },
+      (_, i) => `note-${i}-2026-07-01.md`
+    );
+    mockClient.getFile.mockResolvedValue(null);
+    mockClient.listFiles.mockResolvedValue(candidates);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-2026-07-10.md',
+      'AI/claude',
+      dateNote,
+      { filenameScheme: 'title-date' }
+    );
+
+    expect(result.found).toBe(false);
+    // The direct-path GET plus at most the budgeted scan requests.
+    expect(mockClient.getFile.mock.calls.length).toBeLessThanOrEqual(SCAN_MAX_REQUESTS + 1);
+    // …and it must not have walked the whole candidate list.
+    expect(mockClient.getFile.mock.calls.length).toBeLessThan(candidates.length);
   });
 });
 

--- a/test/lib/image-utils.test.ts
+++ b/test/lib/image-utils.test.ts
@@ -15,7 +15,6 @@ describe('mimeToExtension', () => {
     expect(mimeToExtension('image/jpeg')).toBe('jpg');
     expect(mimeToExtension('image/gif')).toBe('gif');
     expect(mimeToExtension('image/webp')).toBe('webp');
-    expect(mimeToExtension('image/svg+xml')).toBe('svg');
     expect(mimeToExtension('image/avif')).toBe('avif');
     expect(mimeToExtension('image/bmp')).toBe('bmp');
   });
@@ -75,7 +74,11 @@ describe('ALLOWED_IMAGE_MIME_TYPES', () => {
     expect(ALLOWED_IMAGE_MIME_TYPES.has('image/png')).toBe(true);
     expect(ALLOWED_IMAGE_MIME_TYPES.has('image/jpeg')).toBe(true);
     expect(ALLOWED_IMAGE_MIME_TYPES.has('image/webp')).toBe(true);
-    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/svg+xml')).toBe(true);
+    // SVG is deliberately absent: image bytes are written to the vault without
+    // passing through DOMPurify, and SVG is the one raster-adjacent format that
+    // can carry script. Obsidian accepts .svg embeds, so excluding it here is
+    // the only gate.
+    expect(ALLOWED_IMAGE_MIME_TYPES.has('image/svg+xml')).toBe(false);
     // Every allowed type maps to a non-empty extension (SSOT parity)
     for (const mime of ALLOWED_IMAGE_MIME_TYPES) {
       expect(mimeToExtension(mime).length).toBeGreaterThan(0);

--- a/test/lib/validation.test.ts
+++ b/test/lib/validation.test.ts
@@ -58,6 +58,21 @@ describe('validateVaultPath', () => {
     expect(() => validateVaultPath('/etc/passwd')).toThrow('invalid characters');
   });
 
+  // The returned value is the trimmed string, so the checks have to run on the
+  // trimmed string too. Otherwise leading whitespace smuggles a rejected path
+  // through settings validation, and every later save fails in the background
+  // with a bare "Invalid file path".
+  it('throws on traversal hidden behind leading whitespace', () => {
+    expect(() => validateVaultPath(' /Users/victim')).toThrow('invalid characters');
+    expect(() => validateVaultPath('  ../secret')).toThrow('invalid characters');
+    expect(() => validateVaultPath('\t/etc/passwd')).toThrow('invalid characters');
+  });
+
+  it('measures length against the trimmed path', () => {
+    const maxPath = 'a'.repeat(200);
+    expect(validateVaultPath(`  ${maxPath}  `)).toBe(maxPath);
+  });
+
   it('throws on path too long', () => {
     const longPath = 'a'.repeat(201);
     expect(() => validateVaultPath(longPath)).toThrow('too long');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
+      // NOTE: `include` does not narrow the measured set on its own. With the
+      // v8 provider the report still covers every file loaded during the run,
+      // so anything outside src/ must be excluded explicitly below (ADR-019).
       include: ['src/**/*.ts'],
       exclude: [
         'src/**/*.d.ts',
@@ -20,12 +23,18 @@ export default defineConfig({
         'src/popup/index.ts',
         'src/content/index.ts',
         'test/**/*.ts', // Test infrastructure should not count toward coverage
+        // E2E selector-validation tooling. It has its own unit tests, but it is
+        // developer tooling rather than shipped extension code; leaving it in
+        // diluted the thresholds below (ADR-019).
+        'e2e/**',
       ],
+      // Calibrated against the measured src-only figures (96.13 / 87.17 /
+      // 98.67 / 97.43 at the time of ADR-019), leaving a small margin.
       thresholds: {
-        statements: 85,
-        branches: 75,
-        functions: 85,
-        lines: 85,
+        statements: 95,
+        branches: 85,
+        functions: 95,
+        lines: 95,
       },
     },
   },


### PR DESCRIPTION
## Summary

Three independent defects surfaced by a static analysis pass, plus one lockfile bump. Each commit is self-contained.

### 1. Duplicate note per calendar day under the `title-date` filename scheme (`7add910`)

Append mode identified an existing note by taking the last hyphen-delimited segment of the file name as the conversation id. Under `title-date` (`{slug}-{YYYY}-{MM}-{DD}.md`, added in #340) that segment is the **day of month**, so a note re-saved on a later day matched neither the direct path nor the id-suffix scan — every save created a new file.

Reproduced against the real `lookupExistingFile` before the change:

```
day3=my-chat-2026-07-03.md  day10=my-chat-2026-07-10.md
idSuffix(day10)="10"   idSuffix(title-id)="abc123"
lookup.found=false  matchType=none      <-- falls through to a new file
```

and after:

```
found=true  type=id-scan  path=AI/gemini/my-chat-2026-07-03.md
```

Scan candidates are now picked per scheme: `title-id` keeps the id-suffix pre-filter, `title-date` considers every markdown file. The frontmatter id comparison already gated every match, so correctness never depended on the pre-filter.

This is a **separate root cause** from #360 / #365 — it reproduces with no scrolling involved.

Two related changes ride along, both load-bearing for the above:

- **Scan request budget** (`SCAN_MAX_REQUESTS`). The directory walk was bounded in depth but not in breadth; widening the candidate set for `title-date` makes that worse, so total requests per lookup are now capped.
- **SVG images are no longer exported.** Captured image bytes are the only content reaching the vault without passing through DOMPurify, and Obsidian accepts `.svg` embeds. Filtering happens at capture time rather than only in the background allow-list — dropping the MIME type alone would make `validateImages()` reject the **entire note** over one unsupported image. That also fixes the pre-existing case where a single HEIC image failed the whole conversation.

### 2. Coverage thresholds measured the wrong file population (`efa5076`)

`coverage.include: ['src/**/*.ts']` does not narrow the measured set — with coverage-v8 the report still covers every file loaded during the run, so `e2e/` tooling counted toward the thresholds. Verified three ways (config file, CLI flag, globstar-anchored pattern); only `exclude` filters.

| Population | Stmts | Branch | Funcs | Lines |
| --- | --- | --- | --- | --- |
| Before (src + e2e) | 90.85% | 84.76% | 94.45% | 91.66% |
| After (src only) | 96.13% | 87.17% | 98.67% | 97.43% |

At the old 85/75/85/85, `src/` could have regressed ~8 points unnoticed. Thresholds raised to 95/85/95/95. Rationale and evidence in **ADR-019**.

### 3. `validateVaultPath` validated the raw input but returned the trimmed one (`a592f28`)

`" /Users/victim"` passed validation and was persisted as `"/Users/victim"`. Nothing escaped the vault — `handleSave()` re-checks the joined path — but the settings dialog accepted a value that made every later save fail with a bare "Invalid file path", unfixable from the popup because the same input kept validating.

### 4. `chore(deps-dev)`: js-yaml 4.2.0 → 4.3.0 (`0c3ef43`)

Lockfile only, transitive dev dependency via `@commitlint/cli`. No production dependency affected.

## Test plan

All gates run locally on the final commit:

- [x] `npm run build` — `tsc --noEmit` 0 errors, `vite build` succeeds
- [x] `npm run lint` — 0 errors; warnings **4 → 3** (`lookupExistingFile` complexity 16 resolved by helper extraction)
- [x] `npm run format:check` — clean
- [x] `npm run test` — **1248 passed** (+10; each fix written test-first, RED verified before implementing)
- [x] `npm run test:coverage` — 96.13 / 87.17 / 98.67 / 97.43, all four new thresholds met
- [x] Original repro re-run end-to-end against `lookupExistingFile` (output above)

Remaining manual check, since jsdom cannot exercise it:

- [ ] Load `dist/` in Chrome and save a Gemini conversation with a generated image to a real vault, confirming the image still lands and the note body embeds it

## Notes

- Not included: the official Obsidian Local REST API exposes a `/search/` endpoint (JsonLogic) that could resolve the frontmatter-id lookup in a single request instead of a directory walk. Out of scope here; worth considering as a follow-up.
- Squash merge collapses these into one changelog entry, as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)