### PR TITLE
refactor: resolve every extractor's host through the platform registry

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -43,13 +43,20 @@ import { throttle } from '../lib/throttle';
 /**
  * Platform-specific main content container selectors for optimized observation.
  * Keyed by AIPlatform so the compiler enforces an entry per platform (ADR-014).
+ *
+ * Each list is tried in order, falling back to document.body. The former
+ * second entries (`#app-container` for the Google properties, `#__next` for the
+ * React ones) were verified absent on all five platforms in 2026-07 — and they
+ * could only ever be consulted when `<main>` is missing, which is precisely
+ * when they are missing too. They are dropped rather than left as reassurance
+ * that does nothing; the document.body fallback below is the real safety net.
  */
 const PLATFORM_ROOT_SELECTORS: Record<AIPlatform, string[]> = {
-  gemini: ['main', '#app-container'],
-  claude: ['main', '#__next'],
-  chatgpt: ['main', '#__next'],
-  perplexity: ['main', '#__next'],
-  notebooklm: ['main', '#app-container'],
+  gemini: ['main'],
+  claude: ['main'],
+  chatgpt: ['main'],
+  perplexity: ['main'],
+  notebooklm: ['main'],
 };
 
 /**

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -23,6 +23,7 @@ import {
   PLATFORM_LABELS,
 } from '../../lib/constants';
 import { accumulateWhileScrolling, type HarvestEntry } from '../../lib/scroll-manager';
+import { platformForHost } from '../../lib/platform-registry';
 
 /**
  * Per-platform configuration for accumulating a virtualized conversation
@@ -47,10 +48,27 @@ export abstract class BaseExtractor implements IConversationExtractor {
   /** Whether to auto-scroll to load lazily-rendered history (set from settings). */
   enableAutoScroll = false;
 
-  abstract canExtract(): boolean;
   abstract getConversationId(): string | null;
   abstract getTitle(): string;
   abstract extractMessages(): ConversationMessage[];
+
+  /**
+   * Check whether this extractor handles the current page.
+   *
+   * Resolved from PLATFORM_REGISTRY rather than a per-extractor hostname
+   * literal: a host written down twice is a host that can go stale in one
+   * place, which is exactly how the NotebookLM rebrand broke extraction
+   * (ADR-023). Platforms served from several hosts work automatically.
+   *
+   * IMPORTANT: platformForHost() compares each candidate with strict equality,
+   * which prevents subdomain attacks like "evil-claude.ai.attacker.com"
+   * (NFR-001-1; CodeQL js/incomplete-url-substring-sanitization).
+   *
+   * Overridable for platforms that need more than a host match.
+   */
+  canExtract(): boolean {
+    return platformForHost(window.location.hostname) === this.platform;
+  }
 
   // ========== Platform Label ==========
 

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -31,19 +31,6 @@ export class ChatGPTExtractor extends BaseExtractor {
     this.enableAutoScroll = settings.enableAutoScroll ?? false;
   }
 
-  // ========== Platform Detection ==========
-
-  /**
-   * Check if this extractor can handle the current page
-   *
-   * IMPORTANT: Uses strict comparison (===) to prevent
-   * subdomain attacks like "evil-chatgpt.com.attacker.com"
-   * @see NFR-001-1 in design document
-   */
-  canExtract(): boolean {
-    return window.location.hostname === 'chatgpt.com';
-  }
-
   // ========== ID & Title Extraction ==========
 
   /**

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -37,17 +37,6 @@ export class ClaudeExtractor extends BaseExtractor {
   // ========== Platform Detection ==========
 
   /**
-   * Check if this extractor can handle the current page
-   *
-   * IMPORTANT: Uses strict comparison (===) to prevent
-   * subdomain attacks like "evil-claude.ai.attacker.com"
-   * @see NFR-001-1 in design document
-   */
-  canExtract(): boolean {
-    return window.location.hostname === 'claude.ai';
-  }
-
-  /**
    * Check if a Deep Research / Artifact report is the actively-viewed panel.
    *
    * Detects the #markdown-artifact element, but presence alone is not enough:

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -41,13 +41,6 @@ export class GeminiExtractor extends BaseExtractor {
   }
 
   /**
-   * Check if this extractor can handle the current page
-   */
-  canExtract(): boolean {
-    return window.location.hostname === 'gemini.google.com';
-  }
-
-  /**
    * Check if Deep Research panel is currently visible
    */
   isDeepResearchVisible(): boolean {

--- a/src/content/extractors/notebooklm.ts
+++ b/src/content/extractors/notebooklm.ts
@@ -15,7 +15,6 @@
 
 import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
-import { platformForHost } from '../../lib/platform-registry';
 import type { ConversationMessage } from '../../lib/types';
 import { createFootnoteRef, footnoteDefsToHtml, transformCitations } from './footnotes';
 import type { CitationTransformResult } from './footnotes';
@@ -105,29 +104,12 @@ function transformCitationsToFootnotes(
 export class NotebookLMExtractor extends BaseExtractor {
   readonly platform = 'notebooklm';
 
-  // ========== Platform Detection ==========
-
-  /**
-   * Check if this extractor can handle the current page
-   *
-   * Delegates to the platform registry so the accepted hosts stay in one
-   * place: this platform is served from both notebook.google.com and the
-   * legacy notebooklm.google.com (ADR-023).
-   *
-   * IMPORTANT: platformForHost() compares each candidate with strict equality,
-   * which prevents subdomain attacks like
-   * "evil-notebook.google.com.attacker.com".
-   */
-  canExtract(): boolean {
-    return platformForHost(window.location.hostname) === this.platform;
-  }
-
   // ========== ID & Title Extraction ==========
 
   /**
    * Extract notebook ID from URL
    *
-   * URL format: https://notebooklm.google.com/notebook/{uuid}
+   * URL format: https://notebook.google.com/notebook/{uuid}
    * @returns UUID string or null if not found
    */
   getConversationId(): string | null {
@@ -147,7 +129,7 @@ export class NotebookLMExtractor extends BaseExtractor {
     if (titleEl?.textContent) {
       return this.sanitizeText(titleEl.textContent);
     }
-    return 'Untitled NotebookLM Conversation';
+    return 'Untitled Gemini Notebook Conversation';
   }
 
   // ========== Message Extraction ==========

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -182,18 +182,6 @@ type TaggedElement =
 export class PerplexityExtractor extends BaseExtractor {
   readonly platform = 'perplexity';
 
-  // ========== Platform Detection ==========
-
-  /**
-   * Check if this extractor can handle the current page
-   *
-   * IMPORTANT: Uses strict comparison (===) to prevent
-   * subdomain attacks like "evil-www.perplexity.ai.attacker.com"
-   */
-  canExtract(): boolean {
-    return window.location.hostname === 'www.perplexity.ai';
-  }
-
   // ========== ID & Title Extraction ==========
 
   /**

--- a/src/content/extractors/selectors/notebooklm.ts
+++ b/src/content/extractors/selectors/notebooklm.ts
@@ -1,5 +1,5 @@
 /**
- * CSS Selectors for NotebookLM (notebooklm.google.com)
+ * CSS Selectors for Gemini Notebook (notebook.google.com, formerly NotebookLM)
  *
  * Selectors are ordered by stability (HIGH → LOW).
  * NotebookLM uses Angular Material with custom elements

--- a/test/arch/host-literal-ssot.test.ts
+++ b/test/arch/host-literal-ssot.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Fitness function: hostnames live only in the platform registry (ADR-014, ADR-023).
+ *
+ * The NotebookLM rebrand broke extraction because a hostname was written down
+ * twice — once in src/manifest.json and again in the extractor's canExtract().
+ * Updating the manifest alone left the extractor rejecting the very page it had
+ * just been granted access to.
+ *
+ * PLATFORM_REGISTRY is the single source of truth, and content/bootstrap.ts and
+ * BaseExtractor.canExtract() both resolve hosts through platformForHost(). This
+ * check proves no extractor has quietly reintroduced its own copy.
+ *
+ * The manifest is the one legitimate duplicate — it cannot import TypeScript —
+ * and test/arch/platform-ssot.test.ts guards that seam separately.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const extractorsDir = path.join(root, 'src/content/extractors');
+
+/** Every .ts file under src/content/extractors, including selectors/. */
+function collectSources(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectSources(full);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
+  });
+}
+
+const sources = collectSources(extractorsDir);
+
+/**
+ * Strip comments so documenting a host in prose ("formerly notebooklm.google.com")
+ * stays allowed — only executable code is inspected.
+ */
+function stripComments(code: string): string {
+  return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('architecture: hostnames are not duplicated into extractors', () => {
+  it('finds extractor sources to check', () => {
+    expect(sources.length).toBeGreaterThan(0);
+  });
+
+  it.each(sources.map(f => path.relative(root, f)))(
+    '%s does not compare window.location.hostname directly',
+    rel => {
+      const code = stripComments(fs.readFileSync(path.join(root, rel), 'utf-8'));
+      const offenders = code.match(/location\.hostname\s*[=!]==/g) ?? [];
+      expect(
+        offenders,
+        `${rel} compares location.hostname itself — resolve the platform via platformForHost() instead`
+      ).toEqual([]);
+    }
+  );
+});

--- a/test/extractors/can-extract.test.ts
+++ b/test/extractors/can-extract.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Cross-platform canExtract() contract (ADR-014, ADR-023).
+ *
+ * Every extractor answers "is this my page?" from PLATFORM_REGISTRY rather than
+ * a hostname literal of its own. Before this was centralised, the NotebookLM
+ * rebrand broke extraction because the manifest and the extractor each carried
+ * their own copy of the host.
+ *
+ * The suite is driven by the registry itself, so a new platform — or a new host
+ * on an existing platform — is covered the moment it is registered.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { GeminiExtractor } from '../../src/content/extractors/gemini';
+import { ClaudeExtractor } from '../../src/content/extractors/claude';
+import { ChatGPTExtractor } from '../../src/content/extractors/chatgpt';
+import { PerplexityExtractor } from '../../src/content/extractors/perplexity';
+import { NotebookLMExtractor } from '../../src/content/extractors/notebooklm';
+import { PLATFORM_REGISTRY, ALL_PLATFORMS } from '../../src/lib/platform-registry';
+import type { AIPlatform, IConversationExtractor } from '../../src/lib/types';
+import { resetLocation } from '../fixtures/dom-helpers';
+
+/**
+ * Keyed by AIPlatform so the compiler demands an entry when the union grows —
+ * the same exhaustiveness guard EXTRACTOR_CONSTRUCTORS uses in content/bootstrap.ts.
+ */
+const EXTRACTOR_FACTORIES: Record<AIPlatform, () => IConversationExtractor> = {
+  gemini: () => new GeminiExtractor(),
+  claude: () => new ClaudeExtractor(),
+  chatgpt: () => new ChatGPTExtractor(),
+  perplexity: () => new PerplexityExtractor(),
+  notebooklm: () => new NotebookLMExtractor(),
+};
+
+function setHostname(hostname: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { hostname, pathname: '/', href: `https://${hostname}/`, search: '', hash: '' },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/** Hostnames that embed a real host but must never be accepted. */
+function lookalikesFor(host: string): string[] {
+  return [`evil-${host}.attacker.com`, `${host}.attacker.com`, `sub.${host}`, `attacker.com`];
+}
+
+afterEach(() => {
+  resetLocation();
+});
+
+describe('canExtract() is derived from the platform registry', () => {
+  describe.each(ALL_PLATFORMS)('%s', platform => {
+    const createExtractor = EXTRACTOR_FACTORIES[platform];
+    const { hosts } = PLATFORM_REGISTRY[platform];
+
+    it.each(hosts)('accepts its registered host %s', host => {
+      setHostname(host);
+      expect(createExtractor().canExtract()).toBe(true);
+    });
+
+    it('rejects every other platform’s hosts', () => {
+      const foreignHosts = ALL_PLATFORMS.filter(p => p !== platform).flatMap(
+        p => PLATFORM_REGISTRY[p].hosts
+      );
+      for (const host of foreignHosts) {
+        setHostname(host);
+        expect(createExtractor().canExtract(), `${platform} accepted ${host}`).toBe(false);
+      }
+    });
+
+    it.each(lookalikesFor(hosts[0]))('rejects lookalike hostname %s', hostname => {
+      setHostname(hostname);
+      expect(createExtractor().canExtract()).toBe(false);
+    });
+
+    it('rejects an unrelated host', () => {
+      setHostname('localhost');
+      expect(createExtractor().canExtract()).toBe(false);
+    });
+  });
+});

--- a/test/extractors/notebooklm.test.ts
+++ b/test/extractors/notebooklm.test.ts
@@ -112,7 +112,7 @@ describe('NotebookLMExtractor', () => {
     it('falls back to default when .cover-title is absent', () => {
       setNotebookLMLocation('test-id');
       loadFixture('<div></div>');
-      expect(extractor.getTitle()).toBe('Untitled NotebookLM Conversation');
+      expect(extractor.getTitle()).toBe('Untitled Gemini Notebook Conversation');
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #382, which noted this as deliberately out of scope. Closes items 3, 4 and 5 from the post-rebrand review.

The NotebookLM rebrand broke extraction because a hostname was written down **twice** — once in `src/manifest.json`, once in the extractor's `canExtract()`. Granting the new host in the manifest left the extractor rejecting the very page it had just been given access to. Four extractors still carried their own copy of that literal.

- **`BaseExtractor.canExtract()` is no longer abstract.** It resolves the platform via `platformForHost()` and compares to `this.platform`, so the registry is the only place a host is written and multi-host platforms work for free. Still overridable; all five extractors were one-line host checks, so all five overrides are deleted.
- **`PLATFORM_ROOT_SELECTORS` drops its second entries** (`#app-container`, `#__next`) — see measurements below.
- Two stale `notebooklm` comments refreshed.
- **User-visible:** the fallback note title becomes `Untitled Gemini Notebook Conversation`. Append-mode is unaffected — existing notes are matched by conversation-id suffix, not title (`append-utils.ts:121-123`).

Net: **−36 lines in `src/`**, 5 host literals removed.

### Live measurements behind the selector removal

Measured on the real pages before touching the code. `main` is tried first and `document.body` is the final fallback, so a second entry can only ever be consulted when `<main>` is missing — which is exactly when it is missing too.

| Platform | `main` | 2nd selector |
|---|---|---|
| gemini.google.com/app | 1 | `#app-container` **0** |
| notebook.google.com/notebook/{id} | 1 | `#app-container` **0** |
| claude.ai/new | 1 | `#__next` **0** |
| chatgpt.com/ | 1 | `#__next` **0** |
| www.perplexity.ai/ | 1 | `#__next` **0** |

### Two new fitness functions

- **`test/arch/host-literal-ssot.test.ts`** — proves no extractor reintroduces a `location.hostname` comparison. Comments are stripped before the scan, so documenting an old host in prose stays allowed. **Verified RED first**: failed on exactly the 4 offending extractors, passed on `notebooklm.ts` which already delegated.
- **`test/extractors/can-extract.test.ts`** — drives the behavioural contract from the registry itself: every registered host accepted, every other platform's hosts rejected, lookalikes (`evil-claude.ai.attacker.com`, `sub.chatgpt.com`, …) rejected (NFR-001-1). This suite was **green before and after** — that is the point of it: it is the proof the refactor changed no behaviour.

## Test plan

- [x] `npm run test` — 1387 passed / 68 files (was 1336/66; +51 from the two new suites)
- [x] Structural test verified RED before the change, GREEN after
- [x] Behavioural `can-extract` suite green before *and* after (no behaviour change)
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors (3 pre-existing warnings in untouched code paths)
- [x] `npm run build` — succeeds
- [x] Coverage unchanged: 96.24% stmt / 87.25% branch / 98.93% func / 97.41% line
- [ ] Manual smoke: sync one conversation per platform and confirm the Sync button still injects

🤖 Generated with [Claude Code](https://claude.com/claude-code)