### PR TITLE
feat: version-control the Chrome Web Store dashboard text

### DIFF
--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -1,0 +1,156 @@
+# Chrome Web Store dashboard fields
+
+The Privacy tab of the Chrome Web Store Developer Dashboard holds free text that
+no build step reads. It rots silently, and the damage surfaces only at review
+time. Two instances landed on the same day (2026-07-29):
+
+- the host permission justification still said "Seven host permissions" and
+  named only `notebooklm.google.com`, a full release after the rebrand;
+- the single purpose description had listed four platforms ever since NotebookLM
+  shipped in [#206](https://github.com/sho7650/obsidian-AI-exporter/pull/206)
+  (2026-04-09), while the manifest requested host permissions for five.
+
+**This file is the source of truth. The dashboard is synced _from_ it, never the
+other way round.** `test/arch/store-listing-fields.test.ts` proves each field
+fits its limit, that every manifest permission is justified and nothing else is,
+that the host justification names every host in the manifest, and that the
+single purpose covers every registered platform.
+
+## Why the single purpose matters more than it looks
+
+The dashboard states: _"Remove any permissions that are not necessary for your
+extension's single purpose. If you request unnecessary permissions, this version
+will be rejected."_ Whether a permission is *necessary* is judged against the
+single purpose, so a platform missing from that sentence turns its host
+permission into an unjustified one.
+
+## How to update
+
+1. Edit the field below. Keep the fenced block byte-exact — it is pasted verbatim.
+2. Run `npm run test -- store-listing` and fix anything it reports.
+3. Paste each changed field into the dashboard.
+4. Confirm the dashboard's character counter matches the count noted here. A
+   mismatch means the paste was truncated.
+5. Update **Last synced** below.
+
+**Last synced:** 2026-07-29, extension v2.4.1 — except `single_purpose`, which
+is corrected here and **still needs pasting into the dashboard**. The live value
+omits Gemini Notebook.
+
+---
+
+## Single purpose description
+
+Dashboard field: 単一用途の説明 / "Single purpose description". Limit 1000.
+
+<!-- field: single_purpose, limit: 1000 -->
+
+```text
+Export and save Gemini, Claude, ChatGPT, Perplexity AI, and Gemini Notebook conversations locally as Markdown notes - to Obsidian, as files, or to clipboard.
+```
+
+157 characters. The live dashboard value is 140 characters and names only four
+platforms; this corrected text adds Gemini Notebook.
+
+---
+
+## Permission justifications
+
+One per entry in `manifest.permissions`. Limit 1000 each.
+
+### `storage`
+
+<!-- field: permission.storage, limit: 1000 -->
+
+```text
+The extension uses chrome.storage to save user preferences:
+- chrome.storage.local: Stores the Obsidian API key securely on the user's device only (never synced)
+- chrome.storage.sync: Stores non-sensitive settings (vault path, template preferences) to sync across the user's Chrome browsers
+
+No conversation content and no personal data are stored here, and none are sent to any third-party service.
+```
+
+400 characters — matches the live dashboard value.
+
+### `downloads`
+
+<!-- field: permission.downloads, limit: 1000 -->
+
+```text
+The extension allows users to download conversation exports as local files when Obsidian is not available. This provides a fallback option to save conversations as .md (Markdown) files directly to the user's computer. Downloads are user-initiated only.
+```
+
+252 characters — matches the live dashboard value.
+
+### `offscreen`
+
+<!-- field: permission.offscreen, limit: 1000 -->
+
+```text
+The extension uses the offscreen API to process clipboard operations in the background when the user chooses to copy conversation content. This is required because clipboard access from service workers requires an offscreen document. Used only for user-initiated copy actions.
+```
+
+276 characters — matches the live dashboard value.
+
+### `clipboardWrite`
+
+<!-- field: permission.clipboardWrite, limit: 1000 -->
+
+```text
+The extension allows users to copy exported conversation content to their clipboard as an alternative output option. This is entirely user-initiated via a "Copy to Clipboard" button. No automatic clipboard access occurs.
+```
+
+220 characters — matches the live dashboard value.
+
+---
+
+## Host permission justification
+
+Dashboard field: ホスト権限が必要な理由 / "Host permission justification". Limit 1000.
+
+Must name every entry in `manifest.host_permissions`. The `127.0.0.1` HTTP and
+HTTPS entries are one justification; the numbering is for the reviewer, not the
+manifest.
+
+<!-- field: host_permissions, limit: 1000 -->
+
+```text
+Eight host permissions are required:
+
+1. gemini.google.com - inject the "Sync to Obsidian" button and read conversation content from Gemini pages. Read-only.
+2-6. claude.ai, chatgpt.com, www.perplexity.ai, notebook.google.com (Gemini Notebook) and notebooklm.google.com (its former host, still redirected there) - the same button and read-only access, on those sites.
+
+7. *.googleusercontent.com - download AI-generated images so they can be saved with the conversation, when the user turns on image export. This is the same Google image CDN the AI page already loads them from; Chrome blocks the page from fetching them, so the extension does it. Images only: no conversation content or user data is sent.
+
+8. 127.0.0.1 (localhost, HTTP and HTTPS) - communicate with Obsidian's Local REST API plugin on the user's own machine, saving conversations to their vault.
+
+Conversation content is never sent to a third party; it goes only to the user's own Obsidian instance. No analytics or telemetry.
+```
+
+995 characters — matches the live dashboard value. Only 5 characters of headroom
+remain: adding a host will require compressing this text, not just appending to
+it.
+
+---
+
+## Privacy policy
+
+<https://sho7650.github.io/obsidian-AI-exporter/privacy.html> — published from
+[`docs/privacy.html`](../privacy.html).
+
+---
+
+## Not yet captured
+
+These dashboard fields are **not** recorded here because their current values
+have not been read. They are deliberately left blank rather than guessed, since
+a wrong value here would be pasted into a review submission.
+
+- **Remote code** (リモートコード) — the declared answer and any justification.
+- **Data usage** (データ使用) — which data-type checkboxes are ticked, and the
+  compliance certifications.
+- **Store listing tab** — category, screenshots, promo assets. Only the long
+  descriptions are tracked, in `description_en.md` / `description_ja.md`.
+
+Capture them the next time the dashboard is open, then extend
+`test/arch/store-listing-fields.test.ts` to cover whatever gains a length limit.

--- a/scripts/lint-platforms.mjs
+++ b/scripts/lint-platforms.mjs
@@ -40,6 +40,10 @@ const HOST_DISPLAY_NAMES = {
 // "displayName" checks parse a specific JSON field and look for the display name (case-insensitive).
 const CHECK_TARGETS = [
   { file: 'docs/privacy.html', type: 'hostname' },
+  // Chrome Web Store dashboard text (docs/store/listing.md). Field-level checks
+  // live in test/arch/store-listing-fields.test.ts; this only proves every host
+  // is named somewhere in the file.
+  { file: 'docs/store/listing.md', type: 'hostname' },
   { file: 'README.md', type: 'hostname' },
   { file: 'README.ja.md', type: 'hostname' },
   { file: 'CLAUDE.md', type: 'hostname' },

--- a/test/arch/store-listing-fields.test.ts
+++ b/test/arch/store-listing-fields.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Fitness function: the Chrome Web Store dashboard text is version-controlled
+ * and consistent with the manifest.
+ *
+ * The dashboard's Privacy tab holds free text that no build step ever reads, so
+ * it rots silently and the damage only appears at review time. Two instances in
+ * a single day (2026-07-29):
+ *
+ *   - the host permission justification still said "Seven host permissions" and
+ *     named only notebooklm.google.com, one release after the rebrand;
+ *   - the single purpose description had listed four platforms since NotebookLM
+ *     shipped in #206 (2026-04-09), while the manifest requested host
+ *     permissions for five.
+ *
+ * The dashboard itself warns: "Remove any permissions that are not necessary
+ * for your extension's single purpose. If you request unnecessary permissions,
+ * this version will be rejected." Whether a permission is *necessary* is judged
+ * against the single purpose, so the two texts have to agree with the manifest
+ * and with each other.
+ *
+ * docs/store/listing.md is the source of truth; this proves it stays true.
+ *
+ * @see https://developer.chrome.com/docs/webstore/cws-dashboard-privacy
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { PLATFORM_REGISTRY, ALL_PLATFORMS } from '../../src/lib/platform-registry';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = (rel: string): string => fs.readFileSync(path.join(root, rel), 'utf-8');
+
+/**
+ * Every dashboard field is written as:
+ *
+ *   <!-- field: NAME, limit: N -->
+ *   ```text
+ *   ...the exact text pasted into the dashboard...
+ *   ```
+ */
+const FIELD_BLOCK = /<!--\s*field:\s*([\w.*-]+),\s*limit:\s*(\d+)\s*-->\s*```text\n([\s\S]*?)\n```/g;
+
+interface Field {
+  name: string;
+  limit: number;
+  text: string;
+}
+
+function parseFields(markdown: string): Field[] {
+  return [...markdown.matchAll(FIELD_BLOCK)].map(m => ({
+    name: m[1],
+    limit: Number(m[2]),
+    text: m[3],
+  }));
+}
+
+interface Manifest {
+  permissions: string[];
+  host_permissions: string[];
+}
+
+const manifest = JSON.parse(read('src/manifest.json')) as Manifest;
+const fields = parseFields(read('docs/store/listing.md'));
+const byName = new Map(fields.map(f => [f.name, f]));
+
+/** Hosts as a reviewer sees them, with the manifest's scheme/glob stripped. */
+const manifestHosts = manifest.host_permissions.map(p =>
+  p.replace(/^https?:\/\//, '').replace(/\/\*$/, '')
+);
+
+describe('architecture: store listing fields are version-controlled', () => {
+  it('parses every field block in docs/store/listing.md', () => {
+    expect(fields.length).toBeGreaterThan(0);
+  });
+
+  it.each(fields.map(f => [f.name, f] as const))('%s stays within its limit', (_name, field) => {
+    expect(
+      field.text.length,
+      `${field.name} is ${field.text.length} chars; the dashboard caps it at ${field.limit}`
+    ).toBeLessThanOrEqual(field.limit);
+  });
+
+  it.each(manifest.permissions)('declares a justification for the %s permission', permission => {
+    expect(
+      byName.get(`permission.${permission}`),
+      `add a "permission.${permission}" field to docs/store/listing.md`
+    ).toBeDefined();
+  });
+
+  it('justifies no permission the manifest does not request', () => {
+    const justified = fields
+      .map(f => f.name)
+      .filter(n => n.startsWith('permission.'))
+      .map(n => n.slice('permission.'.length));
+    expect(justified.sort()).toEqual([...manifest.permissions].sort());
+  });
+
+  it.each(manifestHosts)('the host permission justification mentions %s', host => {
+    const field = byName.get('host_permissions');
+    expect(field, 'add a "host_permissions" field to docs/store/listing.md').toBeDefined();
+    expect(
+      field!.text.includes(host),
+      `host permission justification never mentions ${host}`
+    ).toBe(true);
+  });
+
+  it.each(ALL_PLATFORMS)('the single purpose description covers %s', platform => {
+    const field = byName.get('single_purpose');
+    expect(field, 'add a "single_purpose" field to docs/store/listing.md').toBeDefined();
+    const { label, labelAliases = [] } = PLATFORM_REGISTRY[platform];
+    const names = [label, ...labelAliases];
+    expect(
+      names.some(name => field!.text.toLowerCase().includes(name.toLowerCase())),
+      `single purpose names none of ${names.join(' / ')} — a reviewer judges whether a ` +
+        `host permission is necessary against this text, and an unjustified permission is rejected`
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes item 9 from the post-rebrand review. The Privacy tab of the CWS dashboard holds free text that **no build step reads**, so it rots silently and the damage surfaces only at review time. Two instances landed on the same day (2026-07-29):

- the host permission justification still said "Seven host permissions" and named only `notebooklm.google.com`, a full release after the rebrand;
- the single purpose description had listed four platforms ever since NotebookLM shipped in #206 (**2026-04-09**), while the manifest requested host permissions for five.

`docs/store/listing.md` becomes the source of truth; the dashboard is synced **from** it. It records the single purpose, all four permission justifications, the host permission justification, and the privacy policy URL.

**Every text was transcribed from the dashboard and verified byte-exact against the character counter shown beside each field** — 140 / 400 / 252 / 276 / 220 / 995, all matching. That check is the reason this PR can claim the file is accurate rather than approximately right.

### The guard

`test/arch/store-listing-fields.test.ts` parses the fields out of the file and proves:

- each field fits its limit;
- every `manifest.permissions` entry has a justification, **and nothing else does**;
- the host justification names every entry in `manifest.host_permissions`;
- the single purpose covers every platform in `PLATFORM_REGISTRY`.

**Both real failures were replayed against it, and both are caught:**

| Replayed regression | Failing test |
|---|---|
| The live (4-platform) single purpose | `× the single purpose description covers notebooklm` |
| This morning's "Seven host permissions" text | `× the host permission justification mentions notebook.google.com` |

The single-purpose check is not cosmetic. The dashboard warns that permissions not necessary for the stated single purpose cause the version to be **rejected**, and necessity is judged against that sentence — so a platform missing from it turns its host permission into an unjustified one.

### ⚠️ Action still required outside this repo

`single_purpose` is recorded here **in corrected form**, naming Gemini Notebook (157 chars). **The live dashboard value is the old 140-char text and still needs pasting.** This is pre-existing drift dating to 2026-04-09, not a regression from the rebrand work — the rebrand only made it visible, by putting "Gemini Notebook" into the host justification in the same form.

### Deliberately not captured

Remote code, data usage checkboxes, and the store-listing assets are listed as **not captured** rather than guessed. Their current values were never read, and a wrong value here would be pasted into a review submission.

## Test plan

- [x] `npm run test` — 1413 passed / 69 files (was 1387/68; +26 from the new guard)
- [x] Guard verified RED against both real regressions, then restored to GREEN
- [x] Every recorded field verified byte-exact against its dashboard character counter
- [x] `npm run lint` — 0 errors; platform lint now covers 8 files including `listing.md`
- [x] `npx tsc --noEmit` — 0 errors
- [ ] Paste the corrected `single_purpose` into the dashboard and confirm the counter reads 157
- [ ] Capture remote code / data usage values on the next dashboard visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)