### PR TITLE
chore(nix): track the nixpkgs 26.05 darwin channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782904953,
-        "narHash": "sha256-ESJ4VgytmAt+98YLM8466luln4HyEZ9Q36b9+Bb4P5w=",
+        "lastModified": 1786527240,
+        "narHash": "sha256-OLtJPnSXcRy79Rf7BhYaMeXAVF625FpLcd3+Svq641Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0921fdb3e13e40fe25fbc52b89661a9d6d32ac68",
+        "rev": "e0c84f9d0ad137f076dc957494f5b39885597d4f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "gemini2obsidian dev environment + task surface (Node toolchain + system deps)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
   };
 
   outputs =


### PR DESCRIPTION
## Summary

Moves the flake input from `nixpkgs-25.11-darwin` to `nixpkgs-26.05-darwin` and updates `flake.lock` to match. Two files, no source changes.

Nix is the canonical task surface (ADR-011), so a channel bump is not a metadata change — it swaps the toolchain every `nix run .#*` task actually executes on. It was therefore verified by running the tasks, not by reading the diff:

| Task | Result |
| --- | --- |
| `nix run .#test` | 78 files / **1850 passed** |
| `nix run .#build` | succeeds |
| `nix run .#lint` | 0 errors; platform consistency check passes (8/8 files) |
| `nix run .#format-check` | clean |

**Toolchain delta measured on both channels**, by building the dev shell before and after the bump:

| | 25.11 | 26.05 |
| --- | --- | --- |
| node | v24.18.0 | **v24.18.1** |
| npm | 11.16.0 | 11.16.0 |

The flake pins `nodejs_24` on both sides, so this is a patch-level move within the same major — which is the reason nothing in the task results changed.

## Test plan

- [x] `nix run .#test` — 1850 passed
- [x] `nix run .#build` — succeeds
- [x] `nix run .#lint` — 0 errors
- [x] `nix run .#format-check` — clean
- [x] `nix develop` resolves on the new channel; node/npm versions recorded above
- [x] Reviewer note: CI does not run through Nix, so a green CI here proves the npm path only. The table above is the evidence for the Nix path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
