### PR TITLE
chore(deps-dev): bump undici, fast-uri and brace-expansion for security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2592,9 +2592,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2679,16 +2679,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/chokidar": {
@@ -3464,9 +3454,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5611,6 +5601,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@crxjs/vite-plugin": {
       "rollup": "2.80.0"
     },
-    "undici": "^7.28.0"
+    "undici": "^7.29.0"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
## Summary

Combines Dependabot #399 and #400 into one change. Both touch `package-lock.json`, so merging them one after the other would leave the second in conflict; this way it is a single merge and a single changelog entry. `npm audit fix` picked up a third fix in the same pass.

| Package | Version | Advisory | How |
| --- | --- | --- | --- |
| `undici` | 7.28.0 → 7.29.0 | [GHSA-4cwx-7wf7-3272](https://github.com/nodejs/undici/security/advisories/GHSA-4cwx-7wf7-3272) (high) | via the existing `overrides` entry pinning cheerio's transitive copy — now hoisted to the top level |
| `fast-uri` | 3.1.4 → 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/fastify/fast-uri/security/advisories/GHSA-7p8r-x3mc-p8w7) | transitive under `@commitlint/config-validator`'s ajv |
| `brace-expansion` | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 | transitive under `minimatch`; previously reported as "no fix available", an upstream fix has since shipped |

**`npm audit`: 24 findings (2 moderate, 22 high) → 0.** Most of that is the `brace-expansion` → `minimatch` → eslint chain clearing.

### No effect on the published extension

All three are dev-only. The runtime dependencies are `dompurify` and `turndown` alone, and none of these three packages appears in the built bundle (`grep` over `dist/assets/` returns nothing).

### Scope

The lock diff is limited to exactly these three packages — nothing else moved. An `allowScripts` block that npm added to `package.json` during the update was deliberately left out: changing install-script policy is a different kind of decision and does not belong in a dependency-bump PR.

Supersedes #399 and #400.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` — 0 errors (3 pre-existing warnings), platform consistency check passes
- [x] `npm test` — 1461 passed
- [x] `npm run format:check`
- [x] `npm audit` — 0 vulnerabilities
- [x] `git diff package-lock.json` reviewed: only the three packages above changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
