### PR TITLE
docs: correct the ADR-026 CRLF audit and record the ordering constraint

### DIFF
--- a/docs/adr/026-line-ending-handling.md
+++ b/docs/adr/026-line-ending-handling.md
@@ -1,8 +1,9 @@
 # ADR-026: Normalise line endings on read, restore them on write
 
-- Status: Proposed
-- Date: 2026-08-05
-- Related: issue #365, [ADR-025](025-note-identity-probe-and-fork-diagnostics.md), issue #327
+- Status: Accepted — shipped in 2.7.3 (#407); ordering constraint added in 2.7.10 (#421)
+- Date: 2026-08-05 (amended 2026-08-09)
+- Related: issue #365, issue #406, [ADR-025](025-note-identity-probe-and-fork-diagnostics.md),
+  [ADR-028](028-message-count-survives-callout-flattening.md), issue #327
 
 ## Context
 
@@ -72,18 +73,35 @@ was never damaged, only unreadable.
 
 ### Measured blast radius
 
-| Function | LF | CRLF | lone CR |
-| --- | --- | --- | --- |
-| `parseFrontmatter().fields.id` | ok | **undefined** | `null` (unparseable) |
-| `countExistingMessages()` | 4 | 4 | **0** |
-| `extractTailMessages()` | ok | ok (CRLF retained) | **empty** |
-| `updateFrontmatter()` | ok | **mixed endings**: `"---\r\nid: x\r\nmessage_count: 4\n---"` | — |
-| `flattenLargeCallouts()` | ok | ok (CRLF retained) | — |
+| Function                       | LF  | CRLF                                                         | lone CR              |
+| ------------------------------ | --- | ------------------------------------------------------------ | -------------------- |
+| `parseFrontmatter().fields.id` | ok  | **undefined**                                                | `null` (unparseable) |
+| `countExistingMessages()`      | 4   | 4                                                            | **0**                |
+| `extractTailMessages()`        | ok  | ok (CRLF retained)                                           | **empty**            |
+| `updateFrontmatter()`          | ok  | **mixed endings**: `"---\r\nid: x\r\nmessage_count: 4\n---"` | —                    |
+| `flattenLargeCallouts()`       | ok  | endings retained, but **callout header degraded** ¹          | —                    |
 
-Only the field extraction is a functional break. But fixing it alone would
-expose the second row: `updateFrontmatter()` rewrites matched lines with `\n`
-while their neighbours keep `\r\n`, so every append to a CRLF file would leave
-it mixed.
+¹ **Corrected 2026-08-09 (#406).** This row originally read `ok (CRLF retained)`.
+The line endings _are_ retained — that much was measured correctly (15 CRLF
+breaks, 0 bare LF) — but retaining endings is not the same as being unaffected,
+and reading the row as "no CRLF problem here" is what allowed the following to
+ship. On CRLF input `CALLOUT_HEADER_PATTERN` (`/^> \[![^\]]+\][+-]? *(.*)$/`,
+no `m` flag) cannot match past the CR, exactly as `parseFrontmatter()` could not
+in row 1. The run therefore falls through to the plain-blockquote branch: the
+`**Label:**` heading is **dropped** and a bare `[!TYPE] Label` is left as body
+text. Measured on a CRLF body: 3 messages in, 2 countable out; on LF, 3 → 3.
+
+Because a message with no label is invisible to `countExistingMessages()`, this
+made the duplicate append of #406 recur on CRLF files even after the counter
+itself was fixed (ADR-028).
+
+Two functional breaks, then, not one: the field extraction above, and this. Note
+also that **`flattenLargeCallouts()` was never hardened** — it still degrades if
+handed CRLF. What protects it is the ordering constraint below, nothing else.
+
+Fixing the field extraction alone would additionally expose the
+`updateFrontmatter()` row: it rewrites matched lines with `\n` while their
+neighbours keep `\r\n`, so every append to a CRLF file would leave it mixed.
 
 ## Decision
 
@@ -95,10 +113,33 @@ it mixed.
    `extractTailMessages()` — sees LF and needs no line-ending awareness of its
    own.
 2. It also returns `eol`, the ending the source used.
-3. `buildAppendContent()` re-applies `eol` to the content it returns.
+3. `buildAppendContent()` returns LF content plus `eol`; the **caller** applies
+   `eol` immediately before writing. See the ordering constraint below.
 
 A fresh save is unaffected: it creates the file, so it defines the convention
 (LF).
+
+### Ordering constraint: restore last
+
+**The restore is the final step before the write. Every body transform runs while
+the content is still LF.**
+
+This was implied by "everything downstream sees LF" in point 1 but never written
+down, and the append path violated it: `buildAppendContent()` used to apply `eol`
+itself, and `tryAppendMode()` then flattened the restored — CRLF — content. That
+is the defect recorded in footnote ¹ above.
+
+Point 3 is therefore a load-bearing part of this decision, not an implementation
+detail. `buildAppendContent()` reports `eol` rather than applying it precisely so
+that a transform cannot be inserted between the restore and the write.
+
+The constraint generalises past flattening: it binds any body transform added
+later. Since no transform is line-ending aware — deliberately, per point 1 — the
+ordering is the only thing keeping them correct.
+
+Guarded by `test/background/append-transform-ordering.test.ts`, which asserts the
+rule (flattening is handed content containing no CR) rather than any single
+symptom, and was verified to fail when the two steps are reversed.
 
 ### Why restore rather than normalise the file
 

--- a/docs/adr/028-message-count-survives-callout-flattening.md
+++ b/docs/adr/028-message-count-survives-callout-flattening.md
@@ -68,6 +68,47 @@ countExistingMessages(transform(body)) === countExistingMessages(body)
 `flattenLargeCallouts` across thresholds that flatten everything, some, and
 nothing, plus the agreement property between counting and tail extraction.
 
+## Addendum (2026-08-09): the invariant was broken a second way
+
+The counter was not the only thing that could break it. The invariant also fails
+when the _writer_ stops emitting a recognisable label at all — and it did, on
+CRLF files, because of **when** the line-ending restore ran rather than anything
+in this ADR's scope.
+
+`tryAppendMode()` flattened content that `buildAppendContent()` had already
+restored to CRLF, so `flattenLargeCallouts()` saw lines ending in `\r`. Its
+header pattern cannot match past a CR, so the `**Label:**` heading was dropped
+and a bare `[!TYPE] Label` left as body text. With no label in either format, the
+message is invisible to `countExistingMessages()` no matter how many formats it
+reads — so #406 recurred on CRLF files even with the fix above in place.
+Measured: LF `3 → 3`, CRLF `3 → 2`.
+
+The fix is an ordering rule, now recorded as a first-class part of ADR-026:
+**body transforms run before the line-ending restore, and the restore is the last
+step before the write.** `buildAppendContent()` reports `eol` instead of applying
+it.
+
+### Correction to the coverage claim above
+
+The seam test covers **LF only**. That is now deliberate — after the ordering fix
+`flattenLargeCallouts()` is never handed CRLF, so a CRLF variant of the seam
+property would assert something the design no longer permits to happen. The CRLF
+path is covered where it belongs instead:
+
+- `test/background/append-transform-ordering.test.ts` — the ordering rule itself,
+  asserted as "flattening receives no CR", and verified to fail when reversed.
+- `test/background/index.test.ts` — the end-to-end outcome on a CRLF note: label
+  kept, no raw `[!TYPE]` in the body, file still CRLF throughout.
+
+### What this adds to the general rule
+
+The original rule said: anything that rewrites a saved body is part of the append
+contract. The CRLF case sharpens it — **so is anything that changes the
+_representation_ the body is in when a transform runs.** A transform that is
+correct on LF is not automatically correct on the bytes actually written, and the
+seam that matters is the one between the transform and the encoding, not only the
+one between the transform and the counter.
+
 ## Consequences
 
 - Fenced-code handling is now uniform: a single column-0 toggle, shared by both

--- a/package-lock.json
+++ b/package-lock.json
@@ -4652,9 +4652,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/test/background/append-transform-ordering.test.ts
+++ b/test/background/append-transform-ordering.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Architectural guard for ADR-026's ordering constraint.
+ *
+ * ADR-026 decided that line endings are normalised on read and the file's own
+ * ending is restored on write, so "everything downstream sees LF". It did not
+ * say *when* the restore happens, and the append path restored it early — before
+ * callout flattening — which handed `flattenLargeCallouts()` lines ending in
+ * '\r'. Its header pattern ends `(.*)$` with no `m` flag and cannot match past a
+ * CR, so the run fell through to the plain-blockquote branch: the `**Label:**`
+ * heading was dropped and a bare `[!TYPE] Label` left as body text. A message
+ * with no label is invisible to `countExistingMessages()`, so #406 recurred on
+ * CRLF files even after the counter was fixed.
+ *
+ * The tests below assert the RULE (flattening is handed LF), not just the
+ * symptom, so reversing the two steps fails here regardless of how the symptom
+ * happens to surface. Verified to fail when the ordering is reversed.
+ *
+ * @see docs/adr/026-line-ending-handling.md — Ordering constraint
+ * @see docs/adr/028-message-count-survives-callout-flattening.md
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flattenLargeCallouts } from '../../src/lib/callout-flatten';
+import { DEFAULT_SYNC_SETTINGS } from '../../src/lib/settings-schema';
+import type { ExtensionSettings, ObsidianNote } from '../../src/lib/types';
+
+const mockClient = {
+  testConnection: vi.fn(),
+  getFile: vi.fn(),
+  putFile: vi.fn(),
+  putBinaryFile: vi.fn(),
+  listFiles: vi.fn(),
+  listEntries: vi.fn(),
+};
+
+vi.mock('../../src/lib/obsidian-api', () => ({
+  ObsidianApiClient: class MockObsidianApiClient {
+    testConnection = mockClient.testConnection;
+    getFile = mockClient.getFile;
+    putFile = mockClient.putFile;
+    putBinaryFile = mockClient.putBinaryFile;
+    listFiles = mockClient.listFiles;
+    listEntries = mockClient.listEntries;
+  },
+  isObsidianApiError: () => false,
+}));
+
+// Real implementation, recorded invocations — we need both: the written file is
+// asserted for real, and the argument handed to flattening is inspected.
+vi.mock(import('../../src/lib/callout-flatten'), { spy: true });
+
+const { handleSave } = await import('../../src/background/obsidian-handlers');
+
+const settings: ExtensionSettings = {
+  ...DEFAULT_SYNC_SETTINGS,
+  obsidianApiKey: 'test-key',
+  vaultPath: 'AI/{platform}',
+  enableAppendMode: true,
+  flattenLargeCallouts: true,
+  maxCalloutLines: 5,
+};
+
+/** Four messages, the second one long enough to be flattened. */
+const BODY_LINES = [
+  '> [!QUESTION] User',
+  '> Hello',
+  '',
+  '> [!NOTE] Claude',
+  ...Array.from({ length: 8 }, (_, i) => `> answer line ${i}`),
+  '',
+  '> [!QUESTION] User',
+  '> Second question',
+  '',
+  '> [!NOTE] Claude',
+  '> Second answer',
+];
+
+const note: ObsidianNote = {
+  fileName: 'chat-abc12345.md',
+  body: BODY_LINES.join('\n'),
+  contentHash: 'hash',
+  images: [],
+  frontmatter: {
+    id: 'claude_abc-def',
+    title: 'Chat',
+    source: 'claude',
+    url: 'https://claude.ai/chat/abc-def',
+    created: '2026-01-01T00:00:00.000Z',
+    modified: '2026-01-01T00:00:00.000Z',
+    tags: ['ai-conversation', 'claude'],
+    message_count: 4,
+  },
+};
+
+/** The note as it already exists on disk, with the given line ending. */
+function existingFile(eol: string): string {
+  return [
+    '---',
+    'id: claude_abc-def',
+    'message_count: 2',
+    'modified: "2026-01-01T00:00:00.000Z"',
+    '---',
+    ...BODY_LINES.slice(0, 12),
+  ].join(eol);
+}
+
+describe('append: body transforms run before the line-ending restore (ADR-026)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.putFile.mockResolvedValue(undefined);
+    mockClient.listFiles.mockResolvedValue([]);
+    mockClient.listEntries.mockResolvedValue([]);
+  });
+
+  it('hands flattening LF content even when the file on disk is CRLF', async () => {
+    mockClient.getFile.mockResolvedValue(existingFile('\r\n'));
+
+    const result = await handleSave(settings, note);
+
+    expect(result.success).toBe(true);
+    expect(flattenLargeCallouts).toHaveBeenCalled();
+    // The rule itself: no transform is ever handed a CR.
+    for (const [content] of vi.mocked(flattenLargeCallouts).mock.calls) {
+      expect(content).not.toContain('\r');
+    }
+  });
+
+  it('still writes the file back with its own CRLF endings', async () => {
+    mockClient.getFile.mockResolvedValue(existingFile('\r\n'));
+
+    await handleSave(settings, note);
+
+    const written = mockClient.putFile.mock.calls[0][1] as string;
+    expect(written).not.toMatch(/(?<!\r)\n/);
+  });
+
+  it('keeps the callout label through flattening on a CRLF file', async () => {
+    // The user-visible consequence of the ordering: with the restore first, the
+    // label vanished and `[!NOTE] Claude` was left in the note text.
+    mockClient.getFile.mockResolvedValue(existingFile('\r\n'));
+
+    await handleSave(settings, note);
+
+    const written = mockClient.putFile.mock.calls[0][1] as string;
+    expect(written).toContain('**Claude:**');
+    expect(written).not.toMatch(/^\[!\w+\]/m);
+  });
+
+  it('behaves identically on an LF file', async () => {
+    mockClient.getFile.mockResolvedValue(existingFile('\n'));
+
+    await handleSave(settings, note);
+
+    const written = mockClient.putFile.mock.calls[0][1] as string;
+    expect(written).toContain('**Claude:**');
+    expect(written).not.toContain('\r');
+  });
+});


### PR DESCRIPTION
Follow-up to the merged #421. Documentation plus one guard test — **no `src/` changes**.

## Why this is a correction, not an addendum

`docs/adr/026-line-ending-handling.md` had this in its table headed **"Measured blast radius"**:

```
| `flattenLargeCallouts()` | ok | ok (CRLF retained) | — |
```

Every other row in that table names a functional break (`undefined`, `mixed endings`). This one says flattening has no CRLF problem. Reading it that way is what let #406's CRLF half ship — anyone re-auditing line endings trusts the row and skips the case, which is exactly what happened.

The row was half right, and the half matters:

- **Endings genuinely are retained.** Measured: 15 CRLF breaks, 0 bare LF. That part was correct.
- **But retaining endings is not being unaffected.** On CRLF input `CALLOUT_HEADER_PATTERN` (`/^> \[![^\]]+\][+-]? *(.*)$/`, no `m` flag) cannot match past the CR — the same mechanism as row 1 — so the run falls through to the plain-blockquote branch: the `**Label:**` heading is dropped and a bare `[!TYPE] Label` is left as body text. LF `3 → 3` messages, CRLF `3 → 2`.

Both halves are now stated, so the distinction cannot be lost again. The row is footnoted rather than silently rewritten, so the original claim and its correction are both on the record.

## Ordering constraint promoted to a decision

ADR-026's Decision said "everything downstream sees LF" but never said **when** the restore happens — and the append path restored early, then flattened. That is now written down:

> The restore is the final step before the write. Every body transform runs while the content is still LF.

It also records something easy to miss: **`flattenLargeCallouts()` was never hardened.** It still degrades if handed CRLF. The ordering is the only thing protecting it, which is why the constraint is a decision rather than a note.

Status was also still `Proposed` although the fix shipped in 2.7.3.

## ADR-028 addendum

- Records the second way its invariant broke — not the counter, but the *representation* the body was in when the transform ran.
- **Corrects its coverage claim.** ADR-028 says the seam test enforces the invariant; that test is **LF-only** (verified: no `\r` anywhere in it). That is now deliberate — after the ordering fix flattening is never handed CRLF, so a CRLF seam variant would assert something the design forbids — with the CRLF path documented as covered at the handler level instead.
- Generalises the rule: anything that changes the representation a transform runs against is part of the append contract, not just anything that rewrites the body.

## The guard test

`test/background/append-transform-ordering.test.ts` asserts the **rule** — flattening receives content containing no CR — rather than any single symptom, so a future reversal fails regardless of how it surfaces. It tests `handleSave()` directly (no chrome globals needed) and uses `vi.mock(import(...), { spy: true })` to keep the real flattening behaviour while recording its arguments.

**Honest note on TDD:** the fix is already merged, so this test could not legitimately start red. It was validated by temporarily reversing the ordering in `obsidian-handlers.ts`:

```
× hands flattening LF content even when the file on disk is CRLF
× keeps the callout label through flattening on a CRLF file
  Tests  2 failed | 2 passed
```

The "file is still CRLF" assertion passes either way — which is precisely why the original audit row looked reassuring, and is now called out in the ADR.

## Verification

- `vitest run` — 75 files, **1520 passed** (4 new)
- `tsc --noEmit` — clean
- `npm run lint` — 0 errors (3 pre-existing warnings in untouched files)
- `npm run format:check` — clean

## Not included, by decision

The merged PR bodies for #421 and #425 were left alone. The squash commit `e9eed60` already carries both commit messages verbatim, including the full CRLF reasoning, so the durable record is intact and editing a merged PR body buys tidiness rather than information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)