### PR TITLE
chore: drop Claude selectors that no code reads

### DIFF
--- a/src/content/extractors/selectors/claude.ts
+++ b/src/content/extractors/selectors/claude.ts
@@ -27,20 +27,17 @@ export const SELECTORS = {
   // in a single extracted message (see issue #200).
   // Legacy selectors remain as fallbacks for older Claude DOM variants
   // that did not expose [data-testid="user-message"].
+  //
+  // 2026-08: two fallbacks dropped, both measured at zero on the live pages.
+  // `.bg-bg-300 p` — Claude removed the bg-bg-300 token outright (the user
+  // bubble is now `.bg-neutral-30 dark:…bg-surface-3 .rounded-xl`).
+  // `[class*="user-message"]` — the turn is identified by the data-testid
+  // attribute, not by a class; the `!font-user-message` class that made this
+  // substring match work disappeared a day after bg-bg-300 did. Chasing either
+  // token would only buy the next rename.
   userMessage: [
     '[data-testid="user-message"]', // Grid container (HIGH)
-    '[class*="user-message"]', // Partial match (MEDIUM)
     '.whitespace-pre-wrap.break-words', // Legacy inner <p> (LOW fallback)
-    '.bg-bg-300 p', // Legacy structural fallback (LOW)
-  ],
-
-  // User message wrapper (for date extraction)
-  // 2026-07: py-2.5 became py-[var(--msg-bubble-py,...)] on the live site,
-  // killing the old .pl-2.5.py-2.5 primary (baseline contract caught it)
-  userWrapper: [
-    '.bg-bg-300.rounded-xl', // Style composite (HIGH)
-    '.bg-bg-300', // Tailwind (MEDIUM)
-    '[class*="bg-bg-300"]', // Partial match (MEDIUM)
   ],
 
   // Assistant response selectors
@@ -58,12 +55,12 @@ export const SELECTORS = {
     '[class*="markdown"]', // Partial match (MEDIUM)
   ],
 
-  // Date selectors
-  messageDate: [
-    'span[data-state="closed"]', // Functional attribute (MEDIUM)
-    '.text-text-500.text-xs', // Tailwind (MEDIUM)
-    '[class*="text-text-500"]', // Partial match (LOW)
-  ],
+  // NOTE (2026-08): `userWrapper` and `messageDate` used to live here. No code
+  // ever read either of them — Claude date extraction was never implemented —
+  // yet the live selector suite validates every declared group, so when Claude
+  // dropped the `bg-bg-300` and `.text-text-500.text-xs` classes the run failed
+  // over selectors nothing consumes. Declare them again only alongside the code
+  // that reads them, measured against the DOM of that day.
 
   // Scroll container for virtualized-conversation auto-scroll (ADR-017).
   // Claude windows/evicts turns; this is the overflow-y-auto element that
@@ -89,10 +86,11 @@ export const DEEP_RESEARCH_SELECTORS = {
   ],
 
   // Report title
+  // 2026-08: `h1.text-text-100` dropped — text-text-100 survives elsewhere in
+  // the DOM but no longer lands on an h1, so the pairing can never match.
   title: [
     '#markdown-artifact h1', // Structure (HIGH)
     '.standard-markdown h1', // Structure (HIGH)
-    'h1.text-text-100', // Tailwind (MEDIUM)
     'h1', // Generic (LOW)
   ],
 


### PR DESCRIPTION

The live selector suite failed on Claude with a zero-match on `SELECTORS:userWrapper` and a baseline `lost` on `DEEP_RESEARCH_SELECTORS:title` (`h1.text-text-100`).

**Nothing about extraction is broken.** Every selector the extractor actually queries still matches. What broke is configuration no code has ever read.

### Cause

Measured live over CDP on 2026-08-04: Claude removed the `bg-bg-300` token outright. The user bubble is structurally unchanged but now reads

```
div.group.relative.inline-flex.gap-2
    .bg-neutral-30  dark:[[data-darker-default]_&]:bg-surface-3
    .rounded-xl  py-[var(--msg-bubble-py,0.625rem)] …
```

The only surviving theme classes are `bg-bg-000/80`, `bg-bg-200`, `text-text-100/300/400/500`. `text-text-500` still exists but no longer pairs with `text-xs`; `text-text-100` no longer lands on an `h1`.

### What still works (measured on both pinned test pages)

| Selector | CONV | DR |
| --- | --- | --- |
| `[data-testid="user-message"]` | 6 | 7 |
| `.whitespace-pre-wrap.break-words` | 6 | 7 |
| `.font-claude-response` | 7 | 8 |
| `.standard-markdown` | 13 | 10 |
| `.overflow-y-auto.overflow-x-hidden.flex-1` | 1 | 1 |
| `#markdown-artifact` / `h1` / `.standard-markdown` | — | 1 / 1 / 1 |
| `span.inline-flex a[href^="http"]` | 17 | 23 |

### Removed (each measured at zero)

| Group : name | Selectors |
| --- | --- |
| `SELECTORS:userWrapper` | `.bg-bg-300.rounded-xl`, `.bg-bg-300`, `[class*="bg-bg-300"]` — whole group |
| `SELECTORS:messageDate` | `span[data-state="closed"]`, `.text-text-500.text-xs`, `[class*="text-text-500"]` — whole group |
| `SELECTORS:userMessage` | `.bg-bg-300 p`, `[class*="user-message"]` |
| `DEEP_RESEARCH_SELECTORS:title` | `h1.text-text-100` |

`userWrapper` and `messageDate` are referenced **nowhere** in `src/` or `test/` — Claude date extraction was never implemented — but the suite validates every declared group, so they failed the run while protecting nothing. Two of `messageDate`'s three selectors still match; they go with the group, because a canary nothing consumes has no contract to defend.

`[class*="user-message"]` is worth calling out: it was still matching on 2026-08-04 (the element carried `!font-user-message`) and measured zero on 2026-08-05 by two independent methods. Claude changed that class again a day later, which is the argument against the alternative fix.

### Why not repoint the selectors at the new classes

A partial-match fallback on a Tailwind class that turns over this fast buys nothing but the next rename — twice in two days here. The attribute-based (`data-testid`) and semantic (`font-claude-response`, `standard-markdown`, `#markdown-artifact`) primaries are what the extractor relies on, and they are stable.

### Test plan

- [x] `npm test` — 1461 passed; `npx eslint src` — 0 errors (3 pre-existing warnings); `format:check`; `build`
  (a failure here would have disproved "unreferenced", which is why it ran before the baseline update)
- [x] `npm run e2e:baseline:update -- --grep Claude` — both groups written; other four platforms' baseline files byte-identical (md5 verified)
- [x] `npm run e2e:selectors -- --grep Claude` — **2 passed**; report shows `fail: 0`, `baselineBlocking: []`, `baselineAdvisory: []`

### Note for reviewers

Baselines are per-machine and gitignored, so each machine needs one `npm run e2e:baseline:update -- --grep Claude` after this change.

Gemini is separately blocked for unrelated reasons (legacy v1 baseline plus a zero-match `generatedImage`, which deadlock each other). Tracked separately in #402; this PR does not touch it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
