### PR TITLE
feat: report why a save forks a duplicate note

### DIFF
--- a/docs/adr/025-note-identity-probe-and-fork-diagnostics.md
+++ b/docs/adr/025-note-identity-probe-and-fork-diagnostics.md
@@ -1,0 +1,133 @@
+# ADR-025: Name the note-identity probe outcomes and report why a save forks
+
+- Status: Proposed
+- Date: 2026-08-04
+- Related: issue #365, issue #327 (the collision safeguard being diagnosed), [ADR-024](024-scroll-progress-includes-movement.md)
+
+## Context
+
+Issue #365 reports duplicate notes: a conversation that already has a note in
+the vault gets a second (and third) file under the deterministic
+collision-fallback name, even though every file carries the same frontmatter
+`id`. Three rounds of correspondence with the reporter failed to identify the
+trigger, and the reason is structural rather than a lack of effort.
+
+### What the reported evidence proves
+
+The reporter supplied three clusters of duplicates with full ids and file
+names. Recomputing `collisionSuffix()` — `generateHash(note.frontmatter.id)`,
+`src/lib/filename-collision.ts:19` — against those ids matches all three
+observed suffixes exactly:
+
+| Conversation id | Observed suffix | `generateHash('claude_<uuid>')` |
+| --- | --- | --- |
+| `claude_1a07d605-…` | `45fd74fa` | `45fd74fa` |
+| `claude_ad00d6b9-…` | `4ff2dde8` | `4ff2dde8` |
+| `claude_a4c3b5f7-…` | `595294a2` | `595294a2` |
+
+(The bare UUIDs hash to `5b9cf0fb` / `3a5361e7` / `43b318a1`, so the input was
+the prefixed id, not the UUID.)
+
+Two facts follow. First, the extra files were produced by
+`resolveCollisionFreePath()` at attempt ≥ 1 — nothing else in the codebase
+generates that name. Second, **the `id` the extension held at that moment was
+correct**, because it is the hash's own input. The failure is therefore on the
+read side: the existing file's `id` did not come back as a match. For the
+`-<hash>-2` files, that happened for *two* candidate files in the same save.
+
+### Why the cause could not be narrowed further
+
+Every read-side negative collapses into one silent outcome:
+
+- `src/background/obsidian-handlers.ts` — `resolveCollisionFreePath()` compared
+  `parseFrontmatter(existing)?.fields.id === note.frontmatter.id` and, on
+  anything but a match, moved to the next candidate. Its own comment
+  acknowledged two different situations ("a different conversation (or an
+  unparseable/foreign file)") that the code neither separated nor recorded. The
+  function contained no logging at all.
+- `src/lib/append-utils.ts` — `readCandidate()` returned `null` for a budget
+  miss, a missing file and a different conversation alike; `notFound()` carried
+  no reason; and `FileLookupResult.matchType` existed but no caller read it.
+- `src/lib/obsidian-api.ts` — `getFile()` returns `null` only for a 404, so a
+  200 with an empty body yields `''`, which is not `null` and so reached the
+  "occupied by another conversation" branch. The Local REST API's OpenAPI
+  specification documents exactly two responses for `GET /vault/{filename}`
+  (200 Success, 404 File does not exist), so a 0-byte note is a legitimate 200
+  with an empty body.
+- `src/lib/obsidian-api.ts` — `listEntries()` maps a 404 to `[]`. The same
+  specification documents 404 as "Directory does not exist" and notes that
+  "empty directories will not be returned", so a missing folder, an empty
+  folder and a swallowed error are indistinguishable to the append scan, and
+  all three silently produce a lookup miss.
+
+A duplicate note is a data-integrity event, and the code that decides to create
+one records nothing about why. No amount of further correspondence can close
+that gap.
+
+## Decision
+
+Make the reasoning observable, and change nothing about the behaviour.
+
+1. **A shared probe primitive.** `src/lib/note-identity.ts` exports
+   `classifyNoteProbe(content, expectedId)` returning one of `absent`, `empty`,
+   `unparseable`, `no-id`, `different-id`, `same-conversation`, plus the id it
+   actually read. Both the append lookup and the collision probe use it, so the
+   duplicated `parseFrontmatter(...)?.fields.id === id` idiom exists once.
+2. **Named lookup misses.** `lookupExistingFile()` returns a `missReason`
+   (`no-candidate-suffix`, `empty-directory`, `no-candidate-file`,
+   `candidate-id-mismatch`, `budget-exhausted`) and the `directProbe` it saw.
+   The directory scans report entry/candidate counts so the reason is derived,
+   not guessed.
+3. **Recorded probes.** `resolveCollisionFreePath()` accumulates a
+   `ProbeOutcome[]` — attempt number, candidate file name, state, id found —
+   and returns it with the chosen target.
+4. **Two log points, at levels the reporter will actually see.**
+   - `console.info` when append mode finds no existing note (this precedes
+     every fork, and also makes ordinary lookup health visible).
+   - `console.warn` when a save lands on an alternative name, or when all ten
+     candidates are exhausted, carrying the full probe list.
+
+   Chrome DevTools hides `console.debug` unless the Verbose level is selected,
+   so a low-frequency, decision-grade event must not use it. This is the
+   opposite trade-off from ADR-024's per-iteration scroll log, which is high
+   frequency and correctly `debug`.
+
+Expected and found ids are logged **in full**. A truncated id would show *that*
+two ids differ but not *how*, which is the entire question. The ids are already
+present in the note's own frontmatter and in the conversation URL, and the
+output goes only to the user's own service-worker console.
+
+## Consequences
+
+- The next report of a duplicate note carries its own cause: which candidate
+  names were probed, what each held, and which id was read versus expected.
+- The `empty` and `no-id` states are now distinguishable from
+  `different-id`. Both still fork, exactly as before — but if the field data
+  shows a fork was caused by an empty or id-less file, that is a different bug
+  with a different fix, and the log will say so.
+- One extra `console.info` per save that falls through append mode. This is at
+  most one line per sync.
+- `FileLookupResult` gains optional fields; existing callers and all 28
+  pre-existing `lookupExistingFile` tests are unaffected.
+
+## Alternatives considered
+
+- **Also change the forking behaviour** — e.g. treat an `empty` or
+  `unparseable` occupant as free and overwrite it. Rejected for now: issue #327
+  exists precisely because overwriting a file we cannot identify destroys data,
+  and a note with no frontmatter may simply be one the user wrote by hand.
+  Changing behaviour before the field data says which state actually occurs
+  would be speculation. This ADR deliberately ships diagnosis first.
+- **Read identity through the API's own parser** — `GET /vault/{filename}` with
+  `Accept: application/vnd.olrapi.note+json` returns a parsed `frontmatter`
+  object, so the extension's regex parser (`src/lib/frontmatter-parser.ts`)
+  would no longer sit between the file and the id. That would structurally
+  remove one candidate cause. Rejected for this change: swapping the read path
+  for every save is a large behavioural change made on a hypothesis, and the
+  JSON response shape would have to be validated at the boundary. Recorded here
+  as the natural follow-up should the logs implicate the parser.
+- **Log at `debug`** — quieter, but hidden at DevTools' default level, which
+  defeats the entire purpose of the change.
+- **Do nothing and keep asking the reporter for detail** — three rounds have
+  already shown the vault-side artefacts cannot distinguish the cases, because
+  the files look correct after the fact.

--- a/src/background/obsidian-handlers.ts
+++ b/src/background/obsidian-handlers.ts
@@ -14,11 +14,11 @@ import {
   getSearchBasePath,
 } from '../lib/path-utils';
 import { lookupExistingFile, buildAppendContent } from '../lib/append-utils';
+import { classifyNoteProbe, isSameConversation, type ProbeState } from '../lib/note-identity';
 import { resolveImagesForObsidian, stripImagePlaceholders } from '../lib/image-output';
 import { flattenLargeCallouts } from '../lib/callout-flatten';
 import { base64ToBytes } from '../lib/image-utils';
 import { collisionSuffix, candidateFileName } from '../lib/filename-collision';
-import { parseFrontmatter } from '../lib/frontmatter-parser';
 import { validateObsidianUrl } from '../lib/validation';
 import type { ExtensionSettings, ObsidianNote, SaveResponse } from '../lib/types';
 
@@ -98,7 +98,17 @@ async function tryAppendMode(
       hintPath: appendPathMemo.get(note.frontmatter.id),
       filenameScheme: settings.templateOptions.filenameScheme,
     });
-    if (!lookup.found) return null;
+    if (!lookup.found) {
+      // A miss is what sends the save down the fork path, so name the negative
+      // rather than letting it vanish (issue #365).
+      console.info('[G2O Background] Append lookup found no existing note', {
+        id: note.frontmatter.id,
+        missReason: lookup.missReason,
+        directProbe: lookup.directProbe,
+        searched: { direct: fullPath, base: searchBasePath },
+      });
+      return null;
+    }
     rememberAppendPath(note.frontmatter.id, lookup.path);
 
     const appendResult = buildAppendContent(lookup.content, note, settings);
@@ -178,6 +188,16 @@ async function saveFreshNote(
   const target = await resolveCollisionFreePath(client, resolvedPath, note);
   if ('error' in target) {
     return { success: false, error: target.error };
+  }
+  if (target.renamed) {
+    // The canonical name was taken by something we could not identify as ours.
+    // This is the moment a duplicate note is born, so say exactly what each
+    // rejected candidate held (issue #365).
+    console.warn('[G2O Background] Filename collision: saved under an alternative name', {
+      expectedId: note.frontmatter.id,
+      savedAs: target.fileName,
+      probes: target.probes,
+    });
   }
 
   const { note: saveNote, failedImages } = await prepareNoteImages(
@@ -270,6 +290,17 @@ interface WritableTarget {
   isNewFile: boolean;
   /** True when the original name was occupied by a different conversation */
   renamed: boolean;
+  /** What each probed candidate name held, in probe order (issue #365). */
+  probes: readonly ProbeOutcome[];
+}
+
+/** What one candidate file name held when it was probed. */
+interface ProbeOutcome {
+  attempt: number;
+  fileName: string;
+  state: ProbeState;
+  /** The id actually read from that file, when it had one. */
+  foundId?: string;
 }
 
 /**
@@ -289,23 +320,33 @@ async function resolveCollisionFreePath(
   note: ObsidianNote
 ): Promise<WritableTarget | { error: string }> {
   const suffix = collisionSuffix(note.frontmatter.id);
+  const probes: ProbeOutcome[] = [];
 
   for (let attempt = 0; attempt < MAX_COLLISION_ATTEMPTS; attempt++) {
     const fileName = candidateFileName(note.fileName, suffix, attempt);
     const path = resolvedPath ? `${resolvedPath}/${fileName}` : fileName;
 
     const existing = await client.getFile(path);
-    if (existing === null) {
-      return { path, fileName, isNewFile: true, renamed: attempt > 0 };
+    const probe = classifyNoteProbe(existing, note.frontmatter.id);
+    probes.push({ attempt, fileName, ...probe });
+
+    if (probe.state === 'absent') {
+      return { path, fileName, isNewFile: true, renamed: attempt > 0, probes };
     }
-    const parsed = parseFrontmatter(existing);
-    if (parsed?.fields.id === note.frontmatter.id) {
-      return { path, fileName, isNewFile: false, renamed: attempt > 0 };
+    if (isSameConversation(probe)) {
+      return { path, fileName, isNewFile: false, renamed: attempt > 0, probes };
     }
-    // Occupied by a different conversation (or an unparseable/foreign file):
-    // never overwrite — try the next deterministic candidate.
+    // Occupied by a different conversation, or holding something we cannot
+    // identify (empty / unparseable / no id): never overwrite — try the next
+    // deterministic candidate. Which of those it was is now recorded, so a
+    // duplicate reported from the field can be traced back to its cause.
   }
 
+  console.warn('[G2O Background] Filename collision: no free name found', {
+    expectedId: note.frontmatter.id,
+    fileName: note.fileName,
+    probes,
+  });
   return {
     error:
       `filename collision: could not find a free name for '${note.fileName}' ` +

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -9,8 +9,34 @@ import type { ObsidianApiClient } from './obsidian-api';
 import type { ObsidianNote, ExtensionSettings, FilenameScheme } from './types';
 import { SCAN_MAX_REQUESTS } from './constants';
 import { parseFrontmatter, updateFrontmatter } from './frontmatter-parser';
+import { classifyNoteProbe, isSameConversation, type NoteProbe } from './note-identity';
 import { countExistingMessages, extractTailMessages } from './message-counter';
 import { formatDateWithTimezone } from './date-utils';
+
+/**
+ * Why a lookup failed to find the conversation's existing note (issue #365).
+ *
+ * A miss makes the save path fork a new file, so when a duplicate turns up in
+ * the wild this is the single most useful thing to know. Reported, never acted
+ * on — the lookup's behaviour is unchanged.
+ *
+ * - `no-candidate-suffix` — a `title-id` file name with no id suffix, so no
+ *   directory scan is possible at all.
+ * - `empty-directory` — the listing returned nothing. `listEntries()` maps a
+ *   404 to `[]`, and the Local REST API documents both "directory does not
+ *   exist" (404) and that empty directories are not returned, so a missing
+ *   folder, an empty one and a swallowed error all look identical here.
+ * - `no-candidate-file` — the folder had files, none carrying our id suffix.
+ * - `candidate-id-mismatch` — same-suffix files existed but none were ours.
+ * - `budget-exhausted` — the scan hit {@link SCAN_MAX_REQUESTS} first, so the
+ *   note may well exist beyond the point the scan stopped.
+ */
+export type LookupMissReason =
+  | 'no-candidate-suffix'
+  | 'empty-directory'
+  | 'no-candidate-file'
+  | 'candidate-id-mismatch'
+  | 'budget-exhausted';
 
 /**
  * Result of file lookup for append mode
@@ -20,6 +46,10 @@ interface FileLookupResult {
   path: string;
   content: string;
   matchType: 'direct' | 'memo' | 'id-scan' | 'none';
+  /** Only on a miss: which negative occurred (issue #365). */
+  missReason?: LookupMissReason;
+  /** What the direct-path GET saw. Absent when a memo hit short-circuited it. */
+  directProbe?: NoteProbe;
 }
 
 /**
@@ -94,8 +124,36 @@ function createScanBudget(max: number): ScanBudget {
 }
 
 /** Uniform "no existing file" result. */
-function notFound(fullPath: string): FileLookupResult {
-  return { found: false, path: fullPath, content: '', matchType: 'none' };
+function notFound(
+  fullPath: string,
+  missReason: LookupMissReason,
+  directProbe?: NoteProbe
+): FileLookupResult {
+  return { found: false, path: fullPath, content: '', matchType: 'none', missReason, directProbe };
+}
+
+/**
+ * What a directory scan saw, so the caller can name the miss.
+ *
+ * `entries`/`candidates` are counts, not data: they separate "the folder was
+ * empty or unreadable" from "the folder had files but none carried our id
+ * suffix" from "same-suffix files existed but none were ours".
+ */
+interface ScanResult {
+  hit: FileLookupResult | null;
+  entries: number;
+  candidates: number;
+}
+
+/** No scan was possible (no directory to list). */
+const NO_SCAN: ScanResult = { hit: null, entries: 0, candidates: 0 };
+
+/** Name the negative a completed scan represents. */
+function scanMissReason(scan: ScanResult, budget: ScanBudget): LookupMissReason {
+  if (budget.exhausted) return 'budget-exhausted';
+  if (scan.entries === 0) return 'empty-directory';
+  if (scan.candidates === 0) return 'no-candidate-file';
+  return 'candidate-id-mismatch';
 }
 
 /**
@@ -136,10 +194,8 @@ async function readCandidate(
 ): Promise<FileLookupResult | null> {
   if (!budget.spend()) return null;
   const content = await client.getFile(candidatePath);
-  if (content === null) return null;
-  const parsed = parseFrontmatter(content);
-  if (parsed?.fields.id !== expectedId) return null;
-  return { found: true, path: candidatePath, content, matchType: 'id-scan' };
+  if (!isSameConversation(classifyNoteProbe(content, expectedId))) return null;
+  return { found: true, path: candidatePath, content: content as string, matchType: 'id-scan' };
 }
 
 /**
@@ -154,10 +210,8 @@ async function tryHintPath(
 ): Promise<FileLookupResult | null> {
   if (!hintPath || hintPath === fullPath) return null;
   const content = await client.getFile(hintPath);
-  if (content === null) return null;
-  const parsed = parseFrontmatter(content);
-  if (parsed?.fields.id !== expectedId) return null;
-  return { found: true, path: hintPath, content, matchType: 'memo' };
+  if (!isSameConversation(classifyNoteProbe(content, expectedId))) return null;
+  return { found: true, path: hintPath, content: content as string, matchType: 'memo' };
 }
 
 /**
@@ -196,34 +250,33 @@ export async function lookupExistingFile(
 
   // Step 1: Direct path match
   const directContent = await client.getFile(fullPath);
-  if (directContent !== null && parseFrontmatter(directContent)?.fields.id === expectedId) {
-    return { found: true, path: fullPath, content: directContent, matchType: 'direct' };
+  const directProbe = classifyNoteProbe(directContent, expectedId);
+  if (isSameConversation(directProbe)) {
+    return {
+      found: true,
+      path: fullPath,
+      content: directContent as string,
+      matchType: 'direct',
+      directProbe,
+    };
   }
 
   // Step 2: Directory scan, bounded by a shared request budget
   const matches = createCandidateMatcher(note.fileName, filenameScheme);
-  if (!matches) return notFound(fullPath);
+  if (!matches) return notFound(fullPath, 'no-candidate-suffix', directProbe);
 
   const budget = createScanBudget(SCAN_MAX_REQUESTS);
   const useRecursive = searchBasePath !== resolvedPath && searchBasePath !== '';
 
-  if (useRecursive) {
-    const recursive = await recursiveIdScan(
-      client,
-      searchBasePath,
-      matches,
-      expectedId,
-      fullPath,
-      budget
-    );
-    if (recursive) return recursive;
-  } else if (resolvedPath) {
-    const flat = await flatIdScan(client, resolvedPath, matches, expectedId, fullPath, budget);
-    if (flat) return flat;
-  }
+  const scan = useRecursive
+    ? await recursiveIdScan(client, searchBasePath, matches, expectedId, fullPath, budget)
+    : resolvedPath
+      ? await flatIdScan(client, resolvedPath, matches, expectedId, fullPath, budget)
+      : NO_SCAN;
+  if (scan.hit) return { ...scan.hit, directProbe };
 
   // Step 3: Not found
-  return notFound(fullPath);
+  return notFound(fullPath, scanMissReason(scan, budget), directProbe);
 }
 
 /**
@@ -240,19 +293,22 @@ async function flatIdScan(
   expectedId: string,
   skipPath: string,
   budget: ScanBudget
-): Promise<FileLookupResult | null> {
-  if (!budget.spend()) return null;
+): Promise<ScanResult> {
+  if (!budget.spend()) return NO_SCAN;
   const files = await client.listFiles(dir);
+  let candidates = 0;
+
   for (const file of files) {
-    if (budget.exhausted) return null;
+    if (budget.exhausted) break;
     if (!matches(file)) continue;
     const candidatePath = `${dir}/${file}`;
     if (candidatePath === skipPath) continue; // Already checked as direct match
+    candidates++;
     const hit = await readCandidate(client, candidatePath, expectedId, budget);
-    if (hit) return hit;
+    if (hit) return { hit, entries: files.length, candidates };
   }
 
-  return null;
+  return { hit: null, entries: files.length, candidates };
 }
 
 /**
@@ -270,14 +326,17 @@ async function recursiveIdScan(
   expectedId: string,
   skipPath: string,
   budget: ScanBudget
-): Promise<FileLookupResult | null> {
+): Promise<ScanResult> {
   type Frame = { dir: string; depth: number };
   const queue: Frame[] = [{ dir: baseDir, depth: 0 }];
+  let seen = 0;
+  let candidates = 0;
 
   while (queue.length > 0) {
     const { dir, depth } = queue.shift() as Frame;
-    if (!budget.spend()) return null;
+    if (!budget.spend()) return { hit: null, entries: seen, candidates };
     const entries = await client.listEntries(dir);
+    seen += entries.length;
     for (const entry of entries) {
       if (entry.endsWith('/')) {
         if (depth + 1 <= RECURSIVE_SCAN_MAX_DEPTH) {
@@ -289,12 +348,13 @@ async function recursiveIdScan(
       if (!matches(entry)) continue;
       const candidatePath = `${dir}/${entry}`;
       if (candidatePath === skipPath) continue;
+      candidates++;
       const hit = await readCandidate(client, candidatePath, expectedId, budget);
-      if (hit) return hit;
+      if (hit) return { hit, entries: seen, candidates };
     }
   }
 
-  return null;
+  return { hit: null, entries: seen, candidates };
 }
 
 /**

--- a/src/lib/note-identity.ts
+++ b/src/lib/note-identity.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared "is this file our conversation?" probe (issue #365).
+ *
+ * The append-mode lookup and the filename-collision probe both answered that
+ * question with the same one-liner — `parseFrontmatter(c)?.fields.id === id` —
+ * and both collapsed every possible negative into a single silent "not ours".
+ * When a duplicate note appeared in the wild there was therefore no way to tell
+ * which negative had occurred: a note holding a genuinely different
+ * conversation, a note with no `id` at all, an unreadable file, or an empty
+ * body. Naming the outcomes is what makes a field report actionable.
+ *
+ * This module only *classifies*. Callers keep their existing behaviour: every
+ * state other than `same-conversation` still means "do not touch this file".
+ */
+
+import { parseFrontmatter } from './frontmatter-parser';
+
+/**
+ * What a read of a candidate file revealed.
+ *
+ * - `absent` — the file does not exist (the API answered 404).
+ * - `empty` — the file exists but its body is empty. The Local REST API
+ *   documents only 200 and 404 for `GET /vault/{filename}`, so a 0-byte note is
+ *   a legitimate 200 with an empty body — distinct from "missing", and not
+ *   evidence of another conversation.
+ * - `unparseable` — content is present but no YAML frontmatter block closes.
+ * - `no-id` — frontmatter parses but carries no `id` (e.g. a note written with
+ *   the "Include ID" template option turned off, or a hand-written note).
+ * - `different-id` — frontmatter carries another conversation's id.
+ * - `same-conversation` — this is our note.
+ */
+export type ProbeState =
+  | 'absent'
+  | 'empty'
+  | 'unparseable'
+  | 'no-id'
+  | 'different-id'
+  | 'same-conversation';
+
+/** Outcome of {@link classifyNoteProbe}. */
+export interface NoteProbe {
+  state: ProbeState;
+  /** The id actually read from the file, when it had a scalar one. */
+  foundId?: string;
+}
+
+/**
+ * Classify a candidate file against the conversation we are saving.
+ *
+ * @param content File content, or null when the file does not exist.
+ * @param expectedId The `id` of the conversation being saved.
+ */
+export function classifyNoteProbe(content: string | null, expectedId: string): NoteProbe {
+  if (content === null) return { state: 'absent' };
+  if (content === '') return { state: 'empty' };
+
+  const parsed = parseFrontmatter(content);
+  if (!parsed) return { state: 'unparseable' };
+
+  const id = parsed.fields.id;
+  if (typeof id !== 'string' || id === '') return { state: 'no-id' };
+
+  return id === expectedId
+    ? { state: 'same-conversation', foundId: id }
+    : { state: 'different-id', foundId: id };
+}
+
+/** True when the probe proves the file holds the conversation being saved. */
+export function isSameConversation(probe: NoteProbe): boolean {
+  return probe.state === 'same-conversation';
+}

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -1010,6 +1010,91 @@ describe('background/index', () => {
       });
     });
 
+    // Forking a new file is a decision the save path used to make in complete
+    // silence, which is why three rounds of correspondence on #365 could not
+    // pin down WHICH negative had occurred. Behaviour is unchanged here — only
+    // the reasoning becomes visible.
+    describe('fork diagnostics (issue #365)', () => {
+      const suffix = generateHash('test-id');
+      const send = (sendResponse: ReturnType<typeof vi.fn>) =>
+        capturedListener(
+          { action: 'saveToOutputs', outputs: ['obsidian'], data: validNote },
+          validSender as chrome.runtime.MessageSender,
+          sendResponse
+        );
+
+      it('warns with every probe outcome when it forks an alternative name', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(
+            path === 'AI/Gemini/test.md' ? '---\nid: other_id\n---\nSomeone else' : null
+          )
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+
+        const call = warn.mock.calls.find(c => String(c[0]).includes('Filename collision'));
+        expect(call).toBeDefined();
+        const detail = call?.[1] as {
+          expectedId: string;
+          savedAs: string;
+          probes: Array<{ attempt: number; fileName: string; state: string; foundId?: string }>;
+        };
+        expect(detail.expectedId).toBe('test-id');
+        expect(detail.savedAs).toBe(`test-${suffix}.md`);
+        expect(detail.probes[0]).toEqual({
+          attempt: 0,
+          fileName: 'test.md',
+          state: 'different-id',
+          foundId: 'other_id',
+        });
+        expect(detail.probes[1]).toMatchObject({ attempt: 1, state: 'absent' });
+        warn.mockRestore();
+      });
+
+      it('reports an empty occupying file as empty, not as another conversation', async () => {
+        // Behaviour is deliberately unchanged (it still forks) — but a 0-byte
+        // note must not be reported as evidence that someone else owns the name.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(path === 'AI/Gemini/test.md' ? '' : null)
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+
+        const call = warn.mock.calls.find(c => String(c[0]).includes('Filename collision'));
+        const detail = call?.[1] as { probes: Array<{ attempt: number; state: string }> };
+        expect(detail.probes[0]).toEqual({ attempt: 0, fileName: 'test.md', state: 'empty' });
+        // Unchanged behaviour: the fork still happens.
+        expect(mockClient.putFile).toHaveBeenCalledWith(
+          `AI/Gemini/test-${suffix}.md`,
+          expect.any(String)
+        );
+        warn.mockRestore();
+      });
+
+      it('stays silent when the note lands on its canonical name', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockClient.getFile.mockResolvedValue(null);
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+
+        expect(warn.mock.calls.filter(c => String(c[0]).includes('Filename collision'))).toEqual(
+          []
+        );
+        warn.mockRestore();
+      });
+    });
+
     it('saves new file successfully', async () => {
       mockClient.getFile.mockResolvedValue(null);
       mockClient.putFile.mockResolvedValue(undefined);
@@ -2105,6 +2190,32 @@ describe('background/index', () => {
       const response = sendResponse.mock.calls[0][0];
       expect(response.allSuccessful).toBe(true);
       expect(response.messagesAppended).toBe(2);
+    });
+
+    it('reports why append mode found no existing note (issue #365)', async () => {
+      // The miss is what makes the save path fork a new file, so name it.
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      mockGetSettings = vi.fn(() => Promise.resolve(appendSettings));
+      mockClient.getFile.mockResolvedValue(null); // direct path absent
+      mockClient.listFiles.mockResolvedValue([]); // …and nothing to scan
+      mockClient.putFile.mockResolvedValue(undefined);
+
+      const sendResponse = vi.fn();
+      capturedListener(
+        { action: 'saveToOutputs', outputs: ['obsidian'], data: appendNote },
+        validSender as chrome.runtime.MessageSender,
+        sendResponse
+      );
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+
+      const call = info.mock.calls.find(c => String(c[0]).includes('Append lookup'));
+      expect(call).toBeDefined();
+      expect(call?.[1]).toMatchObject({
+        id: 'claude_abc-def',
+        missReason: 'empty-directory',
+        directProbe: { state: 'absent' },
+      });
+      info.mockRestore();
     });
 
     it('returns messagesAppended: 0 when no new messages', async () => {

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -338,6 +338,121 @@ describe('lookupExistingFile', () => {
 
   // ----- Request budget -----
 
+  // ===== miss diagnostics (issue #365) =====
+  //
+  // When append mode finds nothing, the save path forks a new note. Three
+  // rounds of correspondence on #365 failed to pin down which negative had
+  // occurred, because every one of them produced the same silent `found:
+  // false`. These pin the reason down without changing any behaviour.
+
+  it('reports missReason no-candidate-suffix when the file name carries no id suffix', async () => {
+    const noSuffix = createTestNote({
+      fileName: 'conversation.md',
+      frontmatter: createTestFrontmatter({ id: 'claude_abc-def-123' }),
+    });
+    mockClient.getFile.mockResolvedValue(null);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/conversation.md',
+      'AI/claude',
+      noSuffix
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.missReason).toBe('no-candidate-suffix');
+    expect(mockClient.listFiles).not.toHaveBeenCalled();
+  });
+
+  it('reports missReason empty-directory when the listing comes back empty', async () => {
+    // listEntries maps a 404 to [] (obsidian-api.ts), so "the folder is gone",
+    // "the folder is empty" and "the request failed" are indistinguishable to
+    // the scan — worth separating from "the folder had files, none matched".
+    mockClient.getFile.mockResolvedValue(null);
+    mockClient.listFiles.mockResolvedValue([]);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-abc12345.md',
+      'AI/claude',
+      testNote
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.missReason).toBe('empty-directory');
+  });
+
+  it('reports missReason no-candidate-file when the folder holds no same-suffix file', async () => {
+    mockClient.getFile.mockResolvedValue(null);
+    mockClient.listFiles.mockResolvedValue(['unrelated-file.md', 'another-note-99999999.md']);
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-abc12345.md',
+      'AI/claude',
+      testNote
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.missReason).toBe('no-candidate-file');
+  });
+
+  it('reports missReason candidate-id-mismatch when a same-suffix file holds another conversation', async () => {
+    mockClient.listFiles.mockResolvedValue(['other-chat-abc12345.md']);
+    mockClient.getFile.mockImplementation((path: string) =>
+      Promise.resolve(
+        path === 'AI/claude/other-chat-abc12345.md'
+          ? '---\nid: claude_someone-else\n---\nBody'
+          : null
+      )
+    );
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-abc12345.md',
+      'AI/claude',
+      testNote
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.missReason).toBe('candidate-id-mismatch');
+  });
+
+  it('records what the direct-path probe saw when it holds a different conversation', async () => {
+    mockClient.listFiles.mockResolvedValue([]);
+    mockClient.getFile.mockResolvedValue('---\nid: claude_someone-else\n---\nBody');
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-abc12345.md',
+      'AI/claude',
+      testNote
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.directProbe).toEqual({
+      state: 'different-id',
+      foundId: 'claude_someone-else',
+    });
+  });
+
+  it('records an empty direct-path file as empty rather than as another conversation', async () => {
+    // A 0-byte note is a legitimate 200 with an empty body, not evidence that
+    // someone else owns the name.
+    mockClient.listFiles.mockResolvedValue([]);
+    mockClient.getFile.mockResolvedValue('');
+
+    const result = await lookupExistingFile(
+      mockClient as never,
+      'AI/claude/my-chat-abc12345.md',
+      'AI/claude',
+      testNote
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.directProbe).toEqual({ state: 'empty' });
+  });
+
   it('stops scanning once the request budget is exhausted', async () => {
     const dateNote = createTestNote({
       fileName: 'my-chat-2026-07-10.md',

--- a/test/lib/note-identity.test.ts
+++ b/test/lib/note-identity.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the shared note-identity probe (issue #365).
+ *
+ * Both the append-mode lookup and the filename-collision probe answer the same
+ * question about a candidate file — "is this the same conversation?" — and both
+ * previously collapsed every negative answer into a single indistinguishable
+ * outcome. `classifyNoteProbe` names the outcomes so the save path can report
+ * WHY it decided to fork a new file. Behaviour is unchanged: every state other
+ * than `same-conversation` still means "not ours".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyNoteProbe, isSameConversation } from '../../src/lib/note-identity';
+import type { ProbeState } from '../../src/lib/note-identity';
+
+const ID = 'claude_1a07d605-561d-46ba-86ea-79227969c0a1';
+
+describe('classifyNoteProbe', () => {
+  it('reports absent when the file does not exist (getFile returned null)', () => {
+    expect(classifyNoteProbe(null, ID)).toEqual({ state: 'absent' });
+  });
+
+  it('reports empty for a 200 with an empty body', () => {
+    // The Local REST API documents only 200 and 404 for GET /vault/{filename},
+    // so a 0-byte note is a legitimate 200 with an empty body — which is NOT
+    // null, and so used to land in the "occupied by another conversation" branch.
+    expect(classifyNoteProbe('', ID)).toEqual({ state: 'empty' });
+  });
+
+  it('reports unparseable when the content has no frontmatter block', () => {
+    expect(classifyNoteProbe('# Just a heading\n\nsome prose', ID)).toEqual({
+      state: 'unparseable',
+    });
+  });
+
+  it('reports unparseable when the frontmatter block is never closed', () => {
+    expect(classifyNoteProbe('---\nid: claude_x\ntitle: t', ID)).toEqual({ state: 'unparseable' });
+  });
+
+  it('reports no-id when the frontmatter parses but carries no id field', () => {
+    // The shape a note written with the "Include ID" option disabled would have.
+    const content = '---\ntitle: Something\nsource: claude\n---\n\nBody';
+    expect(classifyNoteProbe(content, ID)).toEqual({ state: 'no-id' });
+  });
+
+  it('reports different-id and surfaces the id it actually read', () => {
+    const content = `---\nid: claude_ffffffff-0000-0000-0000-000000000000\n---\n\nBody`;
+    expect(classifyNoteProbe(content, ID)).toEqual({
+      state: 'different-id',
+      foundId: 'claude_ffffffff-0000-0000-0000-000000000000',
+    });
+  });
+
+  it('reports same-conversation when the ids match', () => {
+    expect(classifyNoteProbe(`---\nid: ${ID}\n---\n\nBody`, ID)).toEqual({
+      state: 'same-conversation',
+      foundId: ID,
+    });
+  });
+
+  it('accepts a quoted id, matching the frontmatter parser', () => {
+    expect(classifyNoteProbe(`---\nid: '${ID}'\n---\n\nBody`, ID)).toEqual({
+      state: 'same-conversation',
+      foundId: ID,
+    });
+  });
+
+  it('reports different-id when the id field is a list rather than a scalar', () => {
+    // `id:` with no value parses to [] — malformed, but it is still "not ours".
+    expect(classifyNoteProbe('---\nid:\ntitle: t\n---\n\nBody', ID)).toEqual({ state: 'no-id' });
+  });
+});
+
+describe('isSameConversation', () => {
+  const NOT_OURS: ProbeState[] = ['absent', 'empty', 'unparseable', 'no-id', 'different-id'];
+
+  it('is true for a same-conversation probe', () => {
+    expect(isSameConversation({ state: 'same-conversation', foundId: ID })).toBe(true);
+  });
+
+  it.each(NOT_OURS)('is false for %s — every negative still means "do not touch"', state => {
+    expect(isSameConversation({ state })).toBe(false);
+  });
+});


### PR DESCRIPTION

Makes the duplicate-note fork path in #365 diagnosable. **No behaviour changes** — every state other than `same-conversation` still means "do not touch this file".

### What the reported evidence proves

@MAssenheimer supplied three clusters of duplicates with full ids and file names. Recomputing `collisionSuffix()` — `generateHash(note.frontmatter.id)`, `src/lib/filename-collision.ts:19` — against those ids matches all three observed suffixes exactly:

| Conversation id | Observed suffix | `generateHash('claude_<uuid>')` |
| --- | --- | --- |
| `claude_1a07d605-…` | `45fd74fa` | `45fd74fa` |
| `claude_ad00d6b9-…` | `4ff2dde8` | `4ff2dde8` |
| `claude_a4c3b5f7-…` | `595294a2` | `595294a2` |

The bare UUIDs hash to `5b9cf0fb` / `3a5361e7` / `43b318a1`, so the input was the prefixed id, not the UUID.

Two things follow:

1. The extra files came from `resolveCollisionFreePath()` at attempt ≥ 1 — nothing else in the codebase generates that name.
2. **The `id` the extension held at that moment was correct**, because it is the hash's own input.

So the failure is on the *read* side: the existing file's `id` did not come back as a match. For the `-<hash>-2` files that happened for **two** candidate files in the same save.

### Why it could not be narrowed further

Every read-side negative collapsed into one silent outcome:

- `resolveCollisionFreePath()` had **no logging at all**, and its own comment conflated two situations it never separated: "a different conversation (or an unparseable/foreign file)".
- `readCandidate()` returned `null` for a budget miss, a missing file and a foreign note alike; `notFound()` carried no reason; `FileLookupResult.matchType` existed but no caller read it.
- `getFile()` returns `null` only for a 404, so a 200 with an empty body yields `''` — not `null`, and therefore routed into the "occupied by another conversation" branch.
- `listEntries()` maps a 404 to `[]`, making a missing folder, an empty folder and a swallowed error indistinguishable to the append scan.

A duplicate note is a data-integrity event, and the code that decides to create one recorded nothing about why.

### Changes

- **`src/lib/note-identity.ts` (new)** — `classifyNoteProbe(content, expectedId)` names the outcomes: `absent`, `empty`, `unparseable`, `no-id`, `different-id`, `same-conversation`, plus the id actually read. Both call sites use it instead of repeating `parseFrontmatter(...)?.fields.id === id`.
- **`lookupExistingFile()`** returns a `missReason` (`no-candidate-suffix`, `empty-directory`, `no-candidate-file`, `candidate-id-mismatch`, `budget-exhausted`) and the direct-path probe. The scans count entries/candidates so the reason is *derived*, not guessed.
- **`resolveCollisionFreePath()`** accumulates a `ProbeOutcome[]` (attempt, file name, state, id found) and returns it.
- **Two log points**: `console.info` when append mode finds no existing note, `console.warn` when a save lands on an alternative name or all ten candidates are exhausted. Not `debug` — Chrome DevTools hides that below Verbose, which would defeat the purpose. (The opposite trade-off from ADR-024's per-iteration scroll log, which is high-frequency and correctly `debug`.)
- **ADR-025** records the evidence, the decision, and the alternatives rejected.

Expected and found ids are logged in full: a truncated id would show *that* two ids differ but not *how*, which is the whole question. They are already in the note's frontmatter and the conversation URL, and the output goes only to the user's own service-worker console.

### Test plan

- [x] `test/lib/note-identity.test.ts` (new, 15 tests) — every state, including a 0-byte body and a note with no `id`
- [x] `test/lib/append-utils.test.ts` — 6 new miss-reason tests; **all 28 pre-existing tests unchanged and green**
- [x] `test/background/index.test.ts` — probe list logged on fork, an empty occupant reported as `empty` (and still forking, unchanged), silence on the canonical name, append-miss reason logged
- [x] `npm test` — **1461 passed** (+25)
- [x] `npx eslint src` — 0 errors (3 warnings, identical on `main`)
- [x] `npm run format:check`, `npm run build`
- [x] Coverage: `note-identity.ts` 100/100/100/100; overall 96.39 / 87.59 / 98.94 / 97.44
- [x] **Live check against Obsidian's Local REST API**: all six states classify correctly, and a 0-byte note really does return 200 with an empty body rather than 404 — confirming that branch is reachable in practice, not just on paper

Refs #365


🤖 Generated with [Claude Code](https://claude.com/claude-code)
