### PR TITLE
docs: document the ChatGPT Deep Research limitation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -108,6 +108,8 @@ Gemini が生成した画像は自動的に捕捉・エクスポートされま�
 
 > **長い会話では自動スクロールを有効にしてください。** ChatGPT は一度に一部のターンしか DOM に保持せず、画面外のターンは破棄されます。自動スクロールが無効だと、その時点で表示されているターンしかエクスポートできません。
 
+> **ChatGPT の Deep Research レポートはエクスポートできません。** [Deep Research / Extended Thinking の保存](#deep-research--extended-thinking-の保存) を参照してください。
+
 ### Perplexity
 
 1. [www.perplexity.ai](https://www.perplexity.ai) で会話を開く
@@ -139,6 +141,15 @@ Gemini が生成した画像は自動的に捕捉・エクスポートされま�
 1. Deep Research レポートを含む Perplexity の会話を開く
 2. 「Sync」ボタンをクリック
 3. レポート内容が通常の会話メッセージとともに抽出されます
+
+**ChatGPT Deep Research: 非対応。**
+
+ChatGPT は Deep Research レポートを別オリジン（`*.oaiusercontent.com`）のサンドボックス iframe 内に描画するため、ブラウザ拡張機能からは読み取れません。レポートを展開しても取得できません。プロンプトだけでレポートが欠けたノートを保存するのではなく、拡張機能が状況を通知します:
+
+- Deep Research レポート _のみ_ の会話は保存されず、理由が表示されます。
+- 通常のメッセージと混在する場合は、通常のメッセージを保存し、レポートをスキップしたことを警告します。
+
+カスタム GPT を含む通常の ChatGPT 会話には影響しません。進捗は [issue #283](https://github.com/sho7650/obsidian-AI-exporter/issues/283) で管理しています。
 
 ## 出力フォーマット
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Gemini-generated images are captured and exported automatically (see [Image Expo
 
 > **Keep Auto-scroll enabled for long conversations.** ChatGPT mounts only a window of turns at a time and discards the rest; with Auto-scroll off, only the turns currently on screen can be exported.
 
+> **Deep Research reports cannot be exported from ChatGPT.** See [Deep Research / Extended Thinking Export](#deep-research--extended-thinking-export).
+
 ### Perplexity
 
 1. Open a conversation on [www.perplexity.ai](https://www.perplexity.ai)
@@ -139,6 +141,15 @@ Gemini-generated images are captured and exported automatically (see [Image Expo
 1. Open a Perplexity conversation containing a Deep Research report
 2. Click the "Sync" button
 3. The report content will be extracted alongside normal conversation messages
+
+**ChatGPT Deep Research: not supported.**
+
+ChatGPT renders Deep Research reports inside a sandboxed iframe served from another origin (`*.oaiusercontent.com`), which a browser extension is not permitted to read. Expanding the report does not help. Rather than saving a note that contains your prompt and no report, the extension tells you what happened:
+
+- A conversation that is _only_ a Deep Research report is not saved, and the reason is shown.
+- A report alongside ordinary messages saves the ordinary messages and warns that the report was skipped.
+
+Normal ChatGPT conversations, including custom GPTs, are unaffected. Progress is tracked in [issue #283](https://github.com/sho7650/obsidian-AI-exporter/issues/283).
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

Documents the limitation that shipped in 2.7.11 (#425 / #283). Docs only — no `src/`, test, or config changes.

- **`README.md` + `README.ja.md`**: new **"ChatGPT Deep Research: not supported"** entry in the Deep Research / Extended Thinking section, covering why (sandboxed cross-origin iframe on `*.oaiusercontent.com`), that expanding the report does not help, and what the user actually sees — report-only conversations refused with a reason, mixed threads save the rest and warn. Normal ChatGPT chats and custom GPTs explicitly unaffected.
- **Both ChatGPT usage sections**: a one-line pointer to that entry, matching the existing auto-scroll caveat style, so someone who hit the message on a ChatGPT page finds it where they look first.

### Why this was drift worth fixing

The Deep Research section listed Gemini, Claude and Perplexity and omitted ChatGPT **entirely**. Silence there reads as "supported but undocumented" rather than "not supported", and 2.7.11 now surfaces a specific error a user will search the README for.

### Checked and deliberately left alone

- **No settings drift.** Every `SyncSettings` / `TemplateOptions` field is already documented — auto-scroll, append mode, tool content, image export + image folder, callout flattening + threshold, filename schemes, question headers, timezone, message format and callout types. Nothing missing.
- **Store descriptions unchanged.** `docs/store/description_{en,ja}.md` already scope the bullet to `Deep Research support (Gemini, Perplexity)`, so they state no untruth, and `KEY FEATURES` is a feature list rather than a place for limitations. Say the word if you would rather it be spelled out there.
- Platform list matches `platform-registry.ts` (5 platforms).

## Test plan

Docs-only, so build/test are not meaningful here:

- [x] `npm run format:check` — clean
- [x] EN/JA structural parity — 35 headings, identical levels, order and count
- [x] Internal anchors resolve — 3 per file, including both new links (`#deep-research--extended-thinking-export` / `#deep-research--extended-thinking-の保存`)
- [x] Store bullet parity unaffected — 30 / 30
- [x] Rendered check on GitHub that both new blockquote pointers and the new subsection read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)