### PR TITLE
fix(perplexity): extract answers rendered outside the markdown-content placeholder

### DIFF
--- a/e2e/selectors/__tests__/notify-policy.test.ts
+++ b/e2e/selectors/__tests__/notify-policy.test.ts
@@ -37,6 +37,7 @@ function makePlatform(overrides: Partial<PlatformReport> = {}): PlatformReport {
     },
     failedTargets: [],
     stallSkips: [],
+    unsettledTargets: [],
     ...overrides,
   };
 }

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -293,6 +293,24 @@ export class PerplexityExtractor extends BaseExtractor {
       tagged.push({ type: 'response', element: el });
     }
 
+    // An answer that is NOT inside a markdown-content placeholder (issue #444).
+    //
+    // Perplexity now serves two layouts at once. Under the newer one the
+    // placeholder is present but empty and the answer renders as its sibling,
+    // so anchoring only on the placeholder loses every assistant message while
+    // the user query — read from a different subtree — survives alone.
+    //
+    // Collecting these unconditionally is safe rather than clever: under the
+    // old layout every answer prose IS inside a placeholder, so this set is
+    // empty and nothing is added twice. Deep Research cards are skipped
+    // because the report path below already owns them, and a card nests an
+    // `inline` prose of its own that would otherwise be counted as an answer.
+    for (const prose of this.queryAllWithFallback<HTMLElement>(SELECTORS.answerProse)) {
+      if (this.isInside(prose, SELECTORS.markdownContent)) continue;
+      if (this.isInside(prose, SELECTORS.deepResearchCard)) continue;
+      tagged.push({ type: 'response', element: prose });
+    }
+
     for (const card of this.queryAllWithFallback<HTMLElement>(SELECTORS.deepResearchCard)) {
       const proseEl = this.queryWithFallback<HTMLElement>(SELECTORS.deepResearchProse, card);
       if (proseEl) {
@@ -301,6 +319,18 @@ export class PerplexityExtractor extends BaseExtractor {
     }
 
     return tagged;
+  }
+
+  /** True when `el` sits inside an element matching any of `selectors`. */
+  private isInside(el: HTMLElement, selectors: readonly string[]): boolean {
+    return selectors.some(selector => {
+      try {
+        return el.closest(selector) !== null;
+      } catch {
+        // An invalid selector must not abort extraction; treat it as no match.
+        return false;
+      }
+    });
   }
 
   /**

--- a/src/content/extractors/selectors/claude.ts
+++ b/src/content/extractors/selectors/claude.ts
@@ -12,13 +12,12 @@ import type { SelectorGroup, ComputedSelectors } from './types';
  * CSS Selectors for normal chat extraction
  */
 export const SELECTORS = {
-  // Conversation block selectors (each message block)
-  // Stability: HIGH → LOW order for fallback
-  conversationBlock: [
-    '.group[style*="height: auto"]', // Structure-based (HIGH)
-    '[data-test-render-count]', // Test attribute (LOW)
-    '.group', // Generic (MEDIUM)
-  ],
+  // NOTE: a conversationBlock group used to live here. It was removed in
+  // 2026-08 (issue #446): nothing in the extractor ever queried it — messages
+  // are found through userMessage / assistantResponse — while its primary
+  // (`.group[style*="height: auto"]`) became unmatchable when Claude stopped
+  // writing that inline style, which blocked the whole platform baseline. A
+  // selector no code reads is a contract obligation with no payoff.
 
   // User message content selectors
   //

--- a/src/content/extractors/selectors/perplexity.ts
+++ b/src/content/extractors/selectors/perplexity.ts
@@ -28,6 +28,22 @@ export const SELECTORS = {
     '.prose', // Fallback (LOW)
   ],
 
+  // The answer block itself, wherever it is mounted.
+  //
+  // 2026-08 (issue #444): a rollout keeps `markdownContent` as an EMPTY
+  // placeholder and renders the answer beside it. The class list of the answer
+  // prose is identical under both layouts, so this selector finds it either
+  // way; what differs is only whether it sits inside the placeholder.
+  //
+  // `inline` is what separates it from a Deep Research card's own prose
+  // (`… max-w-none text-sm`). That is a narrowing, not the guard: a card also
+  // nests an `inline` prose, so perplexity.ts additionally excludes anything
+  // inside a deepResearchCard, which the report path already owns.
+  answerProse: [
+    '.prose.dark\\:prose-invert.inline', // Answer block (HIGH)
+    '.prose.inline', // Without the theme class (MEDIUM)
+  ],
+
   // Deep Research report card container. Matches generic raised panels too;
   // the extractor only tags a card as a report when deepResearchProse is
   // found inside it (perplexity.ts collectTaggedElements).

--- a/test/arch/source-is-text.test.ts
+++ b/test/arch/source-is-text.test.ts
@@ -16,6 +16,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { describe, it, expect } from 'vitest';
 
 const root = path.resolve(import.meta.dirname, '../..');
@@ -25,22 +26,22 @@ const TEXT_EXTENSIONS = ['.ts', '.tsx', '.mts', '.js', '.mjs', '.json', '.css', 
 /** Control characters a text file may legitimately hold. */
 const ALLOWED_CONTROL_CODES = new Set([0x09, 0x0a, 0x0d]);
 
-function collectFiles(dir: string): string[] {
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      // results/ holds generated run reports; node_modules is not ours.
-      if (entry.name === 'node_modules' || entry.name === 'results') return [];
-      return collectFiles(full);
-    }
-    return entry.isFile() && TEXT_EXTENSIONS.includes(path.extname(entry.name)) ? [full] : [];
-  });
-}
-
-const sources = SCANNED_DIRS.flatMap(dir => collectFiles(path.join(root, dir))).map(f =>
-  path.relative(root, f)
-);
+/**
+ * Tracked files only.
+ *
+ * Walking the directories instead would sweep in per-machine artifacts that
+ * happen to live under them — `e2e/baselines/*.json`, `e2e/auth/state.json` —
+ * which makes the result depend on whose laptop is running it and has this
+ * check reading an auth artifact for no reason. Only committed files can carry
+ * a byte into a diff, so only committed files are in scope.
+ */
+const sources = execFileSync('git', ['ls-files', '-z', ...SCANNED_DIRS], {
+  cwd: root,
+  encoding: 'utf-8',
+  maxBuffer: 32 * 1024 * 1024,
+})
+  .split('\0')
+  .filter(rel => rel.length > 0 && TEXT_EXTENSIONS.includes(path.extname(rel)));
 
 /** Offsets of every disallowed control byte, with a little context. */
 function findControlBytes(rel: string): string[] {

--- a/test/arch/source-is-text.test.ts
+++ b/test/arch/source-is-text.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Fitness function: source files stay text.
+ *
+ * `compareWithBaseline`'s key separator was a raw NUL byte embedded directly in
+ * `e2e/selectors/baseline.ts`. Git classifies such a file as binary, so its
+ * diff renders as `Bin 7129 -> 11141 bytes` — the change is invisible in review
+ * on GitHub, and stays invisible for as long as either side of the comparison
+ * carries the byte. It cost a PR its most important diff before anyone noticed.
+ *
+ * The character itself was fine; writing it raw instead of as `\u0000` was not.
+ * This check keeps that distinction: any control character a source file needs
+ * must be written as an escape.
+ *
+ * Allowed: tab, newline, carriage return — the ones a text file legitimately
+ * contains.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const SCANNED_DIRS = ['src', 'e2e', 'test', 'scripts'] as const;
+const TEXT_EXTENSIONS = ['.ts', '.tsx', '.mts', '.js', '.mjs', '.json', '.css', '.html', '.md'];
+
+/** Control characters a text file may legitimately hold. */
+const ALLOWED_CONTROL_CODES = new Set([0x09, 0x0a, 0x0d]);
+
+function collectFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // results/ holds generated run reports; node_modules is not ours.
+      if (entry.name === 'node_modules' || entry.name === 'results') return [];
+      return collectFiles(full);
+    }
+    return entry.isFile() && TEXT_EXTENSIONS.includes(path.extname(entry.name)) ? [full] : [];
+  });
+}
+
+const sources = SCANNED_DIRS.flatMap(dir => collectFiles(path.join(root, dir))).map(f =>
+  path.relative(root, f)
+);
+
+/** Offsets of every disallowed control byte, with a little context. */
+function findControlBytes(rel: string): string[] {
+  const bytes = fs.readFileSync(path.join(root, rel));
+  const hits: string[] = [];
+  for (let i = 0; i < bytes.length; i++) {
+    const code = bytes[i];
+    if (code < 0x20 && !ALLOWED_CONTROL_CODES.has(code)) {
+      const hex = `0x${code.toString(16).padStart(2, '0')}`;
+      hits.push(`byte ${i} (${hex})`);
+    }
+  }
+  return hits;
+}
+
+describe('architecture: source files are text, not binary', () => {
+  it('finds sources to scan', () => {
+    expect(sources.length).toBeGreaterThan(0);
+  });
+
+  it.each(sources)('%s contains no raw control characters', rel => {
+    expect(
+      findControlBytes(rel),
+      `${rel} embeds a raw control character. Git then treats the file as binary and its diff ` +
+        `stops being reviewable — write the character as an escape (\\u0000, \\x1b, …) instead`
+    ).toEqual([]);
+  });
+});

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -633,8 +633,11 @@ describe('ClaudeExtractor', () => {
 
   // ========== 6.3.7 Fallback Selectors (12 tests) ==========
   describe('Fallback Selectors', () => {
-    describe('conversationBlock selectors', () => {
-      it('works with primary selector (.group[style])', async () => {
+    // These pin that extraction is independent of the message WRAPPER shape:
+    // Claude has changed it repeatedly, and the selector group that used to
+    // describe it was removed in #446 because no code read it.
+    describe('message wrapper shapes', () => {
+      it('works when turns are wrapped in .group with an inline height style', async () => {
         setClaudeLocation('test-123');
         loadFixture(`
           <div class="group" style="height: auto;">
@@ -652,7 +655,7 @@ describe('ClaudeExtractor', () => {
         expect(result.data?.messages.length).toBeGreaterThan(0);
       });
 
-      it('works with secondary selector ([data-test-render-count])', async () => {
+      it('works when turns are wrapped in [data-test-render-count]', async () => {
         setClaudeLocation('test-123');
         loadFixture(`
           <div data-test-render-count="2">
@@ -668,7 +671,7 @@ describe('ClaudeExtractor', () => {
         expect(result.success).toBe(true);
       });
 
-      it('works with tertiary selector (.group)', async () => {
+      it('works when turns are wrapped in a bare .group', async () => {
         setClaudeLocation('test-123');
         loadFixture(`
           <div class="group">

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -984,4 +984,133 @@ describe('PerplexityExtractor', () => {
       expect(messages[4].content).toContain('Summary of the report');
     });
   });
+
+  /**
+   * Issue #444. Perplexity rolled out a layout that keeps
+   * `div[id^="markdown-content-"]` as an EMPTY placeholder and renders the
+   * answer beside it. Both layouts are served concurrently, so the extractor
+   * has to read either one without double-counting the other.
+   *
+   * The fixtures below mirror the class lists measured on live threads:
+   *
+   * - answer prose (BOTH layouts): `prose dark:prose-invert inline leading-relaxed …`
+   * - Deep Research card prose:    `… prose dark:prose-invert max-w-none text-sm`,
+   *   plus an `inline` prose nested INSIDE the card — which is why "collect
+   *   every .prose" is wrong and the card has to be excluded explicitly.
+   */
+  describe('Answers rendered outside the markdown-content placeholder (issue #444)', () => {
+    const ANSWER_PROSE_CLASS =
+      'prose dark:prose-invert inline leading-relaxed break-words min-w-0 [word-break:break-word]';
+
+    beforeEach(() => {
+      setPerplexityLocation('conv-444');
+    });
+
+    it('extracts the answer when the placeholder is empty', () => {
+      loadFixture(`
+        <div class="group/query"><span class="select-text">What is a modern email signature?</span></div>
+        <div class="relative font-sans text-base">
+          <div id="markdown-content-0" class="gap-y-4 after:clear-both after:block"></div>
+        </div>
+        <div class="flex flex-col flex-1 min-w-0 gap-4">
+          <div class="contents">
+            <div class="break-words min-w-0 flex-1">
+              <div>
+                <div class="${ANSWER_PROSE_CLASS}">
+                  <p>Use a hosted PNG under 240px wide.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `);
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.role)).toEqual(['user', 'assistant']);
+      expect(messages[1].content).toContain('Use a hosted PNG');
+    });
+
+    it('keeps every answer of a multi-turn thread, in order', () => {
+      const turn = (q: string, a: string, i: number): string => `
+        <div class="group/query"><span class="select-text">${q}</span></div>
+        <div class="relative font-sans text-base">
+          <div id="markdown-content-${i}" class="gap-y-4"></div>
+        </div>
+        <div class="contents"><div class="break-words min-w-0 flex-1"><div>
+          <div class="${ANSWER_PROSE_CLASS}"><p>${a}</p></div>
+        </div></div></div>
+      `;
+      loadFixture(turn('q1', 'answer one', 0) + turn('q2', 'answer two', 1));
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+      expect(messages[1].content).toContain('answer one');
+      expect(messages[3].content).toContain('answer two');
+    });
+
+    it('does not double-count when the prose IS inside the placeholder (old layout)', () => {
+      loadFixture(`
+        <div class="group/query"><span class="select-text">q</span></div>
+        <div class="relative font-sans text-base">
+          <div id="markdown-content-0" class="gap-y-4">
+            <div class="has-inline-images my-2">
+              <div><div class="${ANSWER_PROSE_CLASS}"><p>only answer</p></div></div>
+            </div>
+          </div>
+        </div>
+      `);
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.role)).toEqual(['user', 'assistant']);
+      expect(messages.filter(m => m.role === 'assistant')).toHaveLength(1);
+    });
+
+    it('does not mistake a Deep Research card for a second answer', () => {
+      // The card carries an `inline` prose of its own; the extractor already
+      // routes the card through the report path, so it must not be collected
+      // again by the placeholder fallback.
+      loadFixture(`
+        <div class="group/query"><span class="select-text">q</span></div>
+        <div class="relative font-sans text-base">
+          <div id="markdown-content-0" class="gap-y-4"></div>
+        </div>
+        <div class="bg-raised rounded-lg">
+          <div class="overflow-hidden px-4 py-3 prose dark:prose-invert max-w-none text-sm">
+            <div class="${ANSWER_PROSE_CLASS}"><p>report body</p></div>
+          </div>
+        </div>
+        <div class="contents"><div class="break-words min-w-0 flex-1"><div>
+          <div class="${ANSWER_PROSE_CLASS}"><p>the actual answer</p></div>
+        </div></div></div>
+      `);
+
+      const messages = extractor.extractMessages();
+      const assistant = messages.filter(m => m.role === 'assistant');
+
+      expect(assistant).toHaveLength(2);
+      expect(assistant.filter(m => m.content.includes('report body'))).toHaveLength(1);
+      expect(assistant.filter(m => m.content.includes('the actual answer'))).toHaveLength(1);
+    });
+
+    it('reports success without the missing-assistant warning', async () => {
+      loadFixture(`
+        <div class="group/query"><span class="select-text">q</span></div>
+        <div class="relative font-sans text-base">
+          <div id="markdown-content-0" class="gap-y-4"></div>
+        </div>
+        <div class="contents"><div class="break-words min-w-0 flex-1"><div>
+          <div class="${ANSWER_PROSE_CLASS}"><p>an answer</p></div>
+        </div></div></div>
+      `);
+
+      const result = await extractor.extract();
+
+      expect(result.success).toBe(true);
+      expect(result.warnings ?? []).not.toContain('No assistant messages found');
+      expect(result.data?.metadata.assistantMessageCount).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #444. Closes #446.

## 1. Perplexity: answers rendered outside the placeholder (#444)

Perplexity serves two answer layouts concurrently. Under the newer one, `div[id^="markdown-content-"]` stays as an **empty placeholder** and the answer renders beside it. Anchoring only on the placeholder therefore lost every assistant message, while the user query — read from a different subtree — survived alone. The export reported success, warned `No assistant messages found`, and wrote a note containing just the heading and the prompt.

**The rule:** collect any `answerProse` match that is neither inside a `markdown-content` placeholder nor inside a Deep Research card.

Collecting unconditionally is safe rather than clever, and that is measurable:

| thread | `.prose.inline` | inside a placeholder | inside a DR card | newly collected |
| --- | --- | --- | --- | --- |
| old layout (pinned e2e conversation) | 3 | 2 | 1 | **0** |
| new layout (reported) | 6 | 0 | 0 | **6** |

The class list of the answer prose is *identical* under both layouts — only its mount point differs — so one selector serves both, and the old layout gains nothing because every answer there is already inside a placeholder.

`inline` is a narrowing, not the guard. A Deep Research card nests an `inline` prose of its own (measured: 48570 chars, inside `div.bg-raised.rounded-lg`), which is exactly why "collect every `.prose`" would be wrong and why the card exclusion is load-bearing.

### Verified against the real page, not only fixtures

The reported thread's live DOM was captured and run through the real extractor:

| | before | after |
| --- | --- | --- |
| `assistantMessageCount` | **0** | **6** |
| warnings | `['No assistant messages found']` | none |
| roles | `user ×6` | `user,assistant ×6` |

And the old-layout thread, same method, `main` vs this branch — **byte-identical**: `roles: user,assistant,user,assistant,assistant`, content lengths `[4386, 23456, 3450]`, `{messageCount: 5, userMessageCount: 2, assistantMessageCount: 3}`. No double-counting, no reordering, no change to the Deep Research path.

(The captured HTML came from the privately shared thread and was deleted after the run; nothing from it is committed.)

## 2. Claude: the unused `conversationBlock` group (#446)

Its primary `.group[style*="height: auto"]` matched 6 elements every run from 2026-07-20 through 2026-08-13 and **0** from 2026-08-14. Claude stopped writing that inline style, and nothing on the page carries it any more — so the selector is unmatchable rather than mis-scoped, and it blocked the platform's whole baseline via the zero-match refusal.

Nothing read the group: `git grep` found only the definition and a fixture test that *builds* DOM with those wrappers. The extractor finds messages through `userMessage` / `assistantResponse`.

The `.group` fallback goes with it: of its 35 matches, the sampled ones are UI chrome — a pill row and three buttons, 9–11 characters each, none containing a response. It was never a conservative fallback for "a message block".

The wrapper-shape tests stay, renamed to say what they actually pin: extraction is independent of how a turn is wrapped.

## 3. Raw control characters in source (the NUL problem)

`test/arch/source-is-text.test.ts` fails any tracked source file containing a control byte other than tab, newline or carriage return, and names the escape form as the remedy. This is the class of defect that made `e2e/selectors/baseline.ts` render as `Bin 7129 -> 11141 bytes` in #447 — the character was fine, writing it raw was not.

Two things worth knowing about this check, both found the hard way:

- **It failed on its own doc comment first**, which is how the raw byte in its own file was caught.
- **The first version walked directories** and so swept in per-machine artifacts living under them — `e2e/baselines/*.json`, `e2e/auth/state.json`. That made the count machine-dependent (300 here, 302 after an e2e run) and had the check reading an auth artifact for no reason. It now enumerates via `git ls-files`: 185 files, stable, and only committed files can carry a byte into a diff anyway.

Non-vacuity was re-proved under the new enumeration by appending a raw NUL to the tracked `src/lib/hash.ts`: the check fails naming the file and byte offset, and passes once removed.

## 4. Pre-existing e2e type error

`notify-policy.test.ts`'s platform factory omitted the required `unsettledTargets`. `npx tsc --noEmit -p e2e/tsconfig.json` is now clean.

## Test plan

- [x] `npm run test` — 80 files / **2055 passed**; RED demonstrated first (4 failures for #444, plus the planted-byte proof for the arch check)
- [x] `npx tsc --noEmit` and `npx tsc --noEmit -p e2e/tsconfig.json` — both clean
- [x] `npm run lint` — 0 errors (3 pre-existing warnings in untouched files); `npm run format:check` clean; `npm run build` succeeds
- [x] Real-DOM verification of #444 on both layouts (tables above)
- [x] **After merge, every machine needs one `npm run e2e:baseline:update`** — removing the Claude selectors surfaces as `removed`, which blocks by contract
- [x] Reviewer note: `.prose.inline` is a Tailwind display utility, so it is more churn-prone than an id or data attribute. The card exclusion is what keeps the rule correct; if `inline` disappears, the fallback `.prose` variant plus the two exclusions still selects the same set on both threads measured here

## Not in scope

The #444 fix does not add outcome-level e2e validation; ADR-031 records why that layer was deferred (page-CSP constraints on injecting over `connectOverCDP`). The fixture pair added here is the rollout-independent detector — it does not depend on which layout the developer's own account has been served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
