### PR TITLE
fix: sample selector counts only after the page has settled

### DIFF
--- a/docs/adr/016-e2e-baseline-contract-and-reporting.md
+++ b/docs/adr/016-e2e-baseline-contract-and-reporting.md
@@ -48,6 +48,34 @@ structurally unable to do its job:
   Missing or legacy-v1 baselines FAIL with the update-command hint.
 - Baselines are per-machine artifacts (gitignored), like `e2e/.env.local`.
 
+#### 1a. When counts are sampled (added 2026-08-08)
+
+A contract over match counts is only as good as the instant they are read.
+Readiness says the page has **started** rendering, not finished: `gemini_conv`
+is ready as soon as the first `.conversation-container` exists, while the
+generated image sits in the third turn behind `loading="lazy"`. Three timed
+loads put that gap at 1313 / 1973 / 1631 ms, and validation began immediately —
+so `generatedImage` intermittently read zero and failed the run at random.
+
+Every platform has such a gap. Ready → every selector name matching: gemini
+774ms, claude 1562ms, chatgpt 371ms, perplexity 168ms, notebooklm 16ms; counts
+then keep moving for a further 600–1600ms.
+
+Therefore **counts are sampled only after the page has settled**
+(`e2e/selectors/settle.ts`), and the wait sits before validation so validate and
+update are governed by the same rule — retrying the assertion alone would still
+have recorded unsettled numbers into the contract.
+
+Settled means the counts repeated `SETTLE_STABLE_RUNS` times in a row **and** at
+least `SETTLE_MIN_MS` has elapsed. The floor is not redundant: counts sit
+perfectly still while a late element is in flight (~1337ms at zero, measured),
+so stability alone can conclude inside that quiet stretch. Settling is defined
+as "counts stopped changing", not "every selector matched" — the latter would
+burn the whole timeout on a genuinely dead selector, and a late arrival changes
+the counts anyway. On timeout the run continues with the last observation and
+the target is listed in `unsettledTargets`, so a diff produced from a
+mid-render page is never mistaken for DOM drift.
+
 ### 2. First-class failure states (`auth-check.ts`, `load-readiness.ts`, `stall-tracker.ts`)
 
 - `resolveAuthStatus()` (pure) classifies post-navigation state:

--- a/e2e/selectors/__tests__/report-builder.test.ts
+++ b/e2e/selectors/__tests__/report-builder.test.ts
@@ -151,6 +151,29 @@ describe('processTestResult', () => {
     expect(map.get('gemini')!.authStatus).toBe('test_data_missing');
   });
 
+  it('records a target whose selector counts never settled', () => {
+    // Counts read off a page that was still rendering are not evidence of DOM
+    // drift, so the report has to say which targets were sampled mid-render
+    // rather than leaving the numbers looking authoritative.
+    const detail = makeDetail({
+      settle: { settled: false, elapsedMs: 15_000, observations: 50 },
+    });
+
+    const map = processTestResult(new Map(), inputFor(detail, 'passed'));
+
+    expect(map.get('gemini')!.unsettledTargets).toEqual(['gemini_conv']);
+  });
+
+  it('leaves unsettledTargets empty when the page settled', () => {
+    const detail = makeDetail({
+      settle: { settled: true, elapsedMs: 2_800, observations: 6 },
+    });
+
+    const map = processTestResult(new Map(), inputFor(detail, 'passed'));
+
+    expect(map.get('gemini')!.unsettledTargets).toEqual([]);
+  });
+
   it('records stall skips with their target', () => {
     const detail = makeDetail({
       skipReason: 'gemini: content did not load (transient — loading indicator present, stall 2/3)',

--- a/e2e/selectors/__tests__/settle.test.ts
+++ b/e2e/selectors/__tests__/settle.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the settle wait that runs between "page is ready" and selector
+ * validation.
+ *
+ * Measured on 2026-08-08: the ready condition does not imply the page has
+ * finished rendering. `gemini_conv` is ready as soon as `.conversation-container`
+ * exists — the first turn — while the generated image lives in the third turn
+ * behind `loading="lazy"`. Three timed loads put the gap at 1313 / 1973 /
+ * 1631 ms, and validation used to start immediately, so `generatedImage`
+ * intermittently read zero and failed the run.
+ *
+ * The gap is not Gemini's alone. Every platform shows one between ready and a
+ * stable count set: gemini 774ms, claude 1562ms, chatgpt 371ms, perplexity
+ * 168ms, notebooklm 16ms — and counts keep moving for a further 600-1600ms
+ * after the last selector first matches, which is what a baseline recorded at
+ * that moment freezes into the contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { observe, isSettled, waitForSettledCounts } from '../settle';
+
+describe('observe / isSettled', () => {
+  it('counts the first observation as one run', () => {
+    const progress = observe(null, [1, 2, 3]);
+
+    expect(progress.stableRuns).toBe(1);
+    expect(isSettled(progress, 3)).toBe(false);
+  });
+
+  it('accumulates runs while the counts repeat', () => {
+    let progress = observe(null, [1, 2, 3]);
+    progress = observe(progress, [1, 2, 3]);
+    progress = observe(progress, [1, 2, 3]);
+
+    expect(progress.stableRuns).toBe(3);
+    expect(isSettled(progress, 3)).toBe(true);
+  });
+
+  it('restarts the count when any selector changes', () => {
+    let progress = observe(null, [4, 4, 0]);
+    progress = observe(progress, [4, 4, 0]);
+    progress = observe(progress, [4, 4, 1]);
+
+    expect(progress.stableRuns).toBe(1);
+    expect(isSettled(progress, 3)).toBe(false);
+  });
+
+  it('does not treat the moment the image appears as settled (issue #402)', () => {
+    // The real transition, from the 2026-08-08 measurement of GEMINI_CONV_URL:
+    //   3705ms [...,0,0,0,...]  →  5042ms [...,1,1,1,...]
+    // Validating on that first non-zero observation is exactly as unsafe as
+    // validating on the zero before it — neither is a settled page.
+    const before = [4, 4, 4, 20, 0, 0, 0, 1, 2];
+    const after = [4, 4, 4, 20, 1, 1, 1, 1, 2];
+
+    let progress = observe(null, before);
+    progress = observe(progress, before);
+    progress = observe(progress, after);
+
+    expect(isSettled(progress, 3)).toBe(false);
+  });
+
+  it('treats an empty selector set as trivially repeatable', () => {
+    let progress = observe(null, []);
+    progress = observe(progress, []);
+    progress = observe(progress, []);
+
+    expect(isSettled(progress, 3)).toBe(true);
+  });
+});
+
+describe('waitForSettledCounts', () => {
+  /** Deterministic clock + sleep so the loop is testable without a browser. */
+  function harness(samples: number[][]) {
+    let now = 0;
+    const sleeps: number[] = [];
+    let index = 0;
+    return {
+      deps: {
+        sleep: (ms: number): Promise<void> => {
+          now += ms;
+          sleeps.push(ms);
+          return Promise.resolve();
+        },
+        now: (): number => now,
+      },
+      sample: (): Promise<number[]> =>
+        Promise.resolve(samples[Math.min(index++, samples.length - 1)]),
+      sleeps,
+    };
+  }
+
+  const OPTIONS = { requiredRuns: 3, pollIntervalMs: 300, timeoutMs: 10_000, minElapsedMs: 0 };
+
+  it('returns as soon as the counts have repeated enough times', async () => {
+    const h = harness([
+      [0, 0],
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ]);
+
+    const result = await waitForSettledCounts(h.sample, { ...OPTIONS, ...h.deps });
+
+    expect(result.settled).toBe(true);
+    expect(result.observations).toBe(4);
+    expect(result.counts).toEqual([1, 1]);
+  });
+
+  it('does not settle inside the quiet stretch before a late selector arrives', async () => {
+    // gemini's shape, and the reason stability alone is not enough: the counts
+    // hold perfectly still at zero while the image is on its way (~1337ms on
+    // the live page), so three identical observations land INSIDE that stretch.
+    // The elapsed floor is what stops the wait from concluding there.
+    const zero = [4, 4, 0, 0, 0];
+    const one = [4, 4, 1, 1, 1];
+    const h = harness([zero, zero, zero, zero, one, one, one]);
+
+    const result = await waitForSettledCounts(h.sample, {
+      ...OPTIONS,
+      ...h.deps,
+      minElapsedMs: 1_200,
+    });
+
+    expect(result.settled).toBe(true);
+    expect(result.counts).toEqual(one);
+  });
+
+  it('settles on a stable page once the floor has passed', async () => {
+    const h = harness([[4, 4, 1], [4, 4, 1], [4, 4, 1], [4, 4, 1], [4, 4, 1], [4, 4, 1]]);
+
+    const result = await waitForSettledCounts(h.sample, {
+      ...OPTIONS,
+      ...h.deps,
+      minElapsedMs: 900,
+    });
+
+    expect(result.settled).toBe(true);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(900);
+  });
+
+  it('gives up at the timeout and reports the last observation', async () => {
+    // A page whose counts never stop moving must not hang the run.
+    let n = 0;
+    let now = 0;
+    const result = await waitForSettledCounts(() => Promise.resolve([n++]), {
+      ...OPTIONS,
+      minElapsedMs: 0,
+      timeoutMs: 1_000,
+      sleep: (ms: number) => {
+        now += ms;
+        return Promise.resolve();
+      },
+      now: () => now,
+    });
+
+    expect(result.settled).toBe(false);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(1_000);
+    expect(result.counts.length).toBe(1);
+  });
+
+  it('samples at the configured interval', async () => {
+    const h = harness([
+      [7],
+      [7],
+      [7],
+    ]);
+
+    await waitForSettledCounts(h.sample, { ...OPTIONS, ...h.deps });
+
+    expect(h.sleeps.every(ms => ms === 300)).toBe(true);
+  });
+
+  it('surfaces a sampling failure instead of looping on it', async () => {
+    const sample = vi.fn().mockRejectedValue(new Error('page closed'));
+
+    await expect(
+      waitForSettledCounts(sample, {
+        ...OPTIONS,
+        sleep: () => Promise.resolve(),
+        now: () => 0,
+      })
+    ).rejects.toThrow('page closed');
+  });
+});

--- a/e2e/selectors/notifier.ts
+++ b/e2e/selectors/notifier.ts
@@ -23,6 +23,12 @@ export interface PlatformReport {
   failedTargets: string[];
   /** Targets skipped on a transient content stall. */
   stallSkips: string[];
+  /**
+   * Targets whose selector counts never settled before they were sampled.
+   * Their numbers were read off a page still rendering, so a diff from such a
+   * run is not evidence of DOM drift.
+   */
+  unsettledTargets: string[];
 }
 
 export interface ValidationReport {

--- a/e2e/selectors/report-builder.ts
+++ b/e2e/selectors/report-builder.ts
@@ -29,6 +29,13 @@ export interface TargetDetail {
   baselineState?: 'ok' | 'legacy' | 'missing_groups';
   /** Present when validation ran. */
   classification?: ClassificationResult;
+  /**
+   * How the page settled before the counts were sampled. `settled: false` means
+   * the wait timed out with the counts still moving, so the numbers below were
+   * read off a page that had not finished rendering — treat any diff from that
+   * run with suspicion rather than as DOM drift.
+   */
+  settle?: { settled: boolean; elapsedMs: number; observations: number };
 }
 
 export interface AttachmentLike {
@@ -116,6 +123,7 @@ export function processTestResult(
     classification: existing?.classification,
     failedTargets: [...(existing?.failedTargets ?? [])],
     stallSkips: [...(existing?.stallSkips ?? [])],
+    unsettledTargets: [...(existing?.unsettledTargets ?? [])],
   };
 
   const targetName = detail?.target ?? input.platform;
@@ -133,6 +141,9 @@ export function processTestResult(
       // Authenticated skip = content stall (auth/unreachable skips carry
       // their own authStatus and are tracked via that field instead)
       report.stallSkips.push(targetName);
+    }
+    if (detail.settle && !detail.settle.settled) {
+      report.unsettledTargets.push(targetName);
     }
     if (detail.classification) {
       report.classification = mergeClassification(existing?.classification, detail.classification);

--- a/e2e/selectors/settle.ts
+++ b/e2e/selectors/settle.ts
@@ -1,0 +1,133 @@
+/**
+ * Settle wait for live selector validation.
+ *
+ * The readiness check answers "has the page started rendering?", not "has it
+ * finished". Measured on 2026-08-08, `gemini_conv` is ready the moment
+ * `.conversation-container` exists — the first turn — while the generated image
+ * sits in the third turn behind `loading="lazy"`. Three timed loads put the gap
+ * between ready and `generated-image img[src]` at 1313 / 1973 / 1631 ms, and
+ * validation started immediately, so `generatedImage` intermittently read zero
+ * and failed the run (issue #402 follow-up).
+ *
+ * The gap exists everywhere, not only on Gemini. Ready → every selector name
+ * matching: gemini 774ms, claude 1562ms, chatgpt 371ms, perplexity 168ms,
+ * notebooklm 16ms. Counts then keep moving for another 600–1600ms, which is the
+ * window a baseline recorded at that instant freezes into the contract — the
+ * likely source of ChatGPT's standing `conversationTurn 13 -> 5` advisory.
+ *
+ * Waiting here, before validation, fixes both modes at once: validate reads a
+ * settled page, and update records settled numbers. Retrying the assertion
+ * instead would leave the recorded baseline just as unstable.
+ *
+ * Settling is defined as "the counts stopped changing", not "every selector
+ * matched". Requiring a match would spend the whole timeout on a genuinely dead
+ * selector, delaying a real failure for nothing; and a late arrival changes the
+ * counts anyway, so stability already covers it.
+ */
+
+/** How many consecutive identical observations mean the page has settled. */
+export const SETTLE_STABLE_RUNS = 3;
+
+/** Delay between observations (ms). */
+export const SETTLE_POLL_INTERVAL_MS = 300;
+
+/**
+ * Never conclude before this much has elapsed since the wait began (ms).
+ *
+ * Stability alone is not enough: the counts sit perfectly still while a late
+ * element is on its way, so a short run of identical observations can land
+ * inside that quiet stretch and settle on the pre-arrival state. Measured on
+ * GEMINI_CONV_URL, the counts held at zero for ~1337ms before the image
+ * appeared, and across three timed loads the image arrived 1313 / 1973 / 1631 ms
+ * after ready. 2500ms clears the slowest of those with margin.
+ */
+export const SETTLE_MIN_MS = 2_500;
+
+/**
+ * Upper bound on a single settle wait (ms).
+ *
+ * The slowest measured platform (claude) stabilised 3146ms after ready; this
+ * leaves a wide margin for a slow network without letting a streaming page
+ * stall the run. Matches the order of READY_TIMEOUT_MS.
+ */
+export const SETTLE_TIMEOUT_MS = 15_000;
+
+/** Running state of the settle observation. */
+export interface SettleProgress {
+  /** The last observed counts, joined for comparison. */
+  readonly signature: string;
+  /** Consecutive observations that produced this signature. */
+  readonly stableRuns: number;
+}
+
+/** Outcome of a settle wait. */
+export interface SettleResult {
+  /** False when the timeout was reached before the counts stopped changing. */
+  readonly settled: boolean;
+  /** Counts from the final observation. */
+  readonly counts: readonly number[];
+  /** Number of observations taken. */
+  readonly observations: number;
+  /** Wall-clock spent waiting (ms). */
+  readonly elapsedMs: number;
+}
+
+/** Fold one observation into the progress, immutably. */
+export function observe(
+  previous: SettleProgress | null,
+  counts: readonly number[]
+): SettleProgress {
+  const signature = counts.join(',');
+  const repeated = previous !== null && previous.signature === signature;
+  return { signature, stableRuns: repeated ? previous.stableRuns + 1 : 1 };
+}
+
+/** True once the same counts have been observed `requiredRuns` times in a row. */
+export function isSettled(progress: SettleProgress, requiredRuns: number): boolean {
+  return progress.stableRuns >= requiredRuns;
+}
+
+/** Injectable clock, so the loop is testable without a browser or real time. */
+export interface SettleOptions {
+  requiredRuns: number;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  /** Floor on elapsed time before stability may be accepted. */
+  minElapsedMs: number;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+/**
+ * Sample the selector counts until they stop changing, or the timeout elapses.
+ *
+ * A sampling error is propagated rather than swallowed: a closed page or a
+ * navigation mid-wait is a real failure, and retrying it would only produce a
+ * confusing timeout later.
+ *
+ * @param sample Returns the current match count of every selector, in a stable order.
+ */
+export async function waitForSettledCounts(
+  sample: () => Promise<number[]>,
+  options: SettleOptions
+): Promise<SettleResult> {
+  const started = options.now();
+  let progress: SettleProgress | null = null;
+  let counts: number[] = [];
+  let observations = 0;
+
+  for (;;) {
+    counts = await sample();
+    observations++;
+    progress = observe(progress, counts);
+
+    const elapsed = options.now() - started;
+    if (isSettled(progress, options.requiredRuns) && elapsed >= options.minElapsedMs) {
+      return { settled: true, counts, observations, elapsedMs: elapsed };
+    }
+    if (elapsed >= options.timeoutMs) {
+      return { settled: false, counts, observations, elapsedMs: elapsed };
+    }
+    await options.sleep(options.pollIntervalMs);
+  }
+}

--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -26,6 +26,13 @@ import {
 import type { SelectorGroup } from '../../src/content/extractors/selectors/types';
 import { checkAuthStatus, type AuthStatus } from './auth-check';
 import {
+  waitForSettledCounts,
+  SETTLE_STABLE_RUNS,
+  SETTLE_POLL_INTERVAL_MS,
+  SETTLE_MIN_MS,
+  SETTLE_TIMEOUT_MS,
+} from './settle';
+import {
   loadBaselineGroups,
   updateBaselineGroups,
   compareWithBaseline,
@@ -116,6 +123,23 @@ async function validateSelectors(
   }
 
   return results;
+}
+
+/**
+ * Match count of every selector across every group, in a stable order.
+ *
+ * Feeds the settle wait: the signature it compares is just these numbers joined,
+ * so any element still arriving shows up as a change.
+ */
+async function sampleCounts(
+  page: Page,
+  selectorGroups: Record<string, SelectorGroup>
+): Promise<number[]> {
+  const flat = Object.values(selectorGroups).flatMap(group => Object.values(group).flat());
+  return page.evaluate(
+    (sels: string[]) => sels.map(sel => document.querySelectorAll(sel).length),
+    flat
+  );
 }
 
 async function runPlatformValidation(
@@ -219,6 +243,30 @@ async function runPlatformValidation(
       }
     }
 
+    // Let the page finish rendering before anything is counted.
+    //
+    // Readiness only says the page has STARTED. Measured 2026-08-08: gemini_conv
+    // is ready as soon as the first `.conversation-container` exists, while the
+    // generated image arrives 1313-1973ms later, so `generatedImage` read zero
+    // and failed the run at random. Every platform has such a gap, and counts
+    // keep moving for a further 600-1600ms after the last selector first
+    // matches — which is what an update run would otherwise freeze into the
+    // baseline. Waiting here fixes validate and update together.
+    const settle = await waitForSettledCounts(() => sampleCounts(page, selectorGroups), {
+      requiredRuns: SETTLE_STABLE_RUNS,
+      pollIntervalMs: SETTLE_POLL_INTERVAL_MS,
+      minElapsedMs: SETTLE_MIN_MS,
+      timeoutMs: SETTLE_TIMEOUT_MS,
+      sleep: (ms: number) => page.waitForTimeout(ms),
+      now: () => Date.now(),
+    });
+    if (!settle.settled) {
+      console.warn(
+        `${platform}: selector counts never settled within ${SETTLE_TIMEOUT_MS}ms ` +
+          `(${settle.observations} observations) — the numbers below may be mid-render`
+      );
+    }
+
     // Validate all selectors
     const allResults: SelectorResult[] = [];
     for (const [groupName, selectors] of Object.entries(selectorGroups)) {
@@ -267,6 +315,11 @@ async function runPlatformValidation(
       authStatus,
       baselineState,
       classification: classified,
+      settle: {
+        settled: settle.settled,
+        elapsedMs: settle.elapsedMs,
+        observations: settle.observations,
+      },
     });
 
     // Assert: the baseline itself must be usable before its diff means anything


### PR DESCRIPTION
## Summary

`SELECTORS:generatedImage` failed the Gemini run a day after it started being validated. **Nothing had rotted** — the image is still there and all three of its selectors still match. Validation was simply starting before the image existed.

### The race

Readiness says the page has **started** rendering, not finished. `gemini_conv` is ready as soon as the first `.conversation-container` exists, while the generated image sits in the third turn behind `loading="lazy"`. Three timed loads:

| load | ready | `generated-image img[src]` | gap |
| --- | --- | --- | --- |
| 1 | 3500ms | 4813ms | **1313ms** |
| 2 | 3634ms | 5607ms | **1973ms** |
| 3 | 2332ms | 3963ms | **1631ms** |

`validateSelectors` ran immediately after the ready check with nothing in between.

**The gap is not Gemini's.** Ready → every selector name matching, measured across all five: gemini 774ms, claude 1562ms, chatgpt 371ms, perplexity 168ms, notebooklm 16ms — and counts keep moving for a further 600–1600ms after the last selector first matches. Gemini surfaced first only because `generatedImage` is the one name that can drop to zero; elsewhere the same race shows up as a count that differs from the baseline.

The race captured in the data:

```
3705ms: [4,4,4,20,4,4,4,12,4,4,4,4, 0,0,0, 1,2]
5042ms: [4,4,4,20,4,4,4,12,4,4,4,4, 1,1,1, 1,2]
```

### The fix

Counts are sampled only once they stop changing, and the wait sits **before** `validateSelectors` so validate and update are governed by the same rule. Retrying the assertion instead would have left update recording unsettled numbers into the contract — the one thing a baseline must not do.

**Stability alone was insufficient, and a test caught that before it shipped.** The counts sit perfectly still while a late element is in flight (~1337ms at zero, measured), so three identical observations can land inside that quiet stretch and settle on the pre-arrival state. An explicit elapsed floor of 2500ms — sized from the slowest measured arrival of 1973ms — is what makes the guarantee hold, and it is asserted directly rather than left as an emergent property of the poll arithmetic.

Settled means *"the counts stopped changing"*, not *"every selector matched"*: the latter would spend the whole timeout on a genuinely dead selector and delay a real failure for nothing, while a late arrival changes the counts anyway. On timeout the run continues with the last observation and the target lands in `unsettledTargets`, so numbers read off a mid-render page are never mistaken for DOM drift.

### Not the race: ChatGPT's advisory

Re-recording the baselines changed **exactly two entries**, both ChatGPT's `conversationTurn` 13 → 5, with **no lost/added/removed anywhere** and the other four platforms byte-identical. That drop **survives the settle** — it comes from the suite opening a fresh page while ChatGPT virtualises its turn list, so 5 is the honest fresh-page value and 13 was the 2026-07-07 reading. It is a property of the harness, not of extraction: the extractor auto-scrolls, the suite does not.

## Test plan

- [x] `npm test` — **1499 passed** (+13)
- [x] `npm run lint` — 0 errors (3 pre-existing warnings); `npm run format:check`; `npm run build`
- [x] New `settle.test.ts` (11) — fold, floor, timeout, sampling-error propagation, and the real `[0,0,0] → [1,1,1]` transition
- [x] New report-builder cases — a mid-render target is recorded, a settled one is not
- [x] **Three consecutive live runs: 7 passed each** (44.5 / 44.0 / 44.8s against 30.5s before; the floor costs ~2.5s per target)
- [x] Final report: **`overallStatus: pass`** — the first in weeks — with zero advisories and empty `unsettledTargets` on every platform
- [x] Baseline re-record diff reviewed entry by entry (2 changed of 92)

ADR-016 gains the sampling rule, including why the floor is not redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
