### PR TITLE
chore(build): stop emitting modulepreload links for extension pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,17 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // Vite injects `<link rel="modulepreload" crossorigin>` into every HTML
+    // entry. Chrome refuses to reuse those preloads inside an extension —
+    // "cross-world extension resource mismatch" — so each is fetched twice and
+    // logs two warnings: five per popup open, three per offscreen document.
+    // They are harmless, but the extension error console is where real
+    // failures get diagnosed (issue #433 and ADR-030 were both read out of it),
+    // and burying it under fixed noise costs more than the preloads save:
+    // these are chrome-extension:// URLs, so there is no network latency to
+    // hide, and nothing here is imported dynamically. `false` also drops the
+    // polyfill chunk, which exists only to emulate the same feature.
+    modulePreload: false,
     rollupOptions: {
       input: {
         offscreen: resolve(__dirname, 'src/offscreen/offscreen.html'),


### PR DESCRIPTION
## Summary

Vite injects a `<link rel="modulepreload" crossorigin>` per shared chunk into every HTML entry. Chrome will not reuse a preload fetched that way inside an extension — *"cross-world extension resource mismatch"* — so the resource is fetched twice and each one logs two warnings:

```
A preload for 'chrome-extension://…/assets/constants-BPkdD8h2.js' is found, but is not
used because it is a cross-world extension resource mismatch.

The resource chrome-extension://…/assets/constants-BPkdD8h2.js was preloaded using link
preload but not used within a few seconds from the window's load event.
```

Five per popup open, three per offscreen document.

**Nothing was broken by them**, and this changes nothing a user can see. The reason to remove them is the console they fill: issue #433 and ADR-030 were both diagnosed by reading the extension error console, and a fixed background of warnings is what buries the next real failure. The preloads buy nothing back here — `chrome-extension://` URLs have no network latency to hide, and no module under `src/` is imported dynamically (verified: zero `import(` call sites).

One line in `vite.config.ts`: `build.modulePreload: false`. Per Vite's own resolution, `false` disables both the preload link injection and the polyfill plugin, so the polyfill chunk stops being emitted too.

## Verification (measured on the built output)

| | before | after |
| --- | --- | --- |
| `dist/src/offscreen/offscreen.html` preload links | 3 | **0** |
| `dist/src/popup/index.html` preload links | 5 | **0** |
| `modulepreload-polyfill-*.js` chunk | emitted | **not emitted** |

Checked for collateral damage, all clean:

- no dangling reference to the removed polyfill chunk anywhere in `dist/`
- every asset the built HTML references still exists (offscreen 2/2, popup 2/2)
- the module graph is unchanged — the offscreen entry still statically imports its shared chunk (`import{t as e}from"./error-utils-P2-3AzoC.js"`). The preload was only ever a hint

## Test plan

- [x] `npm run build` succeeds; emitted HTML inspected directly (table above)
- [x] `npm run test` — 78 files / 1850 passed
- [x] `npx tsc --noEmit`, `npm run format:check` — clean; `npm run lint` — 0 errors (3 pre-existing warnings in untouched files)
- [x] Manual, in a reloaded unpacked build — nothing here is provable from vitest:
  - [x] popup opens and renders
  - [x] settings save and reload
  - [x] clipboard export works (this is the offscreen document path)
  - [x] the five preload warnings are gone from the extension error console

No regression test is added deliberately. A test asserting `modulePreload: false` would only restate the config line; the real invariant — no preload links in the built HTML — needs a build inside the test run, which is not worth its cost here. The reasoning lives in a comment next to the setting instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
