### PR TITLE
fix: let the service worker connect to the image CDN

### DIFF
--- a/docs/adr/027-generated-image-capture-from-rendered-element.md
+++ b/docs/adr/027-generated-image-capture-from-rendered-element.md
@@ -1,0 +1,122 @@
+# ADR-027: Capture generated images from the rendered element when the blob URL is gone
+
+- Status: Proposed
+- Date: 2026-08-07
+- Related: [ADR-008](008-image-sync-strategy.md), [ADR-021](021-remote-image-fetch-in-service-worker.md), issue #186, issue #376
+- Extends: the capture half of ADR-008
+
+## Context
+
+Gemini-generated images stopped reaching the vault. The saved note's assistant
+turn for an image prompt was **completely empty** — no embed, no placeholder, no
+warning, in both the Obsidian and file-download outputs.
+
+### What was measured
+
+All figures below come from live probing of a real conversation through the CDP
+daemon on 2026-08-06/07.
+
+Detection was never the problem: `generated-image img[src]` and both fallbacks
+matched (1 element), inside the assistant content panel, with `complete: true`
+and `naturalWidth × naturalHeight = 1024 × 572`. **The image renders correctly.**
+
+The `src` takes two forms across page loads, and each has exactly one mechanism
+that can reach its bytes:
+
+| `src` form | page (main world) fetch | isolated-world fetch | canvas on the live element | reload with `crossOrigin="anonymous"` | background fetch |
+| --- | --- | --- | --- | --- | --- |
+| `blob:` | ✗ `Failed to fetch` | ✗ `Failed to fetch` | **✓ `image/png`, 1,190,471 B** | — | rejected by the allow-list, by design |
+| `https:` CDN | ✗ (CORS) | ✗ (CORS) | ✗ `SecurityError` (tainted) | ✗ `LOAD FAILED` (no ACAO) | **✓ 200, `image/jpeg`, 131,692 B** |
+
+### Why the blob URL is unreadable
+
+The blob fetch fails **from the page's own main world** while the `<img>` keeps
+rendering. That can only mean the URL has been revoked: MDN describes
+`URL.revokeObjectURL()` as telling the browser "not to keep the reference to the
+file any longer". The element goes on displaying because it holds the decoded
+bitmap, not the URL.
+
+So the premise written into `image-capture.ts` —
+
+> `blob:` URLs are read here because only the page context can resolve them
+
+— no longer holds. **Nobody** can resolve them.
+
+### Why the https form cannot use the same trick
+
+MDN: "As soon as you draw into a canvas any data that was loaded from another
+origin without CORS approval, the canvas becomes tainted", and `toDataURL()`
+then throws `SecurityError`. Measured exactly that, both on the live element and
+on a fresh `<img>`. Setting `crossOrigin="anonymous"` does not help because the
+CDN sends no `Access-Control-Allow-Origin` — the image simply fails to load.
+Chrome's own guidance is to route such fetches through the service worker, which
+is what ADR-021 already does, and the same guidance warns that "a malicious web
+page may abuse the message handler", which is why `isAllowedImageSourceUrl()`
+stays exactly as it is.
+
+### Why nobody noticed which step failed
+
+`collectPendingImages()` dropped failures with `if (image) images.push(image)`,
+`fetchImageAsBase64()` returned a bare `null` for every cause,
+`handleFetchImage()` built an error string nobody read, and once `images` came
+back empty `prepareNoteImages()` called `stripImagePlaceholders()`, erasing the
+marker. There was no `console.*` anywhere in `image-capture.ts`,
+`image-fetch.ts` or `image-output.ts`, and `imageWarning()` only covers vault
+*write* failures. The result was an empty assistant message — **identical to
+what image export being switched off produces**.
+
+## Decision
+
+**Dispatch on the source form, and never fail silently.**
+
+1. `blob:` — try the URL first (a live blob still yields the original encoding),
+   then fall back to reading the bytes off the rendered element through a canvas.
+2. anything else — delegate to the service worker, unchanged.
+3. No cross-fallback. A canvas read of an https source always raises
+   SecurityError and the worker's allow-list always rejects `blob:`; trying
+   either would only cost time.
+4. Every failure carries a reason. It is logged (`console.warn`) and folded into
+   the extraction warnings, which the content script already surfaces through
+   `showWarningToast()`.
+
+Supporting details:
+
+- **PNG for the canvas path.** The original encoding is unrecoverable once the
+  image is decoded, so re-encoding picks one. It is not free: the same image
+  measured 131KB as the CDN's JPEG and 1.19MB as a re-encoded PNG. That is
+  precisely why the live URL is tried first.
+- **Load guard.** The generated `<img>` carries `loading="lazy"` (measured), so
+  `complete` and `naturalWidth` are checked before drawing; an undecoded element
+  would otherwise produce a blank picture.
+- **Size limit unchanged.** `MAX_IMAGE_SIZE_BYTES` (10MB) still applies to the
+  re-encoded result, and exceeding it is now reported instead of swallowed.
+
+## Consequences
+
+- Generated images reach the vault again on the `blob:` path, which is the form
+  observed on a freshly opened conversation.
+- A canvas-captured image is a PNG re-encode, not the original bytes: larger,
+  and any metadata the original carried is gone. Alt text is preserved.
+- An image that still cannot be captured now says so — in the service-worker-
+  independent page console and in the toast — instead of leaving an empty
+  assistant message.
+- **The core of this change cannot be proven by the unit tests.** jsdom has no
+  canvas, so `getContext`/`toDataURL` are stubbed and the tests only pin the
+  control flow. The evidence that a canvas read actually recovers a revoked
+  blob's bytes is the live measurement above, and the manual verification
+  recorded in the PR.
+
+## Alternatives considered
+
+- **Capture at generation time**, e.g. a MutationObserver that grabs each blob
+  before it is revoked. Does nothing for conversations opened after the fact —
+  which is the normal case — and adds a permanently running observer.
+- **`createImageBitmap()` + `OffscreenCanvas.convertToBlob()`** instead of
+  `toDataURL`. Subject to the identical tainting rules, so it changes nothing
+  about which sources are reachable; it would allow choosing JPEG and skipping
+  the base64 round-trip. Worth revisiting only if PNG size becomes a problem.
+- **Ask the CDN for the image via `crossOrigin="anonymous"`** so the canvas
+  stays clean for both forms. Measured: the load fails outright, because the CDN
+  sends no CORS header.
+- **Keep fetching the blob URL only.** This is the status quo, and it is
+  measurably dead.

--- a/src/content/extractors/gemini.ts
+++ b/src/content/extractors/gemini.ts
@@ -7,7 +7,7 @@ import { BaseExtractor } from './base';
 import { sanitizeHtml } from '../../lib/sanitize';
 import { extractErrorMessage } from '../../lib/error-utils';
 import { ensureAllElementsLoaded, type ScrollResult } from '../../lib/scroll-manager';
-import { fetchImageAsBase64 } from '../image-capture';
+import { captureImage } from '../image-capture';
 import type {
   SyncSettings,
   ExtractionResult,
@@ -30,7 +30,9 @@ export class GeminiExtractor extends BaseExtractor {
    * the start of every extract() so re-runs never carry stale ids.
    */
   private imageIdCounter = 0;
-  private pendingImages: Array<{ id: string; src: string; alt: string }> = [];
+  private pendingImages: Array<{ id: string; alt: string; element: HTMLImageElement }> = [];
+  /** Reasons images could not be captured, surfaced as a warning (issue: revoked blob URLs). */
+  private imageFailures: string[] = [];
 
   /**
    * Apply user settings: enable/disable auto-scroll
@@ -65,6 +67,7 @@ export class GeminiExtractor extends BaseExtractor {
       // Reset per-extraction image state before extractMessages() populates it.
       this.imageIdCounter = 0;
       this.pendingImages = [];
+      this.imageFailures = [];
 
       const scrollResult = await this.runAutoScroll();
 
@@ -312,7 +315,11 @@ export class GeminiExtractor extends BaseExtractor {
 
     const clone = element.cloneNode(true) as HTMLElement;
     const imgs = clone.querySelectorAll<HTMLImageElement>(COMPUTED_SELECTORS.generatedImage);
-    imgs.forEach(img => {
+    // The clone's images are markers-to-be; the LIVE elements are what capture
+    // needs, because a revoked blob URL can only be read back off the rendered
+    // bitmap. querySelectorAll is document order, so index i pairs the two.
+    const live = element.querySelectorAll<HTMLImageElement>(COMPUTED_SELECTORS.generatedImage);
+    imgs.forEach((img, index) => {
       // Image export disabled: drop the generated image so a src-less <img>
       // does not leak an empty `![]()` link into the note.
       if (!this.enableImageExport) {
@@ -321,10 +328,11 @@ export class GeminiExtractor extends BaseExtractor {
       }
 
       const src = img.getAttribute('src') ?? '';
-      if (!src) return;
+      const element = live[index];
+      if (!src || !element) return;
       const id = `img-${++this.imageIdCounter}`;
       const alt = img.getAttribute('alt') ?? '';
-      this.pendingImages.push({ id, src, alt });
+      this.pendingImages.push({ id, alt, element });
 
       const marker = clone.ownerDocument.createElement('img');
       marker.setAttribute('data-g2o-image', id);
@@ -343,7 +351,14 @@ export class GeminiExtractor extends BaseExtractor {
   private async attachImages(result: ExtractionResult): Promise<ExtractionResult> {
     if (!result.success || !result.data) return result;
     const images = await this.collectPendingImages();
-    return { ...result, data: { ...result.data, images } };
+    const warnings =
+      this.imageFailures.length > 0
+        ? [
+            ...(result.warnings ?? []),
+            `${this.imageFailures.length} image(s) could not be captured: ${[...new Set(this.imageFailures)].join('; ')}`,
+          ]
+        : result.warnings;
+    return { ...result, data: { ...result.data, images }, ...(warnings && { warnings }) };
   }
 
   /**
@@ -353,8 +368,16 @@ export class GeminiExtractor extends BaseExtractor {
   private async collectPendingImages(): Promise<ExtractedImage[]> {
     const images: ExtractedImage[] = [];
     for (const pending of this.pendingImages) {
-      const image = await fetchImageAsBase64(pending.src, pending.id, pending.alt);
-      if (image) images.push(image);
+      const result = await captureImage(pending.element, pending.id, pending.alt);
+      if (result.image) {
+        images.push(result.image);
+        continue;
+      }
+      // Never drop an image in silence: a lost one leaves an empty assistant
+      // message that looks identical to image export being switched off.
+      const reason = result.reason ?? 'unknown error';
+      console.warn(`[G2O] Image capture failed (${pending.id}): ${reason}`);
+      this.imageFailures.push(reason);
     }
     return images;
   }

--- a/src/content/image-capture.ts
+++ b/src/content/image-capture.ts
@@ -7,7 +7,26 @@
  */
 
 import { MAX_IMAGE_SIZE_BYTES, bytesToBase64, isAllowedImageMime } from '../lib/image-utils';
+import { getErrorMessage } from '../lib/error-utils';
 import type { ExtractedImage, ImageFetchResponse } from '../lib/types';
+
+/**
+ * Outcome of capturing one image.
+ *
+ * A failure used to be an unqualified `null` that the caller dropped in
+ * silence, so a lost image left nothing behind but an empty assistant message —
+ * indistinguishable from image export being switched off. The reason travels
+ * with the result now so it can be logged and surfaced.
+ */
+export interface ImageCaptureResult {
+  image: ExtractedImage | null;
+  /** Present only on failure. */
+  reason?: string;
+}
+
+function captureFailed(reason: string): ImageCaptureResult {
+  return { image: null, reason };
+}
 
 /**
  * Resolve the MIME type to record for a captured blob, or null when the blob
@@ -36,6 +55,18 @@ async function fetchRemoteImage(
   id: string,
   alt: string
 ): Promise<ExtractedImage | null> {
+  return (await fetchRemoteImageDetailed(url, id, alt)).image;
+}
+
+/**
+ * As {@link fetchRemoteImage}, but keeping the worker's reason for a failure
+ * instead of collapsing it into `null`.
+ */
+async function fetchRemoteImageDetailed(
+  url: string,
+  id: string,
+  alt: string
+): Promise<ImageCaptureResult> {
   try {
     const response = (await chrome.runtime.sendMessage({
       action: 'fetchImage',
@@ -43,12 +74,14 @@ async function fetchRemoteImage(
     })) as ImageFetchResponse | undefined;
 
     if (!response?.success) {
-      return null;
+      return captureFailed(response?.error ?? 'background fetch returned no response');
     }
-    return { id, mimeType: response.mimeType, data: response.data, alt, sourceUrl: url };
-  } catch {
+    return {
+      image: { id, mimeType: response.mimeType, data: response.data, alt, sourceUrl: url },
+    };
+  } catch (error) {
     // Service worker asleep or message channel closed — skip this image.
-    return null;
+    return captureFailed(`background fetch unavailable: ${getErrorMessage(error)}`);
   }
 }
 
@@ -95,4 +128,98 @@ export async function fetchImageAsBase64(
     // Revoked/expired blob URL, CORS, or read failure — skip this image.
     return null;
   }
+}
+
+/** Data-URL prefix produced by `canvas.toDataURL('image/png')`. */
+const PNG_DATA_URL_PREFIX = 'data:image/png;base64,';
+
+/** Approximate decoded byte length of a base64 payload. */
+function base64ByteLength(base64: string): number {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+/**
+ * Read the bytes back out of an already-rendered `<img>` via a canvas.
+ *
+ * This is the only way left to reach a generated image whose `blob:` URL Gemini
+ * has revoked: the URL no longer resolves — not even from the page's own main
+ * world — while the element keeps its decoded bitmap and goes on rendering.
+ *
+ * Only same-origin sources can be read this way. Drawing cross-origin data
+ * without CORS approval taints the canvas, and `toDataURL()` then throws a
+ * SecurityError (MDN). That is why https CDN sources keep going through the
+ * service worker instead — and it is measured, not assumed: the CDN serves no
+ * `Access-Control-Allow-Origin`, so even `crossOrigin="anonymous"` fails to load.
+ *
+ * PNG is used because the original encoding is unrecoverable once the image is
+ * decoded. It costs size — a 131KB JPEG measured 1.19MB as re-encoded PNG — so
+ * this path runs only when the original bytes are genuinely out of reach.
+ */
+function captureFromElement(
+  element: HTMLImageElement,
+  id: string,
+  alt: string,
+  sourceUrl: string
+): ImageCaptureResult {
+  if (!element.complete || element.naturalWidth === 0) {
+    // Generated images carry loading="lazy": an off-screen one may not have
+    // decoded yet, and drawing it would yield a blank picture.
+    return captureFailed('image had not finished loading (decode incomplete)');
+  }
+
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = element.naturalWidth;
+    canvas.height = element.naturalHeight;
+    const context = canvas.getContext('2d');
+    if (!context) return captureFailed('2d canvas context unavailable');
+    context.drawImage(element, 0, 0);
+
+    const dataUrl = canvas.toDataURL('image/png');
+    if (!dataUrl.startsWith(PNG_DATA_URL_PREFIX)) {
+      return captureFailed('canvas returned an unexpected data URL');
+    }
+
+    const data = dataUrl.slice(PNG_DATA_URL_PREFIX.length);
+    if (base64ByteLength(data) > MAX_IMAGE_SIZE_BYTES) {
+      return captureFailed('re-encoded image exceeds the size limit');
+    }
+    return { image: { id, mimeType: 'image/png', data, alt, sourceUrl } };
+  } catch (error) {
+    // A tainted canvas lands here (SecurityError).
+    return captureFailed(`canvas capture failed: ${getErrorMessage(error)}`);
+  }
+}
+
+/**
+ * Capture one generated image, choosing the only mechanism that can work for
+ * its source form.
+ *
+ * - `blob:` — read the URL if it is still alive (that keeps the original
+ *   encoding), otherwise recover the bytes from the rendered element.
+ * - anything else — delegate to the service worker, which is exempt from the
+ *   CORS rules the page is bound by.
+ *
+ * The two forms are not interchangeable and no cross-fallback is attempted:
+ * a canvas read of an https source always raises SecurityError, and the
+ * worker's allow-list rejects `blob:` by design.
+ */
+export async function captureImage(
+  element: HTMLImageElement,
+  id: string,
+  alt: string
+): Promise<ImageCaptureResult> {
+  const src = element.getAttribute('src') ?? '';
+  if (!src) return captureFailed('image element has no src');
+
+  if (!src.startsWith('blob:')) {
+    const remote = await fetchRemoteImageDetailed(src, id, alt);
+    return remote;
+  }
+
+  const viaUrl = await fetchImageAsBase64(src, id, alt);
+  if (viaUrl) return { image: viaUrl };
+
+  return captureFromElement(element, id, alt, src);
 }

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -61,7 +61,7 @@ export function isAllowedImageMime(mimeType: string): boolean {
  * Host suffix serving AI-generated images that must be fetched by the
  * background worker rather than the page (see {@link isAllowedImageSourceUrl}).
  */
-const IMAGE_CDN_DOMAIN = 'googleusercontent.com';
+export const IMAGE_CDN_DOMAIN = 'googleusercontent.com';
 
 /**
  * True when `url` is a remote image source the background worker may fetch.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,7 +30,7 @@
     "https://127.0.0.1/*"
   ],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; connect-src 'self' http://127.0.0.1:* https://127.0.0.1:*; object-src 'none'; frame-src 'none'; style-src 'self'"
+    "extension_pages": "default-src 'self'; script-src 'self'; connect-src 'self' http://127.0.0.1:* https://127.0.0.1:* https://*.googleusercontent.com; object-src 'none'; frame-src 'none'; style-src 'self'"
   },
   "background": {
     "service_worker": "src/background/service-worker.ts",

--- a/test/arch/csp-connect-src.test.ts
+++ b/test/arch/csp-connect-src.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Fitness function: the manifest's CSP must permit every host the extension
+ * actually connects to.
+ *
+ * `connect-src` was introduced purely to allow the local Obsidian API
+ * (`fix(csp): add connect-src directive for localhost API access`). Naming any
+ * source at all closes every other one, and the generated-image fetch added
+ * later (#376) went out against a policy that silently blocked it: Chrome's
+ * manifest reference states the extension-pages policy "applies to page and
+ * worker contexts in the extension, including popups, background workers", so
+ * the service worker's fetch of the image CDN failed with a bare
+ * `TypeError: Failed to fetch` — reported by users as "images are not saved".
+ *
+ * Host permissions grant permission; CSP still governs the connection. Both
+ * have to list a host, and this test keeps them from drifting apart again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { IMAGE_CDN_DOMAIN } from '../../src/lib/image-utils';
+
+const manifest = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../src/manifest.json'), 'utf-8')
+) as {
+  host_permissions: string[];
+  content_security_policy: { extension_pages: string };
+};
+
+/** Sources listed for one CSP directive, or null when the directive is absent. */
+function directive(name: string): string[] | null {
+  const policy = manifest.content_security_policy.extension_pages;
+  const found = policy
+    .split(';')
+    .map(part => part.trim())
+    .find(part => part === name || part.startsWith(`${name} `));
+  if (!found) return null;
+  return found.split(/\s+/).slice(1);
+}
+
+/** True when `sources` covers `host` (exact, or a `*.` wildcard parent). */
+function covers(sources: string[], host: string): boolean {
+  return sources.some(source => {
+    const bare = source.replace(/^https?:\/\//, '').replace(/:\*$/, '').replace(/\/\*$/, '');
+    if (bare === host) return true;
+    return bare.startsWith('*.') && (host === bare.slice(2) || host.endsWith(bare.slice(1)));
+  });
+}
+
+describe('manifest CSP connect-src', () => {
+  it('permits the image CDN the service worker fetches from', () => {
+    const sources = directive('connect-src');
+    expect(sources, 'connect-src is absent, so every host is allowed').not.toBeNull();
+    expect(
+      covers(sources as string[], `lh3.${IMAGE_CDN_DOMAIN}`),
+      `connect-src does not cover the image CDN (${IMAGE_CDN_DOMAIN}); the ` +
+        `service worker's fetch will fail with "Failed to fetch". Current: ${sources?.join(' ')}`
+    ).toBe(true);
+  });
+
+  it('permits the local Obsidian API', () => {
+    const sources = directive('connect-src') as string[];
+    expect(covers(sources, '127.0.0.1')).toBe(true);
+  });
+
+  it('lists every remote host_permission it needs to connect to', () => {
+    // Content scripts are not bound by the extension CSP, so page hosts are
+    // exempt; only hosts the extension itself connects to must appear. The
+    // image CDN is the one such host today.
+    const sources = directive('connect-src') as string[];
+    const cdnPermission = manifest.host_permissions.find(p => p.includes(IMAGE_CDN_DOMAIN));
+
+    expect(cdnPermission, 'the image CDN must stay in host_permissions').toBeDefined();
+    expect(covers(sources, `lh3.${IMAGE_CDN_DOMAIN}`)).toBe(true);
+  });
+});

--- a/test/content/image-capture.test.ts
+++ b/test/content/image-capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fetchImageAsBase64 } from '../../src/content/image-capture';
+import { fetchImageAsBase64, captureImage } from '../../src/content/image-capture';
 import { MAX_IMAGE_SIZE_BYTES } from '../../src/lib/image-utils';
 
 /** Build a Blob-like object (jsdom's Blob lacks a usable arrayBuffer()). */
@@ -172,5 +172,159 @@ describe('fetchImageAsBase64 — remote (https) sources', () => {
 
     expect(spy).not.toHaveBeenCalled();
     expect(img?.data).toBe('UE5H');
+  });
+});
+
+// ===== capture from the rendered element (issue: Gemini revokes blob URLs) =====
+//
+// Measured live on 2026-08-06/07 against gemini.google.com:
+//
+//   src form   page fetch   isolated fetch   canvas(in place)   background fetch
+//   blob:      FAILS        FAILS            OK (image/png)     n/a (allow-list)
+//   https:     FAILS(CORS)  FAILS(CORS)      SecurityError      200 image/jpeg
+//
+// The blob URL fails even from the page's own main world while the <img> still
+// renders, which means Gemini revokes it once the image has decoded (MDN: the
+// browser is told "not to keep the reference to the file any longer"). The
+// element keeps the decoded bitmap, so canvas is the only way left to reach the
+// bytes. For https the canvas is tainted — MDN: drawing cross-origin data
+// without CORS approval taints the canvas and toDataURL throws SecurityError —
+// so that form must keep going through the service worker.
+//
+// jsdom has no canvas implementation, so these tests stub it. The real proof is
+// the live verification recorded in the ADR.
+
+/** An <img> that reports itself as fully decoded at the given size. */
+function loadedImage(src: string, width = 4, height = 2): HTMLImageElement {
+  const img = document.createElement('img');
+  img.setAttribute('src', src);
+  Object.defineProperty(img, 'complete', { value: true, configurable: true });
+  Object.defineProperty(img, 'naturalWidth', { value: width, configurable: true });
+  Object.defineProperty(img, 'naturalHeight', { value: height, configurable: true });
+  return img;
+}
+
+/** Stub canvas so drawImage/toDataURL behave like a browser's. */
+function mockCanvas(dataUrl: string | (() => never)): void {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage: vi.fn(),
+  } as unknown as CanvasRenderingContext2D);
+  vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockImplementation(() =>
+    typeof dataUrl === 'function' ? dataUrl() : dataUrl
+  );
+}
+
+describe('captureImage', () => {
+  it('falls back to the canvas when the blob URL has been revoked', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    mockCanvas('data:image/png;base64,UE5H');
+
+    const result = await captureImage(loadedImage('blob:https://gemini.google.com/x'), 'img-1', 'a');
+
+    expect(result.image).toMatchObject({ id: 'img-1', mimeType: 'image/png', data: 'UE5H', alt: 'a' });
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('prefers the original bytes while the blob URL is still alive', async () => {
+    // A live blob keeps the source encoding; re-encoding through the canvas
+    // would inflate a 131KB JPEG to a ~1.19MB PNG (both measured live).
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () =>
+          Promise.resolve({
+            size: bytes.byteLength,
+            type: 'image/jpeg',
+            arrayBuffer: () => Promise.resolve(bytes.buffer),
+          } as unknown as Blob),
+      })
+    );
+    const toDataURL = vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL');
+
+    const result = await captureImage(loadedImage('blob:https://gemini.google.com/y'), 'img-2', '');
+
+    expect(result.image?.mimeType).toBe('image/jpeg');
+    expect(toDataURL).not.toHaveBeenCalled();
+  });
+
+  it('reports a reason when the canvas is tainted', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    mockCanvas(() => {
+      throw new Error('SecurityError: Tainted canvases may not be exported.');
+    });
+
+    const result = await captureImage(loadedImage('blob:https://gemini.google.com/z'), 'img-3', '');
+
+    expect(result.image).toBeNull();
+    expect(result.reason).toMatch(/tainted|SecurityError/i);
+  });
+
+  it('does not capture from an element that has not finished loading', async () => {
+    // The generated <img> carries loading="lazy" (measured), so an off-screen
+    // image can still be undecoded — drawing it would yield a blank picture.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    mockCanvas('data:image/png;base64,UE5H');
+    const img = document.createElement('img');
+    img.setAttribute('src', 'blob:https://gemini.google.com/w');
+    Object.defineProperty(img, 'complete', { value: false, configurable: true });
+    Object.defineProperty(img, 'naturalWidth', { value: 0, configurable: true });
+
+    const result = await captureImage(img, 'img-4', '');
+
+    expect(result.image).toBeNull();
+    expect(result.reason).toMatch(/load|decode/i);
+  });
+
+  it('routes an https source to the service worker and never touches the canvas', async () => {
+    const sendMessage = vi.fn().mockResolvedValue({
+      success: true,
+      data: '/9j/',
+      mimeType: 'image/jpeg',
+    });
+    vi.stubGlobal('chrome', { runtime: { sendMessage } });
+    const toDataURL = vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL');
+
+    const result = await captureImage(
+      loadedImage('https://lh3.googleusercontent.com/gg/abc'),
+      'img-5',
+      'alt'
+    );
+
+    expect(result.image).toMatchObject({ id: 'img-5', mimeType: 'image/jpeg', data: '/9j/' });
+    expect(sendMessage).toHaveBeenCalledWith({
+      action: 'fetchImage',
+      url: 'https://lh3.googleusercontent.com/gg/abc',
+    });
+    expect(toDataURL).not.toHaveBeenCalled();
+  });
+
+  it('reports the worker’s reason when the remote fetch fails', async () => {
+    vi.stubGlobal('chrome', {
+      runtime: {
+        sendMessage: vi.fn().mockResolvedValue({ success: false, error: 'HTTP 403' }),
+      },
+    });
+
+    const result = await captureImage(
+      loadedImage('https://lh3.googleusercontent.com/gg/def'),
+      'img-6',
+      ''
+    );
+
+    expect(result.image).toBeNull();
+    expect(result.reason).toContain('403');
+  });
+
+  it('rejects a canvas capture that exceeds the size limit', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const oversized = 'A'.repeat(Math.ceil((MAX_IMAGE_SIZE_BYTES + 1024) / 3) * 4);
+    mockCanvas(`data:image/png;base64,${oversized}`);
+
+    const result = await captureImage(loadedImage('blob:https://gemini.google.com/big'), 'img-7', '');
+
+    expect(result.image).toBeNull();
+    expect(result.reason).toMatch(/size|limit/i);
   });
 });

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -312,6 +312,67 @@ describe('GeminiExtractor', () => {
       expect(assistant?.content).toContain('data-g2o-image="img-1"');
     });
 
+    it('recovers the image from the rendered element when the blob URL is revoked', async () => {
+      // Gemini revokes the blob URL once the image has decoded, so the fetch
+      // fails while the <img> keeps rendering (measured live 2026-08-06: the
+      // fetch fails even from the page's own main world). The element still
+      // holds the bitmap, so the capture has to come off a canvas.
+      setGeminiLocation('imgrevoked');
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+        drawImage: vi.fn(),
+      } as unknown as CanvasRenderingContext2D);
+      vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+        'data:image/png;base64,UE5H'
+      );
+      loadFixture(
+        createGeminiConversationDOM([
+          { role: 'user', content: 'draw' },
+          { role: 'assistant', content: IMG_HTML('blob:https://gemini.google.com/revoked') },
+        ])
+      );
+      const img = document.querySelector('img.image') as HTMLImageElement;
+      Object.defineProperty(img, 'complete', { value: true, configurable: true });
+      Object.defineProperty(img, 'naturalWidth', { value: 8, configurable: true });
+      Object.defineProperty(img, 'naturalHeight', { value: 4, configurable: true });
+
+      const result = await extractor.extract();
+
+      expect(result.data?.images).toHaveLength(1);
+      expect(result.data?.images?.[0]).toMatchObject({ id: 'img-1', mimeType: 'image/png' });
+      vi.restoreAllMocks();
+    });
+
+    it('warns instead of silently dropping an image it could not capture', async () => {
+      // A dropped image used to leave nothing at all: the marker was stripped
+      // at save time and the assistant message came out empty, which looks
+      // exactly like image export being switched off.
+      setGeminiLocation('imgfail');
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+        drawImage: vi.fn(),
+      } as unknown as CanvasRenderingContext2D);
+      vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockImplementation(() => {
+        throw new Error('SecurityError: Tainted canvases may not be exported.');
+      });
+      loadFixture(
+        createGeminiConversationDOM([
+          { role: 'user', content: 'draw' },
+          { role: 'assistant', content: IMG_HTML('blob:https://gemini.google.com/tainted') },
+        ])
+      );
+      const img = document.querySelector('img.image') as HTMLImageElement;
+      Object.defineProperty(img, 'complete', { value: true, configurable: true });
+      Object.defineProperty(img, 'naturalWidth', { value: 8, configurable: true });
+      Object.defineProperty(img, 'naturalHeight', { value: 4, configurable: true });
+
+      const result = await extractor.extract();
+
+      expect(result.data?.images).toHaveLength(0);
+      expect(result.warnings?.join(' ')).toMatch(/1 image/i);
+      vi.restoreAllMocks();
+    });
+
     it('leaves conversations without images unaffected', async () => {
       setGeminiLocation('noimg');
       loadFixture(


### PR DESCRIPTION
## Summary

Gemini-generated images never reached the vault: the assistant turn for an image prompt came out **completely empty** — no embed, no placeholder, no warning, in both the Obsidian and file-download outputs. Two independent defects, both measured.

### 1. The manifest's CSP blocked the service worker's fetch

```
connect-src 'self' http://127.0.0.1:* https://127.0.0.1:*
```

Chrome's manifest reference: the extension-pages policy "applies to page and worker contexts in the extension, including popups, **background workers**". So the worker's fetch of `https://lh3.googleusercontent.com/...` never left the browser and failed with a bare `TypeError: Failed to fetch`.

`connect-src` was introduced by `0b9dd0e "fix(csp): add connect-src directive for localhost API access"` purely to reach the Obsidian API. **Naming any source at all closes every other one**, and the background image fetch added later (#376) shipped against a policy that silently blocked it — so that path has never worked in the wild.

### 2. Gemini revokes the blob URL, so the old capture could not work either

Measured live through the CDP daemon (2026-08-06/07). Detection was never the problem: the selector matches, the element reports `complete: true` at 1024×572, the image renders.

| `src` form | page (main world) fetch | isolated fetch | canvas on the live element | `crossOrigin="anonymous"` | background fetch |
| --- | --- | --- | --- | --- | --- |
| `blob:` | ✗ `Failed to fetch` | ✗ `Failed to fetch` | **✓ `image/png` 1,190,471 B** | — | rejected by allow-list |
| `https:` | ✗ (CORS) | ✗ (CORS) | ✗ `SecurityError` (tainted) | ✗ `LOAD FAILED` (no ACAO) | **✓ 200 `image/jpeg` 131,692 B** |

The blob fetch fails **from the page's own main world** while the `<img>` still renders — Gemini revokes the URL once the image has decoded (MDN: `revokeObjectURL` tells the browser "not to keep the reference to the file any longer"). The element keeps the decoded bitmap. So the premise in `image-capture.ts`, *"blob: URLs are read here because only the page context can resolve them"*, no longer holds: nobody can.

The https form cannot use a canvas instead — MDN: cross-origin data without CORS approval taints the canvas and `toDataURL()` throws `SecurityError`. Measured, and `crossOrigin="anonymous"` fails to load because the CDN sends no `Access-Control-Allow-Origin`.

### Changes

- **CSP**: `connect-src` now includes `https://*.googleusercontent.com`
- **`captureImage()`**: dispatches on the source form — `blob:` tries the URL first (a live blob keeps the original encoding; the same image is 131KB as JPEG against 1.19MB as re-encoded PNG), then recovers the bytes off the rendered element via canvas; everything else delegates to the worker. No cross-fallback, since each direction is measurably impossible.
- **Lazy-load guard**: the generated `<img>` carries `loading="lazy"` (measured), so `complete`/`naturalWidth` are checked before drawing.
- **No more silent drops**: failures used to vanish in `if (image) images.push(image)`, and once `images` came back empty the save path stripped the placeholder — leaving an empty message indistinguishable from image export being switched off. Each failure now carries a reason, is logged, and reaches the existing warning toast. **This is what identified defect 1**: the toast read `1 image(s) could not be captured: Failed to fetch`.
- **Fitness function** `test/arch/csp-connect-src.test.ts` binds `connect-src` to `IMAGE_CDN_DOMAIN` — the same constant `isAllowedImageSourceUrl()` uses — so policy and connected hosts cannot drift apart again.
- **ADR-027**.

## Test plan

- [x] `npm test` — **1486 passed** (72 files)
- [x] `npm run lint` — 0 errors (3 pre-existing warnings); `npm run format:check`; `npm run build`
- [x] Coverage: `image-capture.ts` 94.82 / 81.57 / 100 / 98.14; `gemini.ts` 97.84 / 89.61 / 100 / 98.48
- [x] Built manifest verified to carry the widened `connect-src`
- [x] New arch test fails on the old policy with a message naming the symptom
- [ ] **Manual verification outstanding**: reload the unpacked extension (CSP is read at install time) and sync a conversation containing a generated image, in both `blob:` and `https:` forms

### Known limit of the automated tests

jsdom has no canvas, so `getContext`/`toDataURL` are stubbed and the unit tests only pin control flow. That a canvas read actually recovers a revoked blob's bytes rests on the live measurement above and on the manual check still to be done. Recorded in ADR-027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
