### PR TITLE
fix: size code fences to survive nested fences (#433)

### DIFF
--- a/docs/adr/026-line-ending-handling.md
+++ b/docs/adr/026-line-ending-handling.md
@@ -178,6 +178,12 @@ remain ordinary characters inside a value.
 - A BOM-prefixed file still fails `content.startsWith('---')` and is reported as
   `unparseable`. That is a different defect and is left alone deliberately —
   ADR-025's states exist precisely so the next report can name it.
+- The LF precondition this ADR establishes is what the code-fence tracker of
+  [ADR-029](029-code-fence-sizing-and-tracking.md) is written against. Its closing
+  rule — "only spaces or tabs after the fence run" — is the exact shape an unmatched
+  CR breaks, which is the failure this ADR's addendum in ADR-028 already cost once,
+  so that tracker tolerates a trailing `\r` as defence in depth rather than relying
+  on the ordering alone.
 
 ## Alternatives considered
 

--- a/docs/adr/028-message-count-survives-callout-flattening.md
+++ b/docs/adr/028-message-count-survives-callout-flattening.md
@@ -115,6 +115,13 @@ one between the transform and the counter.
   functions. The previous regex strip required a closing fence to take effect;
   the toggle treats an unterminated fence as opening a block, matching what
   `extractTailMessages()` already did. All pre-existing tests hold.
+
+  **Superseded in part by [ADR-029](029-code-fence-sizing-and-tracking.md).** The
+  toggle was length-blind, so an inner fence inside a longer block flipped it and
+  desynced the count — this same failure class, reached from issue #433 instead of
+  a flattened callout. It is now a length- and character-aware tracker shared with
+  `escapeByLine()`. The column-0 policy and the unterminated-fence decision
+  recorded above survive unchanged.
 - Notes already corrupted are not repaired. The duplicated block must be deleted
   once by hand; the corrected count keeps the file stable afterwards.
 - **The general rule this encodes:** anything that rewrites a note body after

--- a/docs/adr/029-code-fence-sizing-and-tracking.md
+++ b/docs/adr/029-code-fence-sizing-and-tracking.md
@@ -1,0 +1,158 @@
+# ADR-029: Code fences are sized by the writer and tracked by length
+
+- Status: Accepted
+- Date: 2026-08-13
+- Issue: [#433](https://github.com/sho7650/obsidian-AI-exporter/issues/433)
+- Related: [ADR-026](026-line-ending-handling.md) (line endings),
+  [ADR-028](028-message-count-survives-callout-flattening.md) (append contract),
+  [ADR-025](025-note-identity-probe-and-fork-diagnostics.md) (naming the silent path)
+
+## Context
+
+A user asked ChatGPT for a `README.md`, exported the conversation, and got a note whose
+Markdown structure fell apart in Obsidian. The reported symptom was precise: the exporter
+always writes a three-backtick fence, so a code block whose *content* holds three backticks
+is closed by its own content.
+
+Three separate places in `src/` decided where a code block began and ended, and all three
+were wrong in the same way.
+
+### 1. The writer never looked at the code
+
+`src/content/markdown-rules.ts` overrides Turndown's built-in `fencedCodeBlock` rule twice —
+once for `pre > code` (Claude, Gemini, Perplexity, NotebookLM, ChatGPT's legacy DOM) and once
+for ChatGPT's CodeMirror DOM. Both returned a hardcoded fence:
+
+```js
+return `\n\`\`\`${lang}\n${code.trim()}\n\`\`\`\n`;
+```
+
+Turndown's own rule (`turndown/lib/turndown.cjs.js:190-213`, v7.2.2) already sizes the fence
+from the content:
+
+```js
+var fenceSize = 3;
+var fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
+while ((match = fenceInCodeRegex.exec(code))) {
+  if (match[0].length >= fenceSize) fenceSize = match[0].length + 1;
+}
+```
+
+Turndown's documented rule precedence is *added rules → commonmark rules*, so our two added
+rules shadowed that behaviour. **This was a regression against the library we depend on, not a
+feature it lacks.**
+
+### 2. Both readers used a length-blind toggle
+
+`escapeByLine()` (markdown-rules.ts) and `scanMessageStarts()` (lib/message-counter.ts) each
+flipped a boolean on any line starting with three backticks. Neither compared fence lengths,
+neither required a closing fence to be bare, and each carried its own copy of the rule.
+
+Measured consequences, both reproduced against the real modules before the fix:
+
+- **Escaping leaked into code.** For a block holding an inner fence, the toggle thought the
+  block had ended and escaped angle brackets *inside* it, writing `\<div\>a\</div\>` into the
+  vault, while leaving the genuinely-inside `<span>` after it unescaped.
+- **Append mode lost messages.** For an assistant answer showing an *opening* fence only
+  ("put this at the top of the file" — routine on ChatGPT), a four-message note counted as
+  **2**, and `extractTailMessages(body, 2)` returned `''`. That is the #406 failure class
+  (ADR-028) reached by a different road.
+
+### What the spec allows, and what it does not
+
+CommonMark 0.31.2 §4.5: a fence is a run of at least three backticks or tildes; the closing
+fence uses the same character, is at least as long as the opening one, and carries nothing but
+spaces/tabs; either fence may be indented up to three spaces (four is too many); a backtick
+fence's info string may not contain a backtick.
+
+Obsidian documents the authoring rule that follows from it ("Nesting code blocks"): *"To nest
+code blocks, use four or more backticks (or tildes) for the outer block, while the inner block
+uses three."*
+
+The reporter hoped we could preserve the tilde fence they had asked ChatGPT to use. **We
+cannot.** The rendered DOM is `<pre><code>`; the fence character never reaches the extension.
+Lengthening the backtick fence is the only fix available, and it is the one Obsidian prescribes.
+
+## Decision
+
+**1. One writer entry point.** `fenceCodeBlock(code, lang)` in `src/lib/code-fence.ts` is the
+only place in `src/` that emits a fence. Fence length is `max(3, longest fence-capable backtick
+run in the content + 1)`; the info string is sanitised, because ours is derived from arbitrary
+DOM text in the CodeMirror rule.
+
+The writer is deliberately **more conservative than the reader**: it counts any line whose first
+non-space content is a run of ≥3 backticks, without applying the info-string or bare-closer
+rules. Consumers disagree about lenient vs strict closing — a strict renderer breaks at an inner
+*bare* fence, lenient highlighters break earlier at an inner ` ```python ` — and sizing against
+any fence-capable run is correct under both. It is also exactly Turndown's own heuristic, so we
+are not inventing a second dialect.
+
+**2. One reader tracker.** `nextFenceState(state, line, options)` is a pure state machine
+implementing §4.5 as an *asymmetry*: an opening fence may carry an info string, a closing fence
+may not, and it must use the same character and be at least as long. Everything else inside an
+open block is content. That asymmetry is the whole fix — the old toggle treated ` ```python ` as
+a delimiter.
+
+The two call sites differ, deliberately:
+
+| Site | Blockquote markers | Fence characters |
+| ---- | ------------------ | ---------------- |
+| `escapeByLine()` | stripped — a callout carries every code line behind `> ` | `` ` `` and `~`; a user may paste a tilde block and its contents deserve the same protection |
+| `scanMessageStarts()` | kept — the column-0-only policy of ADR-028 | `` ` `` only |
+
+The counter ignores tildes because the writer never emits them: honouring a stray column-0
+`~~~` would open a block that hides every message after it, and a hidden message is a silent
+append stall. Ignoring it is inert.
+
+**3. The writer ⇄ reader seam is the contract.** Stated in ADR-028's form — for any code
+payload C embedded in an N-message conversation:
+
+```
+extractCodeBlocks(note.body)      contains C
+countExistingMessages(note.body)  === N
+countExistingMessages(extractTailMessages(note.body, k)) === N - k   for every k
+no escaped \< \> \$ appears inside any fenced region
+```
+
+`test/lib/fence-writer-reader-seam.test.ts` asserts all four over a payload matrix × the three
+message formats, recovering the code with a reference parser defined inside the test file so the
+writer is never graded by its own tracker. Verified to fail against the pre-fix code
+(32 of 144 assertions) and to pass after.
+
+**4. Duplication is blocked structurally.** `test/arch/fence-literal-ssot.test.ts` fails any
+module under `src/` other than `code-fence.ts` that spells out a fence literal or detects one
+itself. Verified to name all four pre-fix violations with the remedy. One documented exemption:
+`BaseExtractor.buildMetadata()` probes raw page HTML for a fence substring to set the
+`hasCodeBlocks` metadata flag — a heuristic over HTML, not fence parsing.
+
+**5. LF is the precondition; `\r` is tolerated anyway.** Body transforms run on LF and the
+line-ending restore is the last step before the write (ADR-026), so readers see LF. The closing
+rule — "only spaces or tabs after the run" — is exactly the shape a stray `\r` breaks, and
+ADR-028's addendum records what a single unmatched CR already cost once. The tracker therefore
+tolerates a trailing `\r` rather than losing the fence and every message boundary after it.
+
+**6. The silent case is logged.** A body that ends inside a fenced block is the one shape where
+the count can be wrong with no other symptom: an overcount makes `buildAppendContent()` return
+null and the caller reports a successful no-op. It now emits
+`[G2O] Existing note body ends inside a fenced code block` with the id, the open fence, and both
+counts — the ADR-025 principle that a silent path must at least name itself.
+
+## Consequences
+
+- **Notes already on disk are not repaired**, matching the ADR-028 precedent. The information
+  needed to recover the author's intent was destroyed at write time, so old and new readers both
+  mis-parse a broken note — differently. The parity flip means the count may change on the first
+  sync after upgrade: an undercount appends a tail that is already there once and then
+  self-limits; an overcount is a silent no-op that needs a one-time manual fix. Decision 6 exists
+  so the second case is reportable.
+- **Nothing changes for notes without nested code.** Every fence in them is a balanced
+  three-backtick pair, where the strict tracker and the old toggle agree line for line. No
+  existing test needed editing: 1520 tests passed before, and the same 1520 still pass.
+- **ADR-028's fenced-code consequence is superseded in part.** "A single column-0 toggle, shared
+  by both functions" is now a length- and character-aware tracker. What survives unchanged: the
+  column-0 policy, and the decision that an unterminated fence opens a block.
+- **A known wrinkle is deliberately untouched.** `escapeByLine()` strips blockquote markers
+  before matching, so a quoted `> ```  ` opening and a column-0 ` ``` ` closing are still
+  conflated. It is out of scope for #433 and no reported symptom depends on it.
+- Coverage moved 96.31 → 96.37 stmts / 87.04 → 87.28 branches; `code-fence.ts` and
+  `message-counter.ts` are at 100% on all four metrics.

--- a/src/content/markdown-rules.ts
+++ b/src/content/markdown-rules.ts
@@ -7,6 +7,7 @@
 
 import TurndownService from 'turndown';
 import { MAX_LANG_HINT_LENGTH, MAX_MATH_LENGTH } from '../lib/constants';
+import { fenceCodeBlock, nextFenceState, type OpenFence } from '../lib/code-fence';
 
 /** Leading blockquote prefix (one or more `> ` markers) to preserve as-is. */
 const BLOCKQUOTE_PREFIX_PATTERN = /^(\s*>\s*)+/;
@@ -57,20 +58,25 @@ function escapeSpecialCharsInLine(line: string, pattern: RegExp): string {
 /**
  * Escape target characters across Markdown text, skipping fenced code blocks
  * (where the characters are already literal in Obsidian).
+ *
+ * Fence state comes from {@link nextFenceState}, which is length- and
+ * character-aware: an inner fence inside a longer block is content, not a
+ * delimiter. A length-blind toggle used to lose track there and write escaped
+ * `\<div\>` into the middle of a code block (issue #433, ADR-029).
+ *
+ * Both fence characters open a block here — a user may paste a tilde-fenced
+ * block, and its contents deserve the same protection.
  */
 function escapeByLine(text: string, pattern: RegExp): string {
   const lines = text.split('\n');
-  let inFencedBlock = false;
+  // Delimiters may sit inside a blockquote (`> ```), so markers are stripped
+  // before matching.
+  let fence: OpenFence = null;
 
   const result = lines.map(line => {
-    // Detect fenced code delimiter (may be inside a blockquote)
-    const stripped = line.replace(/^(\s*>\s*)*/, '');
-    if (/^`{3,}/.test(stripped)) {
-      inFencedBlock = !inFencedBlock;
-      return line;
-    }
-
-    if (inFencedBlock) return line;
+    const step = nextFenceState(fence, line, { stripBlockquote: true });
+    fence = step.state;
+    if (step.isDelimiter || fence !== null) return line;
 
     return escapeSpecialCharsInLine(line, pattern);
   });
@@ -126,7 +132,7 @@ turndown.addRule('codeBlocks', {
     const lang = langMatch ? langMatch[1] : '';
 
     const code = codeElement.textContent || '';
-    return `\n\`\`\`${lang}\n${code.trim()}\n\`\`\`\n`;
+    return fenceCodeBlock(code, lang);
   },
 });
 
@@ -180,7 +186,7 @@ turndown.addRule('codemirrorCodeBlocks', {
       }
     }
 
-    return `\n\`\`\`${lang}\n${code.trim()}\n\`\`\`\n`;
+    return fenceCodeBlock(code, lang);
   },
 });
 

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -10,7 +10,7 @@ import type { ObsidianNote, ExtensionSettings, FilenameScheme } from './types';
 import { SCAN_MAX_REQUESTS } from './constants';
 import { parseFrontmatter, updateFrontmatter, type LineEnding } from './frontmatter-parser';
 import { classifyNoteProbe, isSameConversation, type NoteProbe } from './note-identity';
-import { countExistingMessages, extractTailMessages } from './message-counter';
+import { countExistingMessages, extractTailMessages, unterminatedFence } from './message-counter';
 import { formatDateWithTimezone } from './date-utils';
 
 /**
@@ -385,6 +385,22 @@ export function buildAppendContent(
 
   // 2. Count existing messages
   const existingCount = countExistingMessages(parsed.body);
+
+  // A body that ends inside a fenced code block hides every message after the
+  // opening fence, so the count can be wrong while every other signal stays
+  // clean: an overcount returns null below and the caller reports a successful
+  // no-op. Name the condition rather than letting it vanish (ADR-029, and the
+  // same reasoning as the append-lookup miss log in ADR-025).
+  const openFence = unterminatedFence(parsed.body);
+  if (openFence) {
+    console.info('[G2O] Existing note body ends inside a fenced code block', {
+      id: note.frontmatter.id,
+      fence: openFence,
+      countedMessages: existingCount,
+      expectedMessages: note.frontmatter.message_count,
+    });
+  }
+
   if (existingCount === 0) return null; // Cannot detect message boundaries
 
   // 3. Compare counts

--- a/src/lib/code-fence.ts
+++ b/src/lib/code-fence.ts
@@ -1,0 +1,157 @@
+/**
+ * Markdown code fences: one sizer for the writer, one tracker for the readers.
+ *
+ * Issue #433: the two Turndown code-block rules emitted a hardcoded three
+ * backtick fence and never looked at the code, so a conversation *about*
+ * Markdown closed its own code block at the first inner fence. The two fence
+ * readers (`escapeByLine()` and `scanMessageStarts()`) then compounded it with
+ * a length-blind toggle that treated that inner fence as a delimiter.
+ *
+ * Everything here follows CommonMark 0.31.2 §4.5:
+ * - a fence is a run of at least three backticks or tildes;
+ * - the closing fence uses the same character and is at least as long as the
+ *   opening one, and carries nothing but spaces/tabs after it;
+ * - either fence may be indented by up to three spaces (four is too many);
+ * - a backtick fence's info string may not contain a backtick.
+ *
+ * Obsidian documents the same rule for authors ("Nesting code blocks": the
+ * outer block must use more fence characters than any inner block), so sizing
+ * the outer fence is what makes a nested block survive the round trip.
+ *
+ * ADR-029.
+ */
+
+/** CommonMark §4.5: a fence is a run of at least three fence characters. */
+export const MIN_FENCE_LENGTH = 3;
+
+/** The two fence characters CommonMark permits. They cannot be mixed. */
+export type FenceChar = '`' | '~';
+
+/** Both fence characters, in the order they are probed. */
+const ALL_FENCE_CHARS: readonly FenceChar[] = ['`', '~'];
+
+/**
+ * A fence-capable backtick run at the start of a line, allowing the three
+ * spaces of indentation CommonMark permits. Deliberately blind to the info
+ * string and to trailing text: the writer sizes against *any* such run, so the
+ * result is safe under both strict and lenient consumers (ADR-029).
+ */
+const WRITER_FENCE_RUN_PATTERN = /^ {0,3}(`{3,})/gm;
+
+/** Leading blockquote markers (`> `, `> > `), optionally indented. */
+const BLOCKQUOTE_PREFIX_PATTERN = /^(\s*>\s*)*/;
+
+/** Characters that may not appear in a backtick info string, plus line breaks. */
+const INFO_STRING_STRIP_PATTERN = /[`\r\n]/g;
+
+/**
+ * Length of the backtick fence that can safely wrap `code`: the minimum, or
+ * one more than the longest fence-capable run the code contains.
+ */
+export function outerFenceLength(code: string): number {
+  let longest = 0;
+  // `exec` in a loop over a /g regex — reset first so repeated calls are pure.
+  WRITER_FENCE_RUN_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = WRITER_FENCE_RUN_PATTERN.exec(code)) !== null) {
+    longest = Math.max(longest, match[1].length);
+  }
+  return longest === 0 ? MIN_FENCE_LENGTH : Math.max(MIN_FENCE_LENGTH, longest + 1);
+}
+
+/**
+ * Strip what CommonMark forbids in a backtick info string (a backtick would
+ * end the fence line) plus line breaks, which would break the block outright.
+ */
+export function sanitizeInfoString(lang: string): string {
+  return lang.replace(INFO_STRING_STRIP_PATTERN, '').trim();
+}
+
+/**
+ * The single writer entry point: `code` wrapped in a fence no line of it can
+ * close. The surrounding newlines match what the Turndown rules emitted before
+ * ADR-029, so block spacing in generated notes is unchanged.
+ */
+export function fenceCodeBlock(code: string, lang = ''): string {
+  const trimmed = code.trim();
+  const fence = '`'.repeat(outerFenceLength(trimmed));
+  return `\n${fence}${sanitizeInfoString(lang)}\n${trimmed}\n${fence}\n`;
+}
+
+/** The fence currently held open, or `null` when outside any fenced block. */
+export type OpenFence = { readonly char: FenceChar; readonly length: number } | null;
+
+export interface FenceScanOptions {
+  /**
+   * Strip leading blockquote markers before matching. `escapeByLine()` sets
+   * this because a callout carries every code line behind `> `;
+   * `scanMessageStarts()` does not, keeping its column-0-only policy (ADR-028).
+   */
+  readonly stripBlockquote?: boolean;
+  /**
+   * Fence characters allowed to OPEN a block. Both by default. The message
+   * counter passes backticks only: it never reads its own tildes, and a stray
+   * column-0 `~~~` in a note would otherwise open a block that hides every
+   * message after it (ADR-029).
+   */
+  readonly openChars?: readonly FenceChar[];
+}
+
+export interface FenceStep {
+  /** Fence state AFTER consuming the line. */
+  readonly state: OpenFence;
+  /** True when the line is itself an opening or closing delimiter. */
+  readonly isDelimiter: boolean;
+}
+
+/** Length of the fence-character run starting at `index`, or 0 if none. */
+function runLength(text: string, index: number, char: FenceChar): number {
+  let end = index;
+  while (end < text.length && text[end] === char) end++;
+  return end - index;
+}
+
+/** Index of the first character after up to three spaces, or -1 if more. */
+function fenceStart(line: string): number {
+  let i = 0;
+  while (i < line.length && line[i] === ' ') i++;
+  return i <= 3 ? i : -1;
+}
+
+/**
+ * Advance fence state by one line. Pure: the caller threads `state` through its
+ * own loop and this never mutates what it is handed.
+ */
+export function nextFenceState(
+  state: OpenFence,
+  line: string,
+  options: FenceScanOptions = {}
+): FenceStep {
+  const prepared = options.stripBlockquote ? line.replace(BLOCKQUOTE_PREFIX_PATTERN, '') : line;
+  const start = fenceStart(prepared);
+  if (start === -1) return { state, isDelimiter: false };
+
+  if (state !== null) {
+    // Closing: same character, at least as long, nothing but spaces/tabs after
+    // it. A trailing CR is tolerated as defence in depth — a body that reaches
+    // a reader as CRLF is an ordering bug (ADR-026), not a reason to lose the
+    // fence and with it every message boundary that follows (ADR-028).
+    const length = runLength(prepared, start, state.char);
+    if (length >= state.length && /^[ \t]*\r?$/.test(prepared.slice(start + length))) {
+      return { state: null, isDelimiter: true };
+    }
+    return { state, isDelimiter: false };
+  }
+
+  const openChars = options.openChars ?? ALL_FENCE_CHARS;
+  for (const char of openChars) {
+    const length = runLength(prepared, start, char);
+    if (length < MIN_FENCE_LENGTH) continue;
+    // CommonMark: an info string after a backtick fence may not contain a
+    // backtick, so such a line is ordinary text rather than a fence.
+    if (char === '`' && prepared.slice(start + length).includes('`')) continue;
+    return { state: { char, length }, isDelimiter: true };
+  }
+
+  return { state, isDelimiter: false };
+}

--- a/src/lib/message-counter.ts
+++ b/src/lib/message-counter.ts
@@ -6,6 +6,7 @@
  */
 
 import { ALL_PLATFORM_LABELS } from './constants';
+import { nextFenceState, type OpenFence } from './code-fence';
 
 /**
  * Build label alternation from ALL_PLATFORM_LABELS: "User|Gemini Notebook|...".
@@ -41,25 +42,57 @@ const MESSAGE_START_PATTERN = new RegExp(
  * {@link countExistingMessages} and {@link extractTailMessages} read it, so
  * the count and the offset it is used at cannot drift apart.
  */
-function scanMessageStarts(lines: readonly string[]): number[] {
+interface BodyScan {
+  /** Line indices at which a message starts. */
+  readonly starts: readonly number[];
+  /** Fence still open when the body ran out, or null. */
+  readonly openFence: OpenFence;
+}
+
+function scanBody(lines: readonly string[]): BodyScan {
   const starts: number[] = [];
-  let inCodeBlock = false;
+  let fence: OpenFence = null;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Only column-0 fences are tracked: inside a callout every line carries a
-    // `> ` prefix, and a nested `> > [!TYPE] Label` cannot match a start anyway.
-    if (line.startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
+    // Only column-0 backtick fences are tracked, for two separate reasons:
+    //
+    // - Blockquote markers are NOT stripped: inside a callout every line
+    //   carries a `> ` prefix, and a nested `> > [!TYPE] Label` cannot match a
+    //   start anyway (ADR-028).
+    // - Tildes are NOT recognised: the writer only ever emits backtick fences,
+    //   so a column-0 `~~~` in a note is prose. Honouring it would open a block
+    //   that hides every message after it — silently stalling append mode
+    //   (ADR-029).
+    //
+    // The tracker itself is length- and character-aware, so a fence nested
+    // inside a longer one is content rather than a delimiter (issue #433).
+    const step = nextFenceState(fence, line, { openChars: ['`'] });
+    fence = step.state;
+    if (step.isDelimiter || fence !== null) continue;
 
     if (MESSAGE_START_PATTERN.test(line)) starts.push(i);
   }
 
-  return starts;
+  return { starts, openFence: fence };
+}
+
+/** Line indices at which a message starts. */
+function scanMessageStarts(lines: readonly string[]): readonly number[] {
+  return scanBody(lines).starts;
+}
+
+/**
+ * The fence still open when `body` ended, or null when every fence is closed.
+ *
+ * A body that ends inside a code block is the shape where the count can be
+ * wrong with no other symptom: an overcount makes `buildAppendContent()`
+ * return null, and the caller then reports a perfectly successful no-op
+ * (ADR-029).
+ */
+export function unterminatedFence(body: string): OpenFence {
+  return scanBody(body.split('\n')).openFence;
 }
 
 /**

--- a/test/arch/fence-literal-ssot.test.ts
+++ b/test/arch/fence-literal-ssot.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Fitness function: code fences are written and parsed in exactly one place
+ * (ADR-029).
+ *
+ * Issue #433 was one defect written down three times: `markdown-rules.ts` had
+ * a hardcoded three-backtick fence in two rules, and two separate readers
+ * (`escapeByLine()`, `scanMessageStarts()`) each carried their own length-blind
+ * `` ``` `` toggle. Each copy was individually plausible and collectively wrong,
+ * and nothing in the suite objected to a fourth copy being added.
+ *
+ * So the rule is structural: `src/lib/code-fence.ts` emits fences via
+ * `fenceCodeBlock()` and tracks them via `nextFenceState()`, and no other
+ * module under src/ may spell a fence out for itself.
+ *
+ * Comments are stripped first, so documenting a fence in prose stays allowed —
+ * only executable code is inspected.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const srcDir = path.join(root, 'src');
+
+/** The one module allowed to spell fences out. */
+const FENCE_SSOT = 'src/lib/code-fence.ts';
+
+/**
+ * A documented, deliberately narrow exemption: `BaseExtractor.buildMetadata()`
+ * probes raw HTML for a fence substring to set the `hasCodeBlocks` metadata
+ * flag. That is a heuristic over page HTML, not fence emission or fence
+ * parsing, so it is exempt — but only this exact expression is. Any other
+ * fence literal in that file still fails the check below.
+ */
+const EXEMPT_EXPRESSIONS = ["m.content.includes('```')"];
+
+function collectSources(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return collectSources(full);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
+  });
+}
+
+/** Strip comments so prose about fences stays allowed. */
+function stripComments(code: string): string {
+  return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+function executableCode(rel: string): string {
+  const raw = stripComments(fs.readFileSync(path.join(root, rel), 'utf-8'));
+  return EXEMPT_EXPRESSIONS.reduce((code, expr) => code.split(expr).join(''), raw);
+}
+
+const sources = collectSources(srcDir)
+  .map(f => path.relative(root, f))
+  .filter(rel => rel !== FENCE_SSOT);
+
+describe('architecture: code fences have a single source of truth', () => {
+  it('finds sources to check, and the SSOT module itself', () => {
+    expect(sources.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(root, FENCE_SSOT))).toBe(true);
+  });
+
+  it.each(sources)('%s does not spell out a fence literal', rel => {
+    const code = executableCode(rel);
+    // A run of three or more backticks in a string, or the escaped form a
+    // template literal uses.
+    const offenders = [...(code.match(/`{3,}/g) ?? []), ...(code.match(/\\`\\`\\`/g) ?? [])];
+    expect(
+      offenders,
+      `${rel} writes a fence itself — emit fenced code via fenceCodeBlock() from ${FENCE_SSOT}`
+    ).toEqual([]);
+  });
+
+  it.each(sources)('%s does not detect fences itself', rel => {
+    const code = executableCode(rel);
+    // `` `{3,} `` quantifiers and `startsWith('```')`-style probes: both are
+    // length-blind fence detection, which is what desynced the readers in #433.
+    const offenders = [
+      ...(code.match(/`\{\d+,?\d*\}/g) ?? []),
+      ...(code.match(/startsWith\(\s*['"`]`/g) ?? []),
+    ];
+    expect(
+      offenders,
+      `${rel} parses fences itself — track fence state via nextFenceState() from ${FENCE_SSOT}`
+    ).toEqual([]);
+  });
+});

--- a/test/content/markdown.test.ts
+++ b/test/content/markdown.test.ts
@@ -117,6 +117,49 @@ describe('htmlToMarkdown', () => {
       expect(htmlToMarkdown('Use <code>npm install</code>')).toBe('Use `npm install`');
     });
 
+    // Issue #433: a conversation *about* Markdown closed its own code block at
+    // the first inner fence, because the fence was hardcoded to three
+    // backticks. CommonMark §4.5 / Obsidian "Nesting code blocks": the outer
+    // fence must be longer than any fence the content holds (ADR-029).
+    describe('nested code blocks (issue #433)', () => {
+      const F3 = '`'.repeat(3);
+      const F4 = '`'.repeat(4);
+
+      it('wraps a pre>code block containing an inner fence in a longer fence', () => {
+        const code = `# Title\n\n${F3}python\nprint(1)\n${F3}`;
+        const html = `<pre><code class="language-markdown">${code}</code></pre>`;
+        const result = htmlToMarkdown(html);
+
+        expect(result).toContain(`${F4}markdown\n`);
+        expect(result.trim().endsWith(F4)).toBe(true);
+        // The inner block survives verbatim, fence lines included.
+        expect(result).toContain(`${F3}python\nprint(1)\n${F3}`);
+      });
+
+      it('wraps a CodeMirror block containing an inner fence in a longer fence', () => {
+        const html = `<pre><div><div><div class="flex items-center text-sm font-medium">Markdown</div>
+          <div><button aria-label="Copy"></button></div></div>
+          <div><div class="cm-editor"><div class="cm-scroller"><div class="cm-content">
+          <span># Title</span><br><span>${F3}python</span><br><span>print(1)</span><br><span>${F3}</span>
+          </div></div></div></div></div></pre>`;
+        const result = htmlToMarkdown(html);
+
+        expect(result).toContain(`${F4}markdown\n`);
+        expect(result).toContain(`${F3}python\nprint(1)\n${F3}`);
+      });
+
+      it('grows the fence past the longest inner run, not just the first', () => {
+        const code = `${F3}\ntext\n${'`'.repeat(5)}\n${F3}`;
+        const html = `<pre><code class="language-md">${code}</code></pre>`;
+        expect(htmlToMarkdown(html)).toContain(`${'`'.repeat(6)}md\n`);
+      });
+
+      it('leaves ordinary code blocks on the minimum fence', () => {
+        const html = '<pre><code class="language-python">x = 1</code></pre>';
+        expect(htmlToMarkdown(html)).toBe(`${F3}python\nx = 1\n${F3}`);
+      });
+    });
+
     // ChatGPT CodeMirror code blocks (2026-03 DOM change)
     // ChatGPT replaced <pre><code> with <pre> containing CodeMirror editor
     describe('ChatGPT CodeMirror structure', () => {
@@ -428,6 +471,37 @@ describe('escapeAngleBrackets', () => {
     it('preserves fenced code blocks inside blockquotes', () => {
       const input = '> ```\n> <code>\n> ```';
       expect(escapeAngleBrackets(input)).toBe(input);
+    });
+
+    // Issue #433, second order: the length-blind fence toggle thought the
+    // inner fence had closed the block, so it escaped angle brackets *inside*
+    // the code and left the ones after it alone (ADR-029).
+    describe('blocks holding an inner fence', () => {
+      const F3 = '`'.repeat(3);
+      const F4 = '`'.repeat(4);
+
+      it('preserves angle brackets across an inner fence', () => {
+        const input = [`${F4}markdown`, `${F3}html`, '<div>a</div>', F3, F4].join('\n');
+        expect(escapeAngleBrackets(input)).toBe(input);
+      });
+
+      it('still escapes text that follows the closing fence', () => {
+        const input = [`${F4}md`, `${F3}html`, '<div>a</div>', F3, F4, 'after <span>'].join('\n');
+        const expected = [`${F4}md`, `${F3}html`, '<div>a</div>', F3, F4, 'after \\<span\\>'].join(
+          '\n'
+        );
+        expect(escapeAngleBrackets(input)).toBe(expected);
+      });
+
+      it('does not let an inner fence with an info string close the block', () => {
+        const input = [F3, `${F3}html`, '<div>a</div>'].join('\n');
+        expect(escapeAngleBrackets(input)).toBe(input);
+      });
+
+      it('preserves a tilde block a user pasted', () => {
+        const input = ['~~~md', '<div>a</div>', '~~~'].join('\n');
+        expect(escapeAngleBrackets(input)).toBe(input);
+      });
     });
   });
 

--- a/test/lib/append-utils.test.ts
+++ b/test/lib/append-utils.test.ts
@@ -515,6 +515,70 @@ describe('buildAppendContent', () => {
     expect(result).toBeNull();
   });
 
+  // ADR-029 / ADR-025 style: a note whose body ends inside a fenced code block
+  // is the one shape that can make the count wrong in a way that produces no
+  // other signal — an overcount returns null here and the caller reports a
+  // successful no-op. Name it, so a field report is actionable.
+  describe('unterminated code fence diagnostic', () => {
+    const F3 = '`'.repeat(3);
+
+    function existingWith(bodyLines: readonly string[]): string {
+      return [
+        '---',
+        'id: claude_test',
+        'message_count: 2',
+        'modified: "2026-01-01"',
+        '---',
+        ...bodyLines,
+      ].join('\n');
+    }
+
+    it('reports the open fence when the body ends inside a code block', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const existing = existingWith([
+        '> [!QUESTION] User',
+        '> Hello',
+        '',
+        '> [!NOTE] Claude',
+        '> Here:',
+        '',
+        `${F3}markdown`,
+        'unterminated',
+      ]);
+
+      buildAppendContent(existing, testNote, testSettings);
+
+      expect(info).toHaveBeenCalledWith(
+        '[G2O] Existing note body ends inside a fenced code block',
+        expect.objectContaining({
+          id: testNote.frontmatter.id,
+          fence: { char: '`', length: 3 },
+        })
+      );
+      info.mockRestore();
+    });
+
+    it('stays quiet when every fence is closed', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      const existing = existingWith([
+        '> [!QUESTION] User',
+        '> Hello',
+        '',
+        '> [!NOTE] Claude',
+        '> Here:',
+        '',
+        `${F3}markdown`,
+        'closed',
+        F3,
+      ]);
+
+      buildAppendContent(existing, testNote, testSettings);
+
+      expect(info).not.toHaveBeenCalled();
+      info.mockRestore();
+    });
+  });
+
   it('returns null when existing body has no detectable messages', () => {
     const existing = '---\nid: test\nmessage_count: 2\n---\nJust some text';
     const result = buildAppendContent(existing, testNote, testSettings);

--- a/test/lib/code-fence.test.ts
+++ b/test/lib/code-fence.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the single source of truth on Markdown code fences (ADR-029).
+ *
+ * Two halves, written against the rules of CommonMark 0.31.2 §4.5:
+ * - the WRITER side sizes a fence so that nothing in the content can close it;
+ * - the READER side tracks fence state so that an inner fence is content, not
+ *   a delimiter.
+ *
+ * Both halves exist because issue #433 broke in both directions at once: the
+ * emitted fence was too short, and the two fence readers then disagreed about
+ * where the code block ended.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_FENCE_LENGTH,
+  outerFenceLength,
+  sanitizeInfoString,
+  fenceCodeBlock,
+  nextFenceState,
+  type OpenFence,
+} from '../../src/lib/code-fence';
+
+/** Backtick runs, built by repetition so the source itself stays fence-free. */
+const BT = (n: number): string => '`'.repeat(n);
+const F3 = BT(3);
+const F4 = BT(4);
+
+describe('outerFenceLength', () => {
+  it('uses the minimum fence for code with no fence-capable run', () => {
+    expect(outerFenceLength('const x = 1;')).toBe(MIN_FENCE_LENGTH);
+    expect(outerFenceLength('')).toBe(MIN_FENCE_LENGTH);
+  });
+
+  it('grows past an inner opening fence with an info string', () => {
+    expect(outerFenceLength(`# Title\n${F3}python\nprint(1)\n${F3}`)).toBe(4);
+  });
+
+  it('grows past a bare inner fence', () => {
+    expect(outerFenceLength(`text\n${F3}\ncode\n${F3}`)).toBe(4);
+  });
+
+  it('grows past the longest run, not the first', () => {
+    expect(outerFenceLength(`${F3}\n${BT(5)}\n${F3}`)).toBe(6);
+  });
+
+  it('counts a run indented by up to three spaces (CommonMark §4.5)', () => {
+    expect(outerFenceLength(`   ${F3}md`)).toBe(4);
+  });
+
+  it('ignores a run indented by four spaces — too much to be a fence', () => {
+    expect(outerFenceLength(`    ${F3}md`)).toBe(MIN_FENCE_LENGTH);
+  });
+
+  it('ignores backtick runs that are not at the start of a line', () => {
+    expect(outerFenceLength(`const s = "${F3}";`)).toBe(MIN_FENCE_LENGTH);
+  });
+
+  it('ignores runs shorter than a fence', () => {
+    expect(outerFenceLength('``not a fence')).toBe(MIN_FENCE_LENGTH);
+  });
+
+  it('ignores tilde runs — a tilde cannot close a backtick fence', () => {
+    expect(outerFenceLength('~~~\ncode\n~~~')).toBe(MIN_FENCE_LENGTH);
+  });
+});
+
+describe('sanitizeInfoString', () => {
+  it('strips backticks, which CommonMark forbids in a backtick info string', () => {
+    expect(sanitizeInfoString(`py${F3}thon`)).toBe('python');
+  });
+
+  it('strips newlines and carriage returns', () => {
+    expect(sanitizeInfoString('py\r\nthon')).toBe('python');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeInfoString('  python  ')).toBe('python');
+  });
+
+  it('passes an ordinary hint through unchanged', () => {
+    expect(sanitizeInfoString('javascript')).toBe('javascript');
+  });
+});
+
+describe('fenceCodeBlock', () => {
+  it('emits the block shape the Turndown rules emitted before ADR-029', () => {
+    expect(fenceCodeBlock('x = 1', 'python')).toBe(`\n${F3}python\nx = 1\n${F3}\n`);
+  });
+
+  it('omits the info string when no language is given', () => {
+    expect(fenceCodeBlock('x = 1')).toBe(`\n${F3}\nx = 1\n${F3}\n`);
+  });
+
+  it('trims the code exactly as the previous rules did', () => {
+    expect(fenceCodeBlock('\n\nx = 1\n\n', 'py')).toBe(`\n${F3}py\nx = 1\n${F3}\n`);
+  });
+
+  it('wraps nested fences in a longer fence (issue #433)', () => {
+    const code = `# Title\n${F3}python\nprint(1)\n${F3}`;
+    expect(fenceCodeBlock(code, 'markdown')).toBe(`\n${F4}markdown\n${code}\n${F4}\n`);
+  });
+
+  it('sizes the fence from the trimmed code', () => {
+    expect(fenceCodeBlock(`  ${F3}md\ntext`)).toBe(`\n${F4}\n${F3}md\ntext\n${F4}\n`);
+  });
+
+  it('sanitizes the language hint', () => {
+    expect(fenceCodeBlock('x', `m${F3}d`)).toBe(`\n${F3}md\nx\n${F3}\n`);
+  });
+});
+
+describe('nextFenceState', () => {
+  const open = (char: '`' | '~', length: number): OpenFence => ({ char, length });
+
+  describe('opening', () => {
+    it('opens on a bare fence', () => {
+      expect(nextFenceState(null, F3)).toEqual({ state: open('`', 3), isDelimiter: true });
+    });
+
+    it('opens on a fence with an info string', () => {
+      expect(nextFenceState(null, `${F3}python`)).toEqual({
+        state: open('`', 3),
+        isDelimiter: true,
+      });
+    });
+
+    it('records the full run length of a longer fence', () => {
+      expect(nextFenceState(null, F4).state).toEqual(open('`', 4));
+    });
+
+    it('opens on a tilde fence by default', () => {
+      expect(nextFenceState(null, '~~~yaml').state).toEqual(open('~', 3));
+    });
+
+    it('does not open on a tilde fence when openChars excludes it', () => {
+      expect(nextFenceState(null, '~~~yaml', { openChars: ['`'] })).toEqual({
+        state: null,
+        isDelimiter: false,
+      });
+    });
+
+    it('does not open on a backtick fence whose info string contains a backtick', () => {
+      expect(nextFenceState(null, `${F3}js \`x\``)).toEqual({ state: null, isDelimiter: false });
+    });
+
+    it('opens on a tilde fence whose info string contains a backtick', () => {
+      expect(nextFenceState(null, '~~~js `x`').state).toEqual(open('~', 3));
+    });
+
+    it('opens when indented by up to three spaces', () => {
+      expect(nextFenceState(null, `   ${F3}`).state).toEqual(open('`', 3));
+    });
+
+    it('does not open when indented by four spaces', () => {
+      expect(nextFenceState(null, `    ${F3}`)).toEqual({ state: null, isDelimiter: false });
+    });
+
+    it('does not open on a leading tab (a tab reaches column four)', () => {
+      expect(nextFenceState(null, `\t${F3}`)).toEqual({ state: null, isDelimiter: false });
+    });
+
+    it('does not open on a run shorter than three characters', () => {
+      expect(nextFenceState(null, '``x')).toEqual({ state: null, isDelimiter: false });
+    });
+
+    it('leaves ordinary text alone', () => {
+      expect(nextFenceState(null, 'const x = 1;')).toEqual({ state: null, isDelimiter: false });
+    });
+  });
+
+  describe('closing', () => {
+    it('closes on a fence of equal length', () => {
+      expect(nextFenceState(open('`', 3), F3)).toEqual({ state: null, isDelimiter: true });
+    });
+
+    it('closes on a longer fence (CommonMark: at least as long)', () => {
+      expect(nextFenceState(open('`', 3), BT(5))).toEqual({ state: null, isDelimiter: true });
+    });
+
+    it('does not close on a shorter fence — that is content', () => {
+      expect(nextFenceState(open('`', 4), F3)).toEqual({
+        state: open('`', 4),
+        isDelimiter: false,
+      });
+    });
+
+    it('does not close on an inner fence carrying an info string (issue #433)', () => {
+      expect(nextFenceState(open('`', 3), `${F3}python`)).toEqual({
+        state: open('`', 3),
+        isDelimiter: false,
+      });
+    });
+
+    it('does not close on the other fence character', () => {
+      expect(nextFenceState(open('`', 3), '~~~').state).toEqual(open('`', 3));
+      expect(nextFenceState(open('~', 3), F3).state).toEqual(open('~', 3));
+    });
+
+    it('closes when followed by trailing spaces or tabs', () => {
+      expect(nextFenceState(open('`', 3), `${F3}  \t`)).toEqual({
+        state: null,
+        isDelimiter: true,
+      });
+    });
+
+    it('tolerates a trailing carriage return (ADR-026 defence in depth)', () => {
+      expect(nextFenceState(open('`', 3), `${F3}\r`)).toEqual({ state: null, isDelimiter: true });
+    });
+
+    it('closes when indented by up to three spaces', () => {
+      expect(nextFenceState(open('`', 3), `   ${F3}`)).toEqual({ state: null, isDelimiter: true });
+    });
+
+    it('does not close when indented by four spaces', () => {
+      expect(nextFenceState(open('`', 3), `    ${F3}`).state).toEqual(open('`', 3));
+    });
+
+    it('treats ordinary lines inside a block as content', () => {
+      expect(nextFenceState(open('`', 3), '<div>a</div>')).toEqual({
+        state: open('`', 3),
+        isDelimiter: false,
+      });
+    });
+  });
+
+  describe('blockquote handling', () => {
+    it('ignores blockquote markers when stripBlockquote is set', () => {
+      expect(nextFenceState(null, `> ${F3}md`, { stripBlockquote: true }).state).toEqual(
+        open('`', 3)
+      );
+      expect(nextFenceState(open('`', 3), `> ${F3}`, { stripBlockquote: true }).state).toBeNull();
+    });
+
+    it('does not treat a quoted fence as a delimiter by default', () => {
+      expect(nextFenceState(null, `> ${F3}md`)).toEqual({ state: null, isDelimiter: false });
+    });
+  });
+
+  it('is pure — it never mutates the state it is handed', () => {
+    const state = open('`', 3);
+    nextFenceState(state, F3);
+    expect(state).toEqual({ char: '`', length: 3 });
+  });
+});

--- a/test/lib/fence-writer-reader-seam.test.ts
+++ b/test/lib/fence-writer-reader-seam.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Fitness function for the writer ⇄ reader seam behind issue #433.
+ *
+ * `conversationToNote()` decides how a code block is fenced;
+ * `countExistingMessages()` / `extractTailMessages()` decide how much of a
+ * saved note append mode believes is already there; `escapeAngleBrackets()`
+ * decides which characters get backslashes. All three parse fences, and #433
+ * was the three of them disagreeing about where a code block ends.
+ *
+ * ADR-028 taught that the seam, not the unit, is what catches this class: both
+ * modules were individually well covered when #406 shipped. So these tests
+ * drive the real writer and the real readers over one payload matrix, and the
+ * code is recovered by a reference parser defined HERE — deliberately not
+ * importing src/lib/code-fence.ts, so the writer is never graded by its own
+ * tracker.
+ */
+import { describe, it, expect } from 'vitest';
+import { conversationToNote } from '../../src/content/markdown';
+import { countExistingMessages, extractTailMessages } from '../../src/lib/message-counter';
+import type { ConversationData, TemplateOptions } from '../../src/lib/types';
+
+const F3 = '`'.repeat(3);
+const F4 = '`'.repeat(4);
+const F5 = '`'.repeat(5);
+
+/** Code payloads a conversation about Markdown realistically produces. */
+const PAYLOADS: ReadonlyArray<{ name: string; code: string }> = [
+  { name: 'plain code', code: 'const x = 1;' },
+  { name: 'inner block with a language', code: `# Title\n\n${F3}python\nprint(1)\n${F3}` },
+  { name: 'inner bare fence', code: `text\n${F3}\ncode\n${F3}` },
+  { name: 'inner four-backtick block', code: `${F4}md\n${F3}js\nx\n${F3}\n${F4}` },
+  { name: 'opening fence only', code: `Put this at the top:\n\n${F3}md` },
+  { name: 'closing fence only', code: `…and end it with:\n\n${F3}` },
+  { name: 'indented inner fence', code: `text\n   ${F3}md\nx\n   ${F3}` },
+  { name: 'inner fence with trailing spaces', code: `${F3}md  \nx\n${F3}  ` },
+  { name: 'tilde block', code: '~~~md\nx\n~~~' },
+  { name: 'message-shaped lines', code: `${F3}md\n**User:**\n**Claude:**\n${F3}` },
+  { name: 'angle brackets and dollars', code: '<div>$HOME</div>\nif (a < b && c > d) {}' },
+  { name: 'longest run wins', code: `${F3}\n${F5}\n${F3}` },
+];
+
+const FORMATS: ReadonlyArray<TemplateOptions['messageFormat']> = ['callout', 'blockquote', 'plain'];
+
+const BASE_OPTIONS: TemplateOptions = {
+  includeId: true,
+  includeTitle: true,
+  includeTags: true,
+  includeSource: true,
+  includeDates: true,
+  includeMessageCount: true,
+  messageFormat: 'callout',
+  userCalloutType: 'QUESTION',
+  assistantCalloutType: 'NOTE',
+};
+
+/** Escape text for embedding in an HTML fixture, as the real DOM would hold it. */
+function toHtmlText(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * A 4-message conversation whose second message is a code block holding `code`.
+ * Message count is what append mode compares against, so it is set honestly.
+ */
+function noteFor(code: string, messageFormat: TemplateOptions['messageFormat']): string {
+  const data: ConversationData = {
+    id: 'conv433',
+    title: 'Nested code',
+    url: 'https://chatgpt.com/c/conv433',
+    source: 'chatgpt',
+    messages: [
+      { role: 'user', content: 'show me the markdown' },
+      {
+        role: 'assistant',
+        content: `<p>Here:</p><pre><code class="language-markdown">${toHtmlText(code)}</code></pre><p>after</p>`,
+      },
+      { role: 'user', content: 'thanks' },
+      { role: 'assistant', content: '<p>welcome</p>' },
+    ],
+    extractedAt: new Date('2026-08-13T00:00:00Z'),
+    metadata: { messageCount: 4, userMessageCount: 2, assistantMessageCount: 2 },
+  };
+  return conversationToNote(data, { ...BASE_OPTIONS, messageFormat }).body;
+}
+
+/** Drop one blockquote marker per line, the way flattenLargeCallouts() does. */
+function dequote(body: string): string {
+  return body
+    .split('\n')
+    .map(line => line.replace(/^> ?/, ''))
+    .join('\n');
+}
+
+/**
+ * Reference CommonMark fence reader — independent of src/lib/code-fence.ts on
+ * purpose. Returns the content of every fenced block in `text`.
+ */
+function extractCodeBlocks(text: string): string[] {
+  const blocks: string[] = [];
+  let open: { char: string; length: number } | null = null;
+  let buffer: string[] = [];
+
+  for (const line of text.split('\n')) {
+    const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    const run = match ? match[1] : '';
+    const rest = match ? match[2] : '';
+
+    if (open === null) {
+      if (match && !(run[0] === '`' && rest.includes('`'))) {
+        open = { char: run[0], length: run.length };
+        buffer = [];
+      }
+      continue;
+    }
+
+    if (match && run[0] === open.char && run.length >= open.length && rest.trim() === '') {
+      blocks.push(buffer.join('\n'));
+      open = null;
+      continue;
+    }
+    buffer.push(line);
+  }
+
+  if (open !== null) blocks.push(buffer.join('\n'));
+  return blocks;
+}
+
+describe.each(FORMATS)('fence seam — %s format', format => {
+  describe.each(PAYLOADS)('$name', ({ code }) => {
+    const body = () => noteFor(code, format);
+
+    it('P1: the code survives verbatim', () => {
+      const recovered = extractCodeBlocks(dequote(body()));
+      expect(recovered).toContain(code.trim());
+    });
+
+    it('P2: every message is still countable', () => {
+      expect(countExistingMessages(body())).toBe(4);
+    });
+
+    it('P3: counting and tail extraction agree at every offset', () => {
+      const text = body();
+      for (let skip = 0; skip < 4; skip++) {
+        expect(countExistingMessages(extractTailMessages(text, skip))).toBe(4 - skip);
+      }
+    });
+
+    it('P4: no escaping leaks into the code block', () => {
+      for (const block of extractCodeBlocks(dequote(body()))) {
+        expect(block).not.toMatch(/\\[<>$]/);
+      }
+    });
+  });
+});

--- a/test/lib/message-count-flatten-seam.test.ts
+++ b/test/lib/message-count-flatten-seam.test.ts
@@ -65,3 +65,58 @@ describe('message count survives callout flattening (issue #406)', () => {
     }
   });
 });
+
+/**
+ * The #433 composition of the same invariant.
+ *
+ * Flattening strips one `> ` from every line, which MOVES a code fence out of
+ * a callout and onto column 0 — precisely where `scanMessageStarts()` starts
+ * honouring it. So a note whose fences only parse correctly under the
+ * length-aware tracker (ADR-029) is the shape most likely to break the count
+ * invariant this file exists to protect.
+ */
+describe('message count survives flattening when a message holds nested code', () => {
+  const F3 = '`'.repeat(3);
+  const F4 = '`'.repeat(4);
+
+  /** A callout body whose 2nd message is a tall code block holding `codeLines`. */
+  function buildBodyWithCode(messages: number, codeLines: readonly string[]): string {
+    return Array.from({ length: messages }, (_, i) => {
+      const isUser = i % 2 === 0;
+      const header = isUser ? '> [!QUESTION] User' : '> [!NOTE] Claude';
+      const content =
+        i === 1
+          ? codeLines.map(line => `> ${line}`)
+          : Array.from({ length: 2 }, (_, n) => `> line ${n} of message ${i}`);
+      return [header, ...content].join('\n');
+    }).join('\n\n');
+  }
+
+  const CASES = [
+    { name: 'nested block', lines: [`${F4}markdown`, `${F3}python`, 'print(1)', F3, F4] },
+    { name: 'opening fence only', lines: [`${F4}markdown`, 'start with:', `${F3}md`, F4] },
+    {
+      name: 'message-shaped lines inside the inner block',
+      lines: [`${F4}markdown`, `${F3}md`, '**User:**', '**Claude:**', F3, F4],
+    },
+  ] as const;
+
+  it.each(CASES)('$name: count is unchanged by flattening', ({ lines }) => {
+    const total = 8;
+    const body = buildBodyWithCode(total, lines);
+    expect(countExistingMessages(body)).toBe(total);
+
+    for (const threshold of [2, 4, 50]) {
+      expect(countExistingMessages(flattenLargeCallouts(body, threshold))).toBe(total);
+    }
+  });
+
+  it.each(CASES)('$name: counting and tail extraction still agree', ({ lines }) => {
+    const onDisk = flattenLargeCallouts(buildBodyWithCode(8, lines), 4);
+    const count = countExistingMessages(onDisk);
+
+    for (let skip = 1; skip < count; skip++) {
+      expect(countExistingMessages(extractTailMessages(onDisk, skip))).toBe(count - skip);
+    }
+  });
+});

--- a/test/lib/message-counter.test.ts
+++ b/test/lib/message-counter.test.ts
@@ -94,6 +94,62 @@ describe('message-counter', () => {
       expect(countExistingMessages(body)).toBe(3);
     });
 
+    // Issue #433: the length-blind toggle counted an inner fence as a
+    // delimiter, so a note holding a Markdown-about-Markdown answer desynced
+    // and append mode wrote from the wrong offset (the #406 class, ADR-029).
+    describe('code blocks that contain other code blocks (issue #433)', () => {
+      const F3 = '`'.repeat(3);
+      const F4 = '`'.repeat(4);
+
+      /** A 4-message note whose second message holds `codeLines` as a block. */
+      function bodyWith(codeLines: readonly string[]): string {
+        return [
+          '**User:**',
+          '',
+          'q1',
+          '',
+          '**Claude:**',
+          '',
+          ...codeLines,
+          '',
+          '**User:**',
+          '',
+          'q2',
+          '',
+          '**Claude:**',
+          '',
+          'a2',
+        ].join('\n');
+      }
+
+      it('counts across a properly nested block', () => {
+        const body = bodyWith([`${F4}markdown`, '# Title', `${F3}python`, 'print(1)', F3, F4]);
+        expect(countExistingMessages(body)).toBe(4);
+        expect(countExistingMessages(extractTailMessages(body, 2))).toBe(2);
+      });
+
+      it('counts across a block that shows an opening fence only', () => {
+        // "Put this at the top of the file" — the snippet is an opener with no
+        // closer, so the note holds an odd number of column-0 fence lines.
+        const body = bodyWith([`${F4}markdown`, 'Put this at the top:', `${F3}md`, F4]);
+        expect(countExistingMessages(body)).toBe(4);
+        expect(extractTailMessages(body, 2)).not.toBe('');
+        expect(countExistingMessages(extractTailMessages(body, 2))).toBe(2);
+      });
+
+      it('still hides message-shaped lines inside the inner block', () => {
+        const body = bodyWith([`${F4}markdown`, `${F3}md`, '**User:**', '**Claude:**', F3, F4]);
+        expect(countExistingMessages(body)).toBe(4);
+      });
+
+      it('does not let a tilde fence open a block and hide messages', () => {
+        // The writer never emits tildes; a stray column-0 `~~~` in a note must
+        // stay inert rather than swallowing every message after it (ADR-029).
+        const body = bodyWith(['~~~']);
+        expect(countExistingMessages(body)).toBe(4);
+      });
+    });
+
     it('handles ChatGPT and Perplexity labels', () => {
       const body = [
         '> [!QUESTION] User',


### PR DESCRIPTION
## Summary

Closes #433.

A code block whose content holds a fence was closed by its own content, so a conversation *about* Markdown exported as broken Markdown. The same defect was written down three times:

- **The writer never looked at the code.** Both Turndown rules in `markdown-rules.ts` returned a hardcoded three-backtick fence. Turndown's own `fencedCodeBlock` rule already sizes the fence from its content (`turndown.cjs.js:190-213`, v7.2.2), but its documented rule precedence is *added rules → commonmark rules*, so our two added rules shadowed it. This was a regression against the library, not a missing feature.
- **`escapeByLine()` leaked escaping into code.** Its length-blind toggle thought the inner fence had ended the block, writing `\<div\>a\</div\>` *inside* the code while leaving the genuinely-inside `<span>` after it unescaped.
- **`scanMessageStarts()` desynced the append-mode count.** For an assistant answer showing an *opening* fence only ("put this at the top of the file" — routine on ChatGPT), a 4-message note counted as **2** and `extractTailMessages(body, 2)` returned `''`. That is the #406 failure class (ADR-028) reached by a different road.

### What changed

`src/lib/code-fence.ts` is now the only place under `src/` that writes or parses a fence:

- `fenceCodeBlock()` sizes the outer fence to `max(3, longest inner run + 1)` — exactly what [Obsidian's own docs](https://obsidian.md/help/syntax) prescribe for nesting — and sanitises the info string (CommonMark 0.31.2 §4.5 forbids a backtick there, and the CodeMirror rule derives its hint from arbitrary DOM text).
- `nextFenceState()` tracks fences asymmetrically: an opening fence may carry an info string; a closing fence may not, and must use the same character with at least the same length. Both allow up to three spaces of indentation; a trailing `\r` is tolerated (ADR-026 defence in depth).

The two readers differ deliberately: `escapeByLine()` recognises both fence characters, so a pasted tilde block is protected too; `scanMessageStarts()` recognises backticks only and keeps its column-0 policy from ADR-028 — the writer never emits tildes, and honouring a stray column-0 `~~~` would hide every message after it.

`buildAppendContent()` now logs the one shape that fails with no other signal: a body ending inside a fenced block hides every message after the opening fence, and an overcount then returns null while the caller reports a successful no-op (ADR-025 reasoning).

### Output after the fix

The reproduction from the issue, both DOM paths:

`````
````markdown
# Title

```python
print(1)
```
````
`````

**Preserving the reporter's original tilde fence is impossible** — the rendered DOM is `<pre><code>` and the fence character never reaches the extension. Lengthening the backtick fence is the only available fix, and it is the one Obsidian prescribes. This is stated in ADR-029 and will be said in the issue reply.

### Structural guards (ADR-028's lesson: the seam, not the unit)

- `test/lib/fence-writer-reader-seam.test.ts` drives the real writer and the real readers over a payload matrix × 3 message formats: code survives verbatim, count holds, counting and tail extraction agree at every offset, no escaping inside a block. The code is recovered by a reference parser defined inside the test file, deliberately not importing `code-fence.ts`, so the writer is never graded by its own tracker. **Verified: 32 of 144 assertions fail against the pre-fix modules.**
- `test/arch/fence-literal-ssot.test.ts` fails any module under `src/` other than `code-fence.ts` that spells out a fence literal or detects one itself. **Verified: names all four pre-fix violations with the remedy.** One documented exemption: `BaseExtractor`'s `hasCodeBlocks` probe over raw HTML.
- `test/lib/message-count-flatten-seam.test.ts` gains nested-code payloads, because flattening strips a blockquote marker and so moves a fence onto column 0, where the counter starts honouring it. **Verified: 2 failures pre-fix.**

### Known limitation, deliberately not fixed

**Notes already on disk are not repaired**, matching the ADR-028 precedent. The information needed to recover intent was destroyed at write time, so old and new readers both mis-parse such a note — differently. The count may therefore change on the first sync after upgrade: an undercount appends an already-present tail once and then self-limits; an overcount is a silent no-op needing a one-time manual fix. The new diagnostic exists so the second case is reportable.

## Test plan

- [x] `npm run test` — 78 files / **1843 passed**; no existing test was edited to pass (the 1520 that predate this change all still pass)
- [x] `npm run build` — succeeds
- [x] `npm run lint` — **0 errors**, 3 warnings (all pre-existing, in files this PR does not touch)
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:coverage` — 96.31 → **96.37** stmts, 87.04 → **87.28** branches; `code-fence.ts` and `message-counter.ts` at **100%** on all four metrics
- [x] RED demonstrated before each fix: `code-fence.test.ts` unresolvable pre-module; 7 failures in `markdown.test.ts`; 2 in `message-counter.test.ts` (count 2 instead of 4, empty tail)
- [x] Manual smoke in a real Chrome profile: export a ChatGPT answer containing a nested code block to Obsidian, confirm the outer fence is longer and the note renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
