### PR TITLE
chore: update nixpkgs flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786527240,
-        "narHash": "sha256-OLtJPnSXcRy79Rf7BhYaMeXAVF625FpLcd3+Svq641Y=",
+        "lastModified": 1787323337,
+        "narHash": "sha256-PqomwlB2WugM9MC4tV1L2/yosMOfug3KBDjmqOqD1bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0c84f9d0ad137f076dc957494f5b39885597d4f",
+        "rev": "6062ba1a1b8b6281b12533c9075a2dbeb38f7e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Moves the pinned nixpkgs revision forward within the same `nixpkgs-26.05-darwin` branch: `e0c84f9` → `6062ba1` (2026-08-11 → 2026-08-21).
- Input tracking is unchanged — only the locked revision and its `narHash` move. No `flake.nix` change, no new inputs, no change to the task surface (ADR-011).

## Test plan

- [x] `nix flake metadata` resolves and reports the new revision
- [x] `nix run .#format-check` builds against the new nixpkgs and passes (pulled ShellCheck 0.11.0 + libffi from the binary cache)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)