### PR TITLE
fix: count upward scroll movement as accumulation progress

### DIFF
--- a/docs/adr/018-progress-aware-scroll-deadline.md
+++ b/docs/adr/018-progress-aware-scroll-deadline.md
@@ -3,6 +3,9 @@
 - Status: Proposed
 - Date: 2026-07-22
 - Related: [ADR-017](017-autoscroll-virtualized-platforms.md), issue #360
+- Extended by: [ADR-024](024-scroll-progress-includes-movement.md) — the
+  "progress" signal defined here counts only new turns, which mis-classifies the
+  traversal of a single viewport-dwarfing turn as a stuck scroller (issue #365)
 - Supersedes/extends: the fixed `SCROLL_TIMEOUT` wall in `src/lib/scroll-manager.ts`
 
 ## Context

--- a/docs/adr/024-scroll-progress-includes-movement.md
+++ b/docs/adr/024-scroll-progress-includes-movement.md
@@ -1,0 +1,133 @@
+# ADR-024: Upward scroll movement counts as accumulation progress
+
+- Status: Proposed
+- Date: 2026-08-02
+- Related: [ADR-017](017-autoscroll-virtualized-platforms.md), [ADR-018](018-progress-aware-scroll-deadline.md), issue #365
+- Extends: the progress-aware deadline introduced by ADR-018
+
+## Context
+
+ADR-018 replaced the fixed 30s accumulation wall with a progress-aware deadline:
+a pass stays live while it keeps making progress, where **progress was defined
+as "an iteration surfaced a new turn"**. That definition rests on an assumption
+stated in ADR-018's own Context — "Claude mounts ~6 turns per window and
+advances ~1 turn per iteration" — i.e. that turn heights are roughly uniform.
+
+A single turn taller than the viewport breaks the assumption. The virtualized
+engine keys turns by the platform's own row identity (Claude's `data-index`,
+ChatGPT's `conversation-turn-N`), so while the engine crawls upward *through*
+one tall turn, every harvest returns the same key. By construction such a turn
+surfaces no progress, and the idle deadline mis-classifies "traversing a tall
+turn" as "the scroller is stuck".
+
+That makes the failure a distance problem with a computable threshold:
+
+```
+step                        = max(400, floor(clientHeight × 0.6))
+iterations in the idle window = SCROLL_IDLE_TIMEOUT / SCROLL_ACCUMULATE_POLL_INTERVAL
+max traversable without a new turn = iterations × step
+```
+
+Measured against live Claude through the CDP daemon (2026-08-02, 1440×900
+viewport, `.overflow-y-auto.overflow-x-hidden.flex-1`):
+
+| Quantity | Measured |
+| --- | --- |
+| `clientHeight` | 852px |
+| `step` | 511px |
+| Idle window | 15000 / 400 = 37 iterations |
+| **Max traversal without a new turn** | **18,907px** |
+| Code block rendering | 14px font, 22.75px line-height, **22.16px per line** measured |
+| **Single-turn limit** | **≈ 853 lines of code** |
+
+A ~1000-line code block therefore renders ~22,160px tall and exceeds the limit
+by ~3,250px, aborting the pass deterministically at the same place on every
+retry — exactly what was reported in #365 (Claude 2.3.0 and 2.4.1, "sync stops
+when long code blocs/answers are in the chat", repeated runs producing the
+identical 39-turn partial capture).
+
+Two further facts from the same measurement session:
+
+1. **Scroll anchoring is not involved.** Every replayed iteration moved exactly
+   the requested 511px (`scrollTop` after settle equalled the written value), so
+   the container does not push back when tall rows mount. The engine's existing
+   `scrollTop -= step` stepping is sound; only the deadline was wrong.
+2. **Background-tab throttling compounds it.** Chrome checks throttled timers
+   "once per second", and once per minute under intensive throttling for pages
+   hidden > 5 minutes (MDN, `Window/setTimeout`). A backgrounded sync therefore
+   gets far fewer than 37 iterations inside the same 15s, shrinking the
+   traversal limit to a few thousand pixels — a few hundred lines of code.
+
+## Decision
+
+Widen the progress signal in `scrollUpUntilStable()` to
+**a new turn OR a decrease in `container.scrollTop`**. Either resets
+`lastProgressTime`; the stability counter (`SCROLL_STABILITY_THRESHOLD`
+consecutive no-growth iterations while pinned at the top) continues to decide
+normal completion, unchanged.
+
+`SCROLL_IDLE_TIMEOUT` (15s) and `SCROLL_MAX_TIMEOUT` (300s) are unchanged, and
+no new constants are introduced.
+
+Additionally, `scrollUpUntilStable()` now emits one `console.debug` per
+iteration (`scrollTop`, distance moved, whether the window grew), mirroring the
+per-iteration log `ensureAllElementsLoaded()` has always had. A partial-capture
+report is otherwise undiagnosable: #365 consumed three rounds of correspondence
+because the only evidence available was the single summary line.
+
+### Why the widened signal is still bounded
+
+Upward travel is monotonically decreasing and bounded by the initial
+`scrollTop`, so "movement" cannot sustain a pass indefinitely: once the top is
+reached — or the scroller stops responding — movement ceases and the idle
+deadline resumes its ADR-018 job of detecting a genuinely stuck scroller. The
+absolute `SCROLL_MAX_TIMEOUT` still bounds the pathological case where a
+container oscillates. For the reported conversation (`scrollHeight` ≈ 121,155px)
+a full pass costs ≈ 121155 / 511 ≈ 237 iterations ≈ 95s, inside the 300s cap.
+
+### Why this is NOT applied to the Gemini engine
+
+`ensureAllElementsLoaded()` (Gemini's infinite-scroller) re-arms every iteration
+by jumping to `scrollHeight` and back to 0, so its scroll position always
+changes. Treating movement as progress there would make the predicate
+permanently true and disable the idle deadline outright, forcing every stuck
+Gemini pass to grind to the 300s cap. Gemini also does not evict turns, so the
+tall-turn failure mode cannot arise: one turn's height never gates discovery of
+the next. The change is therefore scoped to the virtualized engine only.
+
+## Consequences
+
+- Claude/ChatGPT conversations containing very tall turns (long code blocks,
+  long single answers) accumulate fully instead of truncating at the tall turn.
+- The idle deadline now measures "nothing is happening" rather than "no new
+  turn", which is what ADR-018 intended; a stuck scroller is still detected
+  within ~15s of motion stopping.
+- One test changed meaning: `stops via the idle deadline ... when stuck below
+  the top` models a scroller that travels 10,900 → 3,000 before pinning. Those
+  ~15 iterations of real movement are now progress, so the pass runs ~53
+  iterations instead of ~38. The bound was raised from `< 50` to `< 80`; the
+  assertion's purpose (idle path, not the absolute ~750-iteration cap) is
+  unchanged, and a new test pins the complementary case where the container
+  never moves at all.
+- Per-iteration `console.debug` adds ~2.5 lines/second to the page console
+  during a sync. `debug` is below Chrome DevTools' default log level, so it is
+  opt-in for users while being available in any future report.
+
+## Alternatives considered
+
+- **Adaptive step escalation** — grow `step` when an iteration yields no new
+  turn. Traverses tall turns faster, but a step larger than the overlap window
+  risks skipping short turns between two harvests, which is the exact failure
+  ADR-017's `SCROLL_ACCUMULATE_STEP_FACTOR < 1` exists to prevent. Rejected as
+  strictly riskier than fixing the deadline.
+- **Anchor-based jumping** — scroll so the topmost currently-mounted row's top
+  edge reaches the viewport bottom. Cannot skip a turn (everything below the
+  anchor is already harvested) and crosses a tall turn in one step, but it
+  requires the accumulation engine to reach into the DOM for the anchor element,
+  widening `ScrollConfig` and the extractor contract. Deferred: the deadline fix
+  is a ~15-line change that resolves the reported failure, and the measurement
+  above shows stepping itself is not the problem.
+- **Raise `SCROLL_IDLE_TIMEOUT`** — any fixed value still yields a fixed
+  traversal distance and so merely moves the breaking point to a taller turn,
+  while making every genuinely stuck scroll slower to detect. Rejected for the
+  same reason ADR-018 rejected raising `SCROLL_TIMEOUT`.

--- a/src/lib/scroll-manager.ts
+++ b/src/lib/scroll-manager.ts
@@ -20,10 +20,13 @@ import {
  * Progress-aware accumulation deadline (issue #360, ADR-018).
  *
  * A scroll pass keeps running while it is still making progress: the pass is
- * live until either no new turns have appeared for {@link SCROLL_IDLE_TIMEOUT}
+ * live until either nothing has progressed for {@link SCROLL_IDLE_TIMEOUT}
  * (a stuck/broken scroll) or the absolute {@link SCROLL_MAX_TIMEOUT} safety cap
- * is reached. Callers reset `lastProgressTime` on every iteration that surfaces
- * a new turn, so a genuinely-long conversation is never cut off mid-scroll.
+ * is reached. Callers reset `lastProgressTime` on every iteration that makes
+ * progress, so a genuinely-long conversation is never cut off mid-scroll. What
+ * counts as progress is engine-specific: newly-loaded elements for Gemini's
+ * infinite-scroller, a new turn *or* upward scroll movement for the virtualized
+ * engine (see {@link scrollUpUntilStable}).
  *
  * @param startTime When the pass began (`Date.now()`).
  * @param lastProgressTime When the pass last made progress (`Date.now()`).
@@ -375,6 +378,23 @@ function logAccumulation(fullyLoaded: boolean, turns: number, iterations: number
  * Stability is only counted once already at the top, so a mid-scroll window that
  * happens to mount nothing new doesn't end accumulation prematurely.
  *
+ * **Progress is a new turn OR upward scroll movement** (issue #365). A turn
+ * taller than the viewport mounts as a single row that stays mounted while the
+ * engine crawls up through it, so by construction it surfaces no new key — and
+ * a turn taller than `SCROLL_IDLE_TIMEOUT / poll × step` would abort the whole
+ * pass if only new turns counted. Measured on live Claude (1440×900): step is
+ * 511px and the idle window is 37 iterations, so the limit was 18,907px, while
+ * a ~1000-line code block renders ~22,160px tall (14px font, 22.75px
+ * line-height) — reliably fatal. Counting movement is safe because upward travel
+ * is monotonically decreasing and therefore finite: once the top is reached (or
+ * the scroller stops responding) movement ceases and the idle deadline resumes
+ * its original job of detecting a genuinely stuck scroll.
+ *
+ * This widened definition is deliberately NOT shared with
+ * {@link ensureAllElementsLoaded}: that engine re-arms by jumping to
+ * `scrollHeight` and back to 0 every iteration, so "the position moved" is
+ * always true there and would disable its idle deadline entirely (ADR-024).
+ *
  * @param onWindow Ingest the freshly-mounted window; return true if it grew the
  *   accumulated set. Invoked once per iteration after each scroll settles.
  */
@@ -389,16 +409,26 @@ async function scrollUpUntilStable(
   let lastProgressTime = startTime;
 
   while (withinDeadline(startTime, lastProgressTime)) {
-    const wasAtTop = container.scrollTop <= 0;
-    container.scrollTop = Math.max(0, container.scrollTop - step);
+    const before = container.scrollTop;
+    const wasAtTop = before <= 0;
+    container.scrollTop = Math.max(0, before - step);
     await delay(SCROLL_ACCUMULATE_POLL_INTERVAL);
 
     const grew = onWindow();
+    const moved = before - container.scrollTop;
     iterations++;
+
+    console.debug(
+      `[G2O] Accumulate iteration ${iterations}: scrollTop=${container.scrollTop}, ` +
+        `moved=${moved}, newTurns=${grew}`
+    );
+
+    if (grew || moved > 0) {
+      lastProgressTime = Date.now(); // progress → reset the idle deadline
+    }
 
     if (grew) {
       stable = 0;
-      lastProgressTime = Date.now(); // progress → reset the idle deadline
     } else if (wasAtTop && ++stable >= SCROLL_STABILITY_THRESHOLD) {
       return { iterations, fullyLoaded: true };
     }

--- a/test/lib/scroll-manager.test.ts
+++ b/test/lib/scroll-manager.test.ts
@@ -241,6 +241,54 @@ function createRecordedWindowList(
   return { container, harvest };
 }
 
+/**
+ * Build a virtualized list from explicit per-turn pixel heights.
+ *
+ * Unlike {@link createVirtualList} (which maps scroll *fraction* to a window of
+ * fixed size), this models the real thing: each turn occupies a real span of the
+ * scroll range, and the mounted window is whichever turns intersect the
+ * viewport. That is what makes a single very tall turn expressible — while it
+ * fills the viewport it is the *only* mounted turn, so every harvest returns the
+ * same key no matter how far the engine scrolls (issue #365).
+ *
+ * @param heights Per-turn heights in px, first turn → last turn.
+ */
+function createVirtualListByHeights(
+  heights: readonly number[],
+  clientHeight: number
+): {
+  container: HTMLElement;
+  harvest: () => Array<{ key: string; value: string; order: number }>;
+} {
+  const offsets: number[] = [];
+  let acc = 0;
+  for (const h of heights) {
+    offsets.push(acc);
+    acc += h;
+  }
+  const maxScroll = Math.max(0, acc - clientHeight);
+  let scrollTop = maxScroll; // opens at the bottom
+
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = Math.max(0, Math.min(maxScroll, v));
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, 'clientHeight', { get: () => clientHeight, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', { get: () => acc, configurable: true });
+
+  const harvest = () =>
+    heights
+      .map((h, i) => ({ i, top: offsets[i], bottom: offsets[i] + h }))
+      .filter(t => t.bottom > scrollTop && t.top < scrollTop + clientHeight)
+      .map(t => ({ key: `idx-${t.i}`, value: `v${t.i}`, order: t.i }));
+
+  return { container, harvest };
+}
+
 describe('accumulateWhileScrolling', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
@@ -324,6 +372,55 @@ describe('accumulateWhileScrolling', () => {
     expect(result.items).toEqual(Array.from({ length: 300 }, (_, i) => `v${i}`));
   });
 
+  it('captures the turns above a single viewport-dwarfing turn (issue #365)', async () => {
+    // Measured on live Claude via the CDP daemon (2026-08-02, 1440x900):
+    //   clientHeight 852 -> step = floor(852 * 0.6) = 511px
+    //   idle window     = 15_000 / 400 = 37 iterations
+    //   => at most 37 * 511 = 18_907px may be traversed without a new turn
+    //   code blocks render at 14px/22.75px line-height (measured 22.16 px/line)
+    //   => a ~1000-line code block turn is ~22_160px and blows past that limit.
+    // Crossing such a turn surfaces no new key by construction (the key is the
+    // turn's own data-index), so an idle deadline that only counts new turns as
+    // progress aborts mid-conversation and loses everything above it.
+    const TALL_TURN = 22_160;
+    const heights = [...Array(10).fill(800), TALL_TURN, ...Array(10).fill(800)];
+    const { container, harvest } = createVirtualListByHeights(heights, 852);
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.fullyLoaded).toBe(true);
+    expect(result.itemCount).toBe(21);
+    // The regression: the turns *above* the tall one must survive.
+    expect(result.items.slice(0, 10)).toEqual(Array.from({ length: 10 }, (_, i) => `v${i}`));
+  });
+
+  it('gives up when neither new turns nor the scroll position move', async () => {
+    // The counterpart guard for the fix above: widening "progress" to include
+    // scroll movement must not defeat ADR-018's stuck-scroller detection. Here
+    // the container refuses to move at all, so the idle deadline must still fire
+    // promptly rather than grinding to the absolute cap (~750 iterations).
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'scrollTop', {
+      get: () => 5_000,
+      set: () => {}, // a scroller that ignores every write
+      configurable: true,
+    });
+    Object.defineProperty(container, 'clientHeight', { get: () => 852, configurable: true });
+    Object.defineProperty(container, 'scrollHeight', { get: () => 50_000, configurable: true });
+    const window = Array.from({ length: 6 }, (_, i) => ({ key: `k${i}`, value: `v${i}` }));
+
+    const promise = accumulateWhileScrolling(container, () => window);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.fullyLoaded).toBe(false);
+    expect(result.itemCount).toBe(6);
+    // 15_000ms / 400ms ≈ 38 iterations, plus slack — nowhere near the cap.
+    expect(result.iterations).toBeLessThan(45);
+  });
+
   it('stops via the idle deadline (not the absolute cap) when stuck below the top', async () => {
     // The scroll never reaches the top and no new turns ever mount after the
     // seed window: a broken/stuck scroller. Accumulation must give up promptly
@@ -349,9 +446,12 @@ describe('accumulateWhileScrolling', () => {
 
     expect(result.fullyLoaded).toBe(false);
     expect(result.itemCount).toBe(6);
-    // Idle deadline (~15s / 400ms ≈ 38 iters) fires long before the old 30s
-    // wall (~75) or the absolute cap (~750): proves the idle path, not the cap.
-    expect(result.iterations).toBeLessThan(50);
+    // The scroller still travels 10_900 → 3_000 before pinning, i.e. ~15
+    // iterations of real upward movement, and movement is progress (issue
+    // #365). The idle deadline (~38 iters) then runs from the moment motion
+    // stops, so ~53 iterations total — still nowhere near the absolute cap
+    // (~750): this proves the idle path, not the cap.
+    expect(result.iterations).toBeLessThan(80);
   });
 
   it('captures the newest turn even when Sync starts scrolled up (issue #348)', async () => {


### PR DESCRIPTION
Fixes the sync stall reported in #365 and split out into #394: a Claude/ChatGPT conversation containing a very long code block aborts mid-scroll and loses every turn above the tall one.

### Problem

The virtualized engine keys turns by the platform's row identity, so while it crawls up through a turn taller than the viewport, every harvest returns the same key. ADR-018 counted only "a new turn appeared" as progress, so a tall enough turn starves the idle deadline and kills the pass.

The threshold is a distance, not a clock, which is why repeated syncs of the same conversation produced byte-identical partial captures.

### Measurements (live Claude via the CDP daemon, 1440×900)

- `clientHeight` 852px → `step` 511px; idle window 37 iterations → **18,907px** may be traversed without a new turn
- Claude code blocks: 14px font / 22.75px line-height, **22.16px per line** measured
- → the limit is **≈853 lines** in one turn; a ~1000-line block is ~22,160px and always overruns
- Scroll anchoring ruled out: every iteration moved exactly the requested 511px

### Change

- `scrollUpUntilStable()`: progress is now **a new turn OR `scrollTop` decreased**. Upward travel is monotonically decreasing and therefore finite, so once motion stops the idle deadline resumes detecting a genuinely stuck scroller. No constants changed.
- Deliberately **not** applied to `ensureAllElementsLoaded()` (Gemini): that engine re-arms by jumping to `scrollHeight` every iteration, so "the position moved" would always be true and disable its idle deadline outright.
- Adds a per-iteration `console.debug`, matching the log the Gemini engine has always had — a partial-capture report was otherwise undiagnosable.
- ADR-024; ADR-018 cross-linked.

### Test plan

- [x] New test: `captures the turns above a single viewport-dwarfing turn (issue #365)` — built from the measured constants; fails on `main` with "timed out with 11 turns" out of 21
- [x] New test: `gives up when neither new turns nor the scroll position move` — guards ADR-018's stuck-scroller detection against the widened signal
- [x] Updated `stops via the idle deadline ... when stuck below the top`: that fixture travels 10,900 → 3,000 before pinning, and those ~15 iterations of real movement are now progress, so the pass runs ~53 iterations instead of ~38. Bound raised `< 50` → `< 80`; the assertion's purpose (idle path, not the ~750-iteration absolute cap) is unchanged.
- [x] `npm test` — 1436 passed
- [x] `npm run lint` — 0 errors (3 pre-existing warnings, identical on `main`)
- [x] `npm run format:check`, `npm run build`
- [x] Coverage: `scroll-manager.ts` 99.2 / 94.23 / 100 / 100
- [x] **Live verification**: on a real Claude conversation with one row inflated to 22,160px, reaching the top takes 58 iterations — the old rule aborts at 47 without reaching the top, the new rule completes

Refs #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)