### PR TITLE
fix: read and write notes that use CRLF line endings

### DIFF
--- a/docs/adr/026-line-ending-handling.md
+++ b/docs/adr/026-line-ending-handling.md
@@ -1,0 +1,154 @@
+# ADR-026: Normalise line endings on read, restore them on write
+
+- Status: Proposed
+- Date: 2026-08-05
+- Related: issue #365, [ADR-025](025-note-identity-probe-and-fork-diagnostics.md), issue #327
+
+## Context
+
+Issue #365 reported duplicate notes: a conversation with an existing note in the
+vault got a second file under the deterministic collision-fallback name, even
+though both files carried the same frontmatter `id`. Three rounds of
+correspondence could not identify the trigger, so 2.7.0 shipped diagnostics
+(ADR-025) instead of a fix.
+
+The first field report after that shipped identified the cause immediately:
+
+```
+[G2O Background] Append lookup found no existing note
+{id: 'claude_5acb9457-…', missReason: 'no-candidate-file',
+ directProbe: {state: 'no-id'}, …}
+
+[G2O Background] Filename collision: saved under an alternative name
+{expectedId: 'claude_5acb9457-…', probes: [
+  {attempt: 0, fileName: '…-5acb9457.md',          state: 'no-id'},
+  {attempt: 1, fileName: '…-5acb9457-418ea102.md', state: 'same-conversation', …}]}
+```
+
+`no-id` on a file whose first frontmatter line is `id: claude_5acb9457-…`.
+
+### The mechanism
+
+`parseFrontmatter()` split on `'\n'` and matched each line against
+
+```js
+/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/
+```
+
+On a CRLF file every line retains a trailing `\r`, and this pattern cannot match
+it. Per MDN:
+
+- Wildcard: "A wildcard matches all characters **except line terminators**."
+- Lexical grammar: the line terminators are `U+000A <LF>`, **`U+000D <CR>`**,
+  `U+2028 <LS>` and `U+2029 <PS>`.
+- Input boundary assertion: without the `m` flag, `$` "asserts that the
+  character to the right is **out of bounds of the string**".
+
+So `(.*)` stops before the `\r`, `$` cannot be reached, and the match fails.
+Verified directly:
+
+```
+node -e "console.log('id: abc\r'.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/))"
+→ null
+```
+
+Every field of a CRLF file was therefore silently dropped. The block still
+looked like valid frontmatter, so the parser returned an object with **zero
+fields** rather than null — `fields.id` was `undefined`, which ADR-025's probe
+correctly reports as `no-id`, and the save path did what it is designed to do
+with a file it cannot identify: refuse to overwrite it and fork a new name.
+
+The reporter's own note explains where the CRLF came from. They are on Windows
+and post-process frontmatter with their own tagging tool; the rewritten file's
+`tags` are an inline array (`tags: ["gmail", …]`), the signature of a YAML
+dumper writing the file back. The extension's own file — attempt 1 in the log
+above, never touched by that tool — parsed as `same-conversation` in the very
+same save. LF readable, CRLF not, in one vault.
+
+This also explains every earlier observation: a scan of the maintainer's own
+vault (macOS, no external tooling, all LF) found 0 failures in 186 notes, and
+the affected files always looked correct on inspection afterwards — the content
+was never damaged, only unreadable.
+
+### Measured blast radius
+
+| Function | LF | CRLF | lone CR |
+| --- | --- | --- | --- |
+| `parseFrontmatter().fields.id` | ok | **undefined** | `null` (unparseable) |
+| `countExistingMessages()` | 4 | 4 | **0** |
+| `extractTailMessages()` | ok | ok (CRLF retained) | **empty** |
+| `updateFrontmatter()` | ok | **mixed endings**: `"---\r\nid: x\r\nmessage_count: 4\n---"` | — |
+| `flattenLargeCallouts()` | ok | ok (CRLF retained) | — |
+
+Only the field extraction is a functional break. But fixing it alone would
+expose the second row: `updateFrontmatter()` rewrites matched lines with `\n`
+while their neighbours keep `\r\n`, so every append to a CRLF file would leave
+it mixed.
+
+## Decision
+
+**Normalise line endings on read; restore the file's own ending on write.**
+
+1. `parseFrontmatter()` normalises `\r\n` and `\r` to `\n` before matching, and
+   returns `raw` and `body` in that normalised form. Everything downstream —
+   field matching, `updateFrontmatter()`, `countExistingMessages()`,
+   `extractTailMessages()` — sees LF and needs no line-ending awareness of its
+   own.
+2. It also returns `eol`, the ending the source used.
+3. `buildAppendContent()` re-applies `eol` to the content it returns.
+
+A fresh save is unaffected: it creates the file, so it defines the convention
+(LF).
+
+### Why restore rather than normalise the file
+
+The alternative — normalise once in `ObsidianApiClient.getFile()` and always
+write LF — is a smaller change, and was rejected. The notes belong to the user,
+not to this extension. An append is a request to add messages to a file, not a
+licence to rewrite every line of it. For the reporter specifically, whose
+tooling writes CRLF, converting on each sync would produce a rewrite war
+visible in every diff of a version-controlled vault.
+
+### Mixed files: first occurrence wins
+
+`detectLineEnding()` takes the first `\r\n | \r | \n` it finds. Deterministic
+and cheap, and a mixed file converges on whichever style it opens with instead
+of staying mixed.
+
+### Lone CR yes, U+2028 / U+2029 no
+
+Lone CR costs nothing — it falls out of the same split — and without it a
+classic-Mac file is not merely misread but unparseable. `U+2028` / `U+2029` are
+deliberately **not** treated as line breaks: neither Markdown nor YAML uses them
+as such, and rewriting them would alter body text rather than repair it. They
+remain ordinary characters inside a value.
+
+## Consequences
+
+- A note maintained as CRLF by external tooling is recognised as its own, so the
+  duplicate-note fork of #365 stops for that cause.
+- Appends preserve the file's line ending; no mixed-ending output.
+- `ParsedFrontmatter.raw` and `.body` are now always LF regardless of input.
+  All three call sites (`append-utils.ts` ×2, `note-identity.ts`) were checked.
+- Existing behaviour on LF files is unchanged: the 1461 tests that predate this
+  change pass without a single edit.
+- **Duplicates already written are not merged.** This stops new ones; existing
+  pairs need manual consolidation.
+- A BOM-prefixed file still fails `content.startsWith('---')` and is reported as
+  `unparseable`. That is a different defect and is left alone deliberately —
+  ADR-025's states exist precisely so the next report can name it.
+
+## Alternatives considered
+
+- **Make the regexes CR-tolerant** (`\r?$`, or trim each line). The smallest
+  possible diff, but it leaves `updateFrontmatter()`'s mixed output in place,
+  does nothing for lone CR, and spreads line-ending awareness across every
+  pattern anyone adds later. Rejected.
+- **Normalise in `getFile()`, always write LF.** See above — rewrites the user's
+  file as a side effect of appending to it.
+- **Parse YAML with a real library.** Would fix this and the BOM case, and the
+  Local REST API can even return parsed frontmatter itself via
+  `Accept: application/vnd.olrapi.note+json`. But it is a large change to the
+  read path of every save, made while a targeted cause is already identified and
+  reproduced. Recorded here as the option to revisit if the hand-rolled parser
+  produces a third class of failure.

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -8,7 +8,7 @@
 import type { ObsidianApiClient } from './obsidian-api';
 import type { ObsidianNote, ExtensionSettings, FilenameScheme } from './types';
 import { SCAN_MAX_REQUESTS } from './constants';
-import { parseFrontmatter, updateFrontmatter } from './frontmatter-parser';
+import { parseFrontmatter, updateFrontmatter, applyLineEnding } from './frontmatter-parser';
 import { classifyNoteProbe, isSameConversation, type NoteProbe } from './note-identity';
 import { countExistingMessages, extractTailMessages } from './message-counter';
 import { formatDateWithTimezone } from './date-utils';
@@ -391,10 +391,14 @@ export function buildAppendContent(
   });
 
   // 6. Rebuild: updated frontmatter + existing body + separator + new messages
+  //
+  // Everything above works on the LF-normalised forms parseFrontmatter returns,
+  // so the result is restored to the file's own line ending before it goes
+  // back. An append must add to the file, not rewrite every line of it (#365).
   const content = updatedRaw + '\n' + parsed.body + '\n\n' + newMessages;
 
   return {
-    content,
+    content: applyLineEnding(content, parsed.eol),
     messagesAppended: newTotal - existingCount,
   };
 }

--- a/src/lib/frontmatter-parser.ts
+++ b/src/lib/frontmatter-parser.ts
@@ -7,25 +7,61 @@
 
 import { escapeYamlValue } from './yaml-utils';
 
+/** Line ending a file uses. Lone CR is legacy but costs nothing to support. */
+export type LineEnding = '\r\n' | '\n' | '\r';
+
+/**
+ * Line ending this content uses, taken from its first occurrence.
+ *
+ * First-occurrence wins is deliberate: it is deterministic and cheap, and a
+ * mixed-ending file ends up consistently on whichever style it opened with
+ * rather than staying mixed.
+ */
+export function detectLineEnding(content: string): LineEnding {
+  const match = /\r\n|\r|\n/.exec(content);
+  return (match?.[0] as LineEnding | undefined) ?? '\n';
+}
+
+/** Rewrite every line ending in `content` to `eol`. */
+export function applyLineEnding(content: string, eol: LineEnding): string {
+  return eol === '\n' ? content : content.replace(/\n/g, eol);
+}
+
 /**
  * Parsed frontmatter result
  */
 interface ParsedFrontmatter {
-  /** Raw frontmatter string including --- delimiters */
+  /** Raw frontmatter string including --- delimiters, normalised to LF */
   raw: string;
   /** Parsed key-value pairs (tags stored as string[]) */
   fields: Record<string, string | string[]>;
-  /** Body content after frontmatter */
+  /** Body content after frontmatter, normalised to LF */
   body: string;
+  /**
+   * Line ending the source content used, so a writer can restore it (#365).
+   * `raw` and `body` are always LF; the caller re-applies this on the way out.
+   */
+  eol: LineEnding;
 }
 
 /**
  * Parse YAML frontmatter from markdown content.
  * Returns null if no valid frontmatter found.
+ *
+ * Line endings are normalised to LF before anything is matched. A CR-terminated
+ * line defeats the key-value pattern below outright: a wildcard matches every
+ * character *except* line terminators, U+000D CR is one of them, and `$`
+ * without the `m` flag only matches at the end of the input (MDN). A file
+ * rewritten on Windows therefore parsed as a valid frontmatter block with zero
+ * fields, so `fields.id` came back undefined and the save path forked a
+ * duplicate note for a file that was its own (issue #365).
  */
 export function parseFrontmatter(content: string): ParsedFrontmatter | null {
   // Must start with ---
   if (!content.startsWith('---')) return null;
+
+  const eol = detectLineEnding(content);
+  content = content.replace(/\r\n|\r/g, '\n');
 
   // Find closing --- (must be at line start)
   const closingIndex = content.indexOf('\n---', 3);
@@ -74,7 +110,7 @@ export function parseFrontmatter(content: string): ParsedFrontmatter | null {
     }
   }
 
-  return { raw, fields, body };
+  return { raw, fields, body, eol };
 }
 
 /**

--- a/test/background/index.test.ts
+++ b/test/background/index.test.ts
@@ -1079,6 +1079,29 @@ describe('background/index', () => {
         warn.mockRestore();
       });
 
+      it('does not fork when the existing note is CRLF-terminated (issue #365)', async () => {
+        // The reported failure end to end: a note the extension wrote, later
+        // rewritten with Windows line endings by the user's own tooling. It
+        // used to read as `no-id`, so the save forked `…-<hash>.md` beside it.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const ownNote = ['---', 'id: test-id', 'title: T', '---', '', 'Body'].join('\r\n');
+        mockClient.getFile.mockImplementation((path: string) =>
+          Promise.resolve(path === 'AI/Gemini/test.md' ? ownNote : null)
+        );
+        mockClient.putFile.mockResolvedValue(undefined);
+
+        const sendResponse = vi.fn();
+        send(sendResponse);
+        await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+
+        // Written back to its own name, not to a collision-free alternative.
+        expect(mockClient.putFile).toHaveBeenCalledWith('AI/Gemini/test.md', expect.any(String));
+        expect(warn.mock.calls.filter(c => String(c[0]).includes('Filename collision'))).toEqual(
+          []
+        );
+        warn.mockRestore();
+      });
+
       it('stays silent when the note lands on its canonical name', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         mockClient.getFile.mockResolvedValue(null);

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -571,6 +571,58 @@ describe('buildAppendContent', () => {
     expect(result!.content).toContain('> Hi there!');
   });
 
+  // ===== line endings (issue #365) =====
+  //
+  // An append must not rewrite the line endings of a file the user (or their
+  // tooling) maintains as CRLF. Normalising for processing is fine; writing the
+  // normalised form back is not — it would touch every line of a file we were
+  // only asked to add to.
+
+  it('appends to a CRLF file without disturbing the existing bytes', () => {
+    const existingLines = [
+      '---',
+      'id: claude_test',
+      'message_count: 2',
+      'modified: "2026-01-01T00:00:00.000Z"',
+      '---',
+      '> [!QUESTION] User',
+      '> Hello',
+      '',
+      '> [!NOTE] Claude',
+      '> Hi there!',
+    ];
+    const existing = existingLines.join('\r\n');
+
+    const result = buildAppendContent(existing, testNote, testSettings);
+
+    expect(result).not.toBeNull();
+    expect(result!.messagesAppended).toBe(2);
+    // The whole file stays CRLF — no mixed endings anywhere.
+    expect(result!.content).not.toMatch(/(?<!\r)\n/);
+    // …and the body we were not asked to touch is preserved verbatim.
+    expect(result!.content).toContain(['> [!QUESTION] User', '> Hello'].join('\r\n'));
+    expect(result!.content).toContain('New question');
+  });
+
+  it('keeps an LF file on LF', () => {
+    const existing = [
+      '---',
+      'id: claude_test',
+      'message_count: 2',
+      '---',
+      '> [!QUESTION] User',
+      '> Hello',
+      '',
+      '> [!NOTE] Claude',
+      '> Hi there!',
+    ].join('\n');
+
+    const result = buildAppendContent(existing, testNote, testSettings);
+
+    expect(result).not.toBeNull();
+    expect(result!.content).not.toContain('\r');
+  });
+
   it('updates modified timestamp in frontmatter', () => {
     const existing = [
       '---',

--- a/test/lib/frontmatter-parser.test.ts
+++ b/test/lib/frontmatter-parser.test.ts
@@ -113,6 +113,101 @@ describe('frontmatter-parser', () => {
 
   // ========== updateFrontmatter ==========
 
+  // ========== line endings (issue #365) ==========
+  //
+  // A note rewritten by an external tool on Windows comes back CRLF-terminated.
+  // `split('\n')` then leaves a trailing `\r` on every line, and the key-value
+  // pattern cannot match it: MDN states a wildcard "matches all characters
+  // except line terminators", U+000D CR is a line terminator, and `$` without
+  // the `m` flag "asserts that the character to the right is out of bounds of
+  // the string". So every field was silently dropped, `fields.id` came back
+  // undefined, and the save path forked a duplicate note for a file that was
+  // its own (#365).
+
+  describe('line endings', () => {
+    /** The reporter's own note (#365, 2026-08-05), field-for-field. */
+    const REPORTED_LINES = [
+      '---',
+      'id: claude_5acb9457-ae97-4744-a048-46d716e674ed',
+      'title: Gmail search returning irrelevant results',
+      'source: claude',
+      'url: "https://claude.ai/chat/5acb9457-ae97-4744-a048-46d716e674ed"',
+      'created: "2026-08-01T10:35:27+03:00"',
+      'modified: "2026-08-01T13:04:00+03:00"',
+      'tags: ["gmail", "semantic-search", "hebrew"]',
+      'message_count: 239',
+      '---',
+      '',
+      '> [!QUESTION] User',
+      '> Hello',
+    ];
+    const withEol = (eol: string): string => REPORTED_LINES.join(eol);
+    const EXPECTED_ID = 'claude_5acb9457-ae97-4744-a048-46d716e674ed';
+
+    it('reads every field from a CRLF file (issue #365)', () => {
+      const result = parseFrontmatter(withEol('\r\n'));
+
+      expect(result).not.toBeNull();
+      expect(result!.fields.id).toBe(EXPECTED_ID);
+      expect(result!.fields.title).toBe('Gmail search returning irrelevant results');
+      expect(result!.fields.message_count).toBe('239');
+    });
+
+    it('reads every field from a lone-CR file', () => {
+      const result = parseFrontmatter(withEol('\r'));
+
+      expect(result).not.toBeNull();
+      expect(result!.fields.id).toBe(EXPECTED_ID);
+    });
+
+    it('reports the file’s line ending so writers can preserve it', () => {
+      expect(parseFrontmatter(withEol('\r\n'))!.eol).toBe('\r\n');
+      expect(parseFrontmatter(withEol('\r'))!.eol).toBe('\r');
+      expect(parseFrontmatter(withEol('\n'))!.eol).toBe('\n');
+    });
+
+    it('takes the first line ending it sees when a file is mixed', () => {
+      // Decided rule: first occurrence wins — simple and deterministic.
+      const mixed = `---\r\nid: ${EXPECTED_ID}\ntitle: T\r\n---\r\n\r\nBody`;
+      const result = parseFrontmatter(mixed);
+
+      expect(result!.eol).toBe('\r\n');
+      expect(result!.fields.id).toBe(EXPECTED_ID);
+    });
+
+    it('normalises raw and body to LF regardless of the source endings', () => {
+      const crlf = parseFrontmatter(withEol('\r\n'))!;
+      const lf = parseFrontmatter(withEol('\n'))!;
+
+      expect(crlf.raw).not.toContain('\r');
+      expect(crlf.body).not.toContain('\r');
+      // The strongest statement of intent: the source endings must make no
+      // difference to anything downstream except the recorded `eol`.
+      expect(crlf.raw).toBe(lf.raw);
+      expect(crlf.body).toBe(lf.body);
+      expect(crlf.fields).toEqual(lf.fields);
+    });
+
+    it('parses a CRLF tag list into the same array as an LF one', () => {
+      const lines = ['---', 'tags:', '  - ai-conversation', '  - claude', '---', 'Body'];
+
+      expect(parseFrontmatter(lines.join('\r\n'))!.fields.tags).toEqual([
+        'ai-conversation',
+        'claude',
+      ]);
+      expect(parseFrontmatter(lines.join('\n'))!.fields.tags).toEqual([
+        'ai-conversation',
+        'claude',
+      ]);
+    });
+
+    it('still rejects content that does not open with a delimiter', () => {
+      // A UTF-8 BOM is a different failure and stays a failure: the caller
+      // reports it as `unparseable`, not as another conversation.
+      expect(parseFrontmatter('﻿' + withEol('\r\n'))).toBeNull();
+    });
+  });
+
   describe('updateFrontmatter', () => {
     it('updates existing field values', () => {
       const raw = '---\nid: abc\nmodified: "2026-01-01"\nmessage_count: 2\n---';

--- a/test/lib/note-identity.test.ts
+++ b/test/lib/note-identity.test.ts
@@ -71,6 +71,48 @@ describe('classifyNoteProbe', () => {
   });
 });
 
+describe('line endings (issue #365 regression)', () => {
+  // The reported failure, reduced: a note the extension itself wrote, later
+  // rewritten CRLF-terminated by the reporter's own tagging tool on Windows.
+  // The save path read `no-id` from a file whose first frontmatter line is the
+  // matching id, decided it belonged to another conversation, and forked a
+  // duplicate.
+  const lines = [
+    '---',
+    `id: ${ID}`,
+    'title: Gmail search returning irrelevant results',
+    'source: claude',
+    'message_count: 239',
+    '---',
+    '',
+    '> [!QUESTION] User',
+    '> Hello',
+  ];
+
+  it('recognises its own note when the file has CRLF endings', () => {
+    expect(classifyNoteProbe(lines.join('\r\n'), ID)).toEqual({
+      state: 'same-conversation',
+      foundId: ID,
+    });
+  });
+
+  it('recognises its own note when the file has lone-CR endings', () => {
+    expect(classifyNoteProbe(lines.join('\r'), ID)).toEqual({
+      state: 'same-conversation',
+      foundId: ID,
+    });
+  });
+
+  it('still reports a different conversation when the id genuinely differs', () => {
+    const foreign = lines.map(l => l.replace(ID, 'claude_ffffffff')).join('\r\n');
+
+    expect(classifyNoteProbe(foreign, ID)).toEqual({
+      state: 'different-id',
+      foundId: 'claude_ffffffff',
+    });
+  });
+});
+
 describe('isSameConversation', () => {
   const NOT_OURS: ProbeState[] = ['absent', 'empty', 'unparseable', 'no-id', 'different-id'];
 


### PR DESCRIPTION
## Summary

Root cause of the duplicate notes in #365. The first field report after the 2.7.0 diagnostics shipped named it outright: `directProbe: {state: 'no-id'}` on a file whose first frontmatter line is the matching id.

### The mechanism

`parseFrontmatter()` split on `'\n'` and matched each line with

```js
/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/
```

On a CRLF file every line keeps a trailing `\r`, which this cannot match. Per MDN: a wildcard "matches all characters **except line terminators**", **U+000D CR is one of them**, and `$` without the `m` flag "asserts that the character to the right is out of bounds of the string". So `(.*)` stops before the `\r` and `$` is never reached:

```
node -e "console.log('id: abc\r'.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/))"
→ null
```

Every field was dropped while the block still *looked* like valid frontmatter, so the parser returned zero fields, `fields.id` was `undefined`, and the save path did exactly what it is designed to do with a file it cannot identify (#327): refuse to overwrite it and fork a new name.

### Why it only happened to some people

The reporter is on Windows and post-processes frontmatter with their own tagging tool — the rewritten file's inline `tags: [...]` array is a YAML dumper's signature. The extension's own copy of the same conversation, untouched by that tool, read as `same-conversation` in the very same save. LF readable, CRLF not, in one vault. It also explains why a scan of 186 notes in an all-LF vault found nothing, and why the affected files always looked correct on inspection — the content was never damaged, only unreadable.

### Measured blast radius

| Function | LF | CRLF | lone CR |
| --- | --- | --- | --- |
| `parseFrontmatter().fields.id` | ok | **undefined** | `null` |
| `countExistingMessages()` | 4 | 4 | **0** |
| `extractTailMessages()` | ok | ok | **empty** |
| `updateFrontmatter()` | ok | **mixed endings** | — |
| `flattenLargeCallouts()` | ok | ok | — |

Only field extraction is a functional break — but fixing it alone would expose row 4, leaving every append to a CRLF file with mixed endings.

### The change

Normalise on read, restore on write (ADR-026):

- `parseFrontmatter()` normalises `\r\n` and `\r` before matching, returns `raw`/`body` in that form, and reports the source `eol`. Nothing downstream needs line-ending awareness of its own.
- `buildAppendContent()` re-applies that `eol`.
- Mixed files: first occurrence wins. Lone CR supported; `U+2028`/`U+2029` deliberately not treated as line breaks, since neither Markdown nor YAML uses them that way and rewriting them would alter body text.

Normalising in `getFile()` and always writing LF was rejected: an append is a request to add messages to a file, not a licence to rewrite every line of it — for this reporter it would mean a rewrite war with their own tooling on every sync.

**Already-written duplicates are not merged.** This stops new ones.

## Test plan

- [x] `npm test` — **1474 passed**. The 1461 tests that predate this change pass **without a single edit**, which is the statement that LF behaviour is unchanged
- [x] New: the reporter's own frontmatter as a CRLF fixture; lone CR; mixed; BOM still `unparseable`; CRLF and LF parses asserted *identical*
- [x] New: `classifyNoteProbe` on a CRLF note → `same-conversation` (the #365 regression test)
- [x] New: append to a CRLF file keeps the existing bytes and produces no mixed endings; an LF file stays LF
- [x] New: background save does not fork when the existing note is CRLF
- [x] `npm run lint` — 0 errors (3 pre-existing warnings); `npm run format:check`; `npm run build`
- [x] Coverage: `frontmatter-parser.ts` 98.14 / 87.5 / 100 / 98.07; overall 96.4 / 87.55 / 98.94 / 97.44
- [x] **Live against Obsidian's Local REST API**: a CRLF note round-trips CRLF, probes as `same-conversation`, appends 2 messages, and the file on disk stays entirely CRLF

Fixes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)
