### PR TITLE
fix: keep the localized store description within Chrome's 132-character limit

### DIFF
--- a/scripts/lint-platforms.mjs
+++ b/scripts/lint-platforms.mjs
@@ -25,10 +25,14 @@ const HOST_DISPLAY_NAMES = {
   'claude.ai': 'Claude',
   'chatgpt.com': 'ChatGPT',
   'www.perplexity.ai': 'Perplexity',
-  // Google rebranded NotebookLM to "Gemini Notebook" and moved the host.
-  // Both hosts stay listed while the old one still redirects (ADR-023).
+  // Google rebranded NotebookLM to "Gemini Notebook" and moved the host. Both
+  // hosts stay listed while the old one still redirects (ADR-023), and both
+  // serve the *same* product, so both map to the current brand name. Requiring
+  // the retired "NotebookLM" name here would force it into every description,
+  // including the store's 132-character extDescription (see
+  // test/arch/store-listing-limits.test.ts).
   'notebook.google.com': 'Gemini Notebook',
-  'notebooklm.google.com': 'NotebookLM',
+  'notebooklm.google.com': 'Gemini Notebook',
 };
 
 // Check targets: each entry defines a file and what to look for.

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name shown in browser"
   },
   "extDescription": {
-    "message": "Export AI conversations from Gemini, Claude, ChatGPT, Perplexity, and Gemini Notebook (formerly NotebookLM) to Obsidian via Local REST API",
+    "message": "Export AI conversations from Gemini, Claude, ChatGPT, Perplexity, and Gemini Notebook to Obsidian via Local REST API",
     "description": "Extension description shown in browser and store"
   },
 

--- a/test/arch/store-listing-limits.test.ts
+++ b/test/arch/store-listing-limits.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Fitness function: Chrome Web Store field limits.
+ *
+ * The store rejects a package upload outright when a localized manifest field
+ * exceeds its limit — the failure surfaces only at upload time, after a release
+ * has already been tagged. v2.4.0 shipped a 138-character `en` extDescription
+ * (limit 132) and could not be published.
+ *
+ * Limits are per *locale*, so every file under src/_locales must be checked,
+ * not just the default one.
+ *
+ * @see https://developer.chrome.com/docs/extensions/reference/manifest/name
+ * @see https://developer.chrome.com/docs/extensions/reference/manifest/description
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const localesDir = path.join(root, 'src/_locales');
+
+/** Chrome Web Store maximum lengths for localized manifest fields. */
+const FIELD_LIMITS: Record<string, number> = {
+  extName: 45,
+  extDescription: 132,
+};
+
+interface LocaleMessages {
+  [key: string]: { message?: string } | undefined;
+}
+
+const locales = fs
+  .readdirSync(localesDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory())
+  .map(entry => entry.name);
+
+describe('architecture: Chrome Web Store field limits', () => {
+  it('discovers at least one locale', () => {
+    expect(locales.length).toBeGreaterThan(0);
+  });
+
+  describe.each(locales)('locale %s', locale => {
+    const messages = JSON.parse(
+      fs.readFileSync(path.join(localesDir, locale, 'messages.json'), 'utf-8')
+    ) as LocaleMessages;
+
+    it.each(Object.entries(FIELD_LIMITS))(
+      '%s stays within its %i-character store limit',
+      (field, limit) => {
+        const message = messages[field]?.message;
+        expect(message, `${locale}/messages.json is missing ${field}`).toBeDefined();
+        expect(
+          message!.length,
+          `${locale} ${field} is ${message!.length} chars; the store rejects uploads over ${limit}`
+        ).toBeLessThanOrEqual(limit);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

v2.4.0 could not be uploaded to the Chrome Web Store: the `en` `extDescription` was **138 characters against the store's 132-character limit**, so the package was rejected outright.

The overflow came from appending `(formerly NotebookLM)` while documenting the rebrand in #382. That string is a **manifest field**, not prose — and nothing checked its length, so it passed lint, tests, build, and CI, and only failed at upload time after 2.4.0 was already tagged.

- **`en` extDescription: 138 → 116 chars.** The parenthetical is dropped from this field only.
- **`lint-platforms.mjs`: both NotebookLM hosts now map to `Gemini Notebook`.** They serve the same product — the legacy host is just an old URL. Requiring the retired name there would force `NotebookLM` back into every checked description, including the one field that cannot afford it.
- The READMEs and both store long descriptions still say "formerly NotebookLM", where discoverability matters and no length limit applies.

### New fitness function

`test/arch/store-listing-limits.test.ts` checks `extName` (45) and `extDescription` (132) against the store's limits **for every locale** under `src/_locales` — limits are per-locale, so checking only the default one would have missed this. Written RED first: it reproduced the exact upload error (`en extDescription is 138 chars; the store rejects uploads over 132`) before the fix.

## Test plan

- [x] `npm run test` — 1336 passed / 66 files (was 1331/65; +5 from the new fitness function)
- [x] New test verified RED before the fix, GREEN after
- [x] `npm run lint` — 0 errors; platform lint reports all 7 files consistent
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] Final lengths: `en` 116/132, `ja` 106/132, `extName` 20/45 both locales
- [ ] Re-upload the package to the Chrome Web Store and confirm it is accepted

## Note

The store's **host permission justification** field also needs updating for this release (it still says "Seven host permissions" and lists only `notebooklm.google.com`). That text lives solely in the store dashboard and is not version-controlled, which is why it drifted — worth tracking in `docs/store/` as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)