### PR TITLE
chore: unblock the Gemini e2e baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,18 @@ conversation via the daemon and print its URL → update `*_CONV_URL` in `e2e/.e
 `e2e-baseline-update`. Baselines are per-machine (gitignored) and are written ONLY by the
 update command; zero-match selectors are rejected at update time.
 
+**Test-data requirements.** A baseline can only be written when EVERY selector of the
+platform matches at least once — the rejection is per selector string, not per name, so a
+single dead fallback blocks the whole platform even while its primary works (issue #402).
+Consequently:
+
+- `GEMINI_CONV_URL` must point at a conversation that **contains a generated image**, because
+  `generatedImage` lives in `GEMINI_SELECTORS` and is validated by the conversation test.
+- If the update refuses with `refusing to record zero-match selectors`, the message names the
+  offender. Fix the selector (a fallback the platform no longer renders should be deleted, as
+  in #401) or the test conversation — never work around it by relaxing the baseline contract,
+  which exists because v1's zero entries made `lost` undetectable (ADR-016).
+
 Load the extension in Chrome: `chrome://extensions` → Load unpacked → select `dist/` folder
 
 ## Architecture

--- a/src/content/extractors/selectors/gemini.ts
+++ b/src/content/extractors/selectors/gemini.ts
@@ -78,8 +78,13 @@ export const DEEP_RESEARCH_LINK_SELECTORS = {
     'source-footnote sup.superscript[data-turn-source-index]',
     'sup.superscript[data-turn-source-index]',
   ],
-  // Source list container
-  sourceListContainer: ['deep-research-source-lists', '#used-sources-list'],
+  // Source list container.
+  // 2026-08: the `#used-sources-list` fallback was dropped — measured at zero on
+  // the live Deep Research page while `deep-research-source-lists` still matches.
+  // A zero-match entry is per-entry fatal to `npm run e2e:baseline:update`
+  // (baseline.ts refuses to record a selector that cannot be found, ADR-016), so
+  // a dead fallback blocks the whole platform's baseline (issue #402).
+  sourceListContainer: ['deep-research-source-lists'],
   // Source list items
   sourceListItem: ['a[data-test-id="browse-web-item-link"]', 'a[data-test-id="browse-chip-link"]'],
   // Source title


### PR DESCRIPTION
## Summary

Gemini's live selector validation could not run **and** could not be repaired by the documented procedure (#402). Both entrances were closed:

- validation stopped at `gemini: baseline file is legacy v1` — the **first** assertion in `runPlatformValidation` (`smoke-test.spec.ts:276`), so nothing downstream ever ran;
- the update that would migrate the file to v2 threw on the platform's only zero-match selector, because `updateBaselineGroups()` refuses to record one by design (ADR-016 — v1's zero entries made `lost` undetectable).

Measured on 2026-08-07 rather than trusted from the older report: **14 pass / 1 zero-match** (`SELECTORS:generatedImage`), and `e2e/baselines/gemini.json` was the last remaining v1 file.

### Two causes, the second found by gating on a measurement

1. **The pinned conversation had no generated image**, so `generatedImage` could never match. Fixed by adding an image to the test conversation — test data lives in the per-machine `.env.local`, so nothing in this diff.
2. **`DEEP_RESEARCH_LINK_SELECTORS.sourceListContainer` carried a dead fallback.** `#used-sources-list` measured 0 while its primary `deep-research-source-lists` still matches 1. The rejection is per selector **string**, not per name, so one dead fallback blocks the whole platform even though the name is healthy — the same shape that blocked Claude's baseline earlier through `[class*="user-message"]`.

Only the dead fallback is removed. The primary stays: unlike the groups dropped in #401 it still matches and remains a useful canary for the Deep Research source DOM.

Running the update before the gate would have been worse than useless — the partial-write behaviour (one test writes while another throws, observed on Claude) would have left `gemini.json` half-migrated with only the Deep Research groups, turning the failure from `legacy` into `missing_groups`.

### Documentation

`CLAUDE.md` now records the per-entry rejection rule and the requirement that `GEMINI_CONV_URL` point at a conversation containing a generated image, with the instruction to fix the selector or the test data rather than relax the contract.

## Test plan

- [x] `npm test` — **1486 passed, unchanged**, which is the evidence that nothing read the removed fallback
- [x] `npm run lint` — 0 errors (3 pre-existing warnings); `npm run format:check`; `npm run build`
- [x] Gate re-measured: every selector on both Gemini targets non-zero
- [x] `e2e:baseline:update -- --grep Gemini` — `gemini.json` now **v2**, 3 groups / 33 entries / 0 zeros; the other four baselines md5-unchanged
- [x] `e2e:selectors -- --grep Gemini` — 2 passed; Gemini reports **15 pass / 0 warn / 0 fail / 0 blocking / 0 advisory**
- [x] Full run, all five platforms — **7 passed**

The overall status is `warn`, from ChatGPT's pre-existing advisory (`conversationTurn` 13→5). It is non-blocking, appears in the 2026-08-04 report as well, and is unrelated to this change.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)