### PR TITLE
fix(perplexity): follow the layout rollout that removed the answer placeholder

### DIFF
--- a/docs/adr/035-perplexity-placeholder-removal-and-collapsed-deep-research.md
+++ b/docs/adr/035-perplexity-placeholder-removal-and-collapsed-deep-research.md
@@ -1,0 +1,95 @@
+# ADR-035: Perplexity's answer placeholder is gone and Deep Research is lazy-mounted
+
+- Status: Accepted
+- Date: 2026-08-26
+- Extends: [ADR-016](016-e2e-baseline-contract-and-reporting.md) §1, [ADR-031](031-selector-content-metric.md)
+- Follows: [#444](https://github.com/sho7650/obsidian-AI-exporter/issues/444), [#402](https://github.com/sho7650/obsidian-AI-exporter/issues/402)
+- Known limitation: [#463](https://github.com/sho7650/obsidian-AI-exporter/issues/463)
+
+## Context
+
+`nix run .#e2e-selectors` failed on Perplexity with three zero-match selectors, and the run took
+54.6s against ~6s for every other platform. Measured live through the CDP daemon against an
+authenticated session (`connectOverCDP` → `PERPLEXITY_CONV_URL`), not inferred from the failure:
+
+| selector | before (baseline 2026-08-16) | now |
+| --- | --- | --- |
+| `div[id^="markdown-content-"]` | 2 | **0** |
+| `[id^="markdown-content"]` (prefix loosened) | — | **0** |
+| `div[class~="group/query"] span.select-text` | 2 | **0** |
+| `div.bg-raised.rounded-lg` | 4 | **0** |
+| `.prose.max-w-none` | 1 | **0** |
+| `.prose.inline` | 3 | 2 |
+
+Three changes shipped together.
+
+**1. The answer placeholder was removed, id and all.** #444 caught the first half of this rollout:
+`#markdown-content-N` stayed in the DOM as an *empty* placeholder while the answer rendered beside
+it. The second half deleted it. The answer is now a bare
+`.prose.dark:prose-invert.inline` carrying a new `data-renderer="lm"` attribute, and nothing else
+anchors it.
+
+**2. The user bubble lost its `group/query` wrapper.** The bubble itself
+(`div.bg-subtle.rounded-2xl`) is what now scopes the query text. The primary selector
+`span.select-text` was unaffected, so this surfaced only as a `lost` fallback.
+
+**3. Deep Research reports are lazy-mounted behind a collapsed card.** The report used to be inline
+prose inside a raised card. It is now an attachment card — title, a "Deep research report" label,
+and buttons — whose subtree, walked to depth 6, contains **no report body at all**. Clicking it
+navigates to `?preview=1` and mounts the report into a side panel:
+
+| | collapsed (default) | after clicking the card |
+| --- | --- | --- |
+| `.prose` | 2 | 4 |
+| `.prose.max-w-none` | 0 | 1 |
+| `[data-renderer="lm"]` bodies | 948, 756 chars | 948, 756, **3785** chars |
+
+`#markdown-content-N` stays at 0 in both states: its removal is permanent, not a collapse artifact.
+
+Two consequences follow that the failure output did not show. The ready selector for the live test
+was `div[id^="markdown-content-"]` — the same dead selector — so every run burned three navigation
+retries before validating anything; that is the 54.6s. And `markdownContent` was Perplexity's only
+entry in `CONTENT_REQUIRED`, the list that refuses to record a matched-but-empty answer container
+(ADR-031). Removing it would have left the platform with no content guard at all — exactly the hole
+#444 fell through.
+
+## Decision
+
+**Selectors that cannot be proven against a freshly loaded conversation do not live in
+`SELECTORS`.** The live baseline refuses to record a zero-match selector, and the refusal is per
+selector *string*, so one unprovable entry blocks the whole platform (#402). Both the legacy
+placeholder and the Deep Research report body are now unprovable — the first because most users no
+longer receive it, the second because it requires a click. They move to private constants in
+`perplexity.ts`, where they still drive extraction but are invisible to the contract.
+
+**`answerProse` inherits the content guard.** It is now the only container an assistant message is
+read out of, so it takes `markdownContent`'s place in `CONTENT_REQUIRED` for this platform. Without
+that, a future layout that keeps the class list but moves the text elsewhere would extract empty
+notes and stay green — the #444 failure mode, restaged.
+
+**The report is keyed off its prose, not its card.** `.prose.max-w-none` marks report prose under
+both layouts, and under both it *wraps* the report's own `inline` prose. Matching on it alone both
+finds the report and excludes it from the answer set, so the card itself never needs naming — which
+is why the card's `rounded-lg` → `rounded-xl` rename costs nothing. A collapsed card matches
+nothing here, which is correct: there is no body to extract.
+
+**An opened preview panel is extracted as a report.** The panel's prose already satisfied
+`answerProse`, so the shipped extension was *already* capturing it — as a trailing plain answer,
+by accident. Routing it through the report path keeps the content and makes the capture
+deliberate. Ordering comes from the split-pane DOM rather than the thread, so a report may land at
+the end rather than beside its turn; that is accepted over silently dropping 3785 characters a user
+had open on screen.
+
+**The ready selector tracks the answer container.** `perplexity_conv` becomes
+`.prose[data-renderer="lm"]`.
+
+## Consequences
+
+- A Deep Research report that the user has **not** opened is not exported. Only the inline summary
+  is. This is a real capability loss, tracked as #463 and in the same class as ChatGPT's
+  cross-origin Deep Research iframe (#283).
+- The pre-2026-08 layout keeps working. The placeholder is demoted, not deleted, and its
+  double-count guard is intact — the legacy-layout tests all stay green.
+- The live run went from 54.6s (1 failed) to 6.0s (passed); the whole suite from 1.6m to 44.8s.
+- `DES-004` §4.1 still describes the original 2025 placeholder-pairing design. It is historical from
+  this point on; this ADR and the selector module are the current source of truth.

--- a/e2e/selectors/baseline.ts
+++ b/e2e/selectors/baseline.ts
@@ -87,6 +87,11 @@ export const BLOCKING_CONTENT_STATUSES: readonly ContentStatus[] = ['content_los
 export const CONTENT_REQUIRED: readonly { group: string; name: string }[] = [
   { group: 'SELECTORS', name: 'markdownContent' },
   { group: 'SELECTORS', name: 'proseContent' },
+  // Perplexity's answer container since 2026-08. `markdownContent` used to
+  // cover it, but that placeholder was removed from the platform's selectors
+  // when Perplexity dropped the id; `answerProse` inherits the duty of
+  // proving the assistant message still has content behind it.
+  { group: 'SELECTORS', name: 'answerProse' },
   { group: 'SELECTORS', name: 'modelResponse' },
   { group: 'SELECTORS', name: 'assistantMessage' },
   { group: 'SELECTORS', name: 'responseContent' },

--- a/e2e/selectors/smoke-test.spec.ts
+++ b/e2e/selectors/smoke-test.spec.ts
@@ -67,7 +67,7 @@ const READY_SELECTORS: Readonly<Record<string, string>> = {
   claude_conv: '.font-claude-response',
   claude_dr: '#markdown-artifact',
   chatgpt_conv: 'section[data-turn-id]',
-  perplexity_conv: 'div[id^="markdown-content-"]',
+  perplexity_conv: '.prose[data-renderer="lm"]',
   notebooklm_conv: '.chat-message-pair',
 };
 

--- a/src/content/extractors/perplexity.ts
+++ b/src/content/extractors/perplexity.ts
@@ -21,6 +21,46 @@ import type { CitationTransformResult } from './footnotes';
 
 import { SELECTORS } from './selectors/perplexity';
 
+// ========== Layout selectors kept out of the live contract ==========
+//
+// Both groups below are DETECTION-ONLY: neither can be guaranteed to match on
+// a freshly loaded conversation, so neither may live in SELECTORS — the live
+// baseline refuses to record a zero-match selector, and a name that cannot be
+// recorded blocks the whole platform (ADR-016, issues #402/#444).
+
+/**
+ * The pre-2026-08 answer placeholder.
+ *
+ * Perplexity removed `#markdown-content-N` id and all; the answer now renders
+ * as a bare `.prose.inline`. Users who have not received the rollout still see
+ * the placeholder, so it stays as a collection anchor and as the guard that
+ * keeps an answer inside it from being counted twice — but it is invisible to
+ * the live contract and belongs here rather than in SELECTORS.
+ */
+const LEGACY_MARKDOWN_CONTENT: readonly string[] = ['div[id^="markdown-content-"]'];
+
+/**
+ * The Deep Research report body.
+ *
+ * Under the old layout it was inline prose inside a raised card
+ * (`div.bg-raised.rounded-lg`). Since 2026-08 the report collapses to an
+ * attachment card that carries NO body at all, and the report mounts only
+ * after the user opens it, into a `?preview=1` side panel.
+ *
+ * `max-w-none` is what marks report prose under both layouts, and under both
+ * it wraps the report's own `inline` prose — so matching on it alone both
+ * finds the report and excludes it from the answer set, with no need to name
+ * the card itself (whose class list changed from `rounded-lg` to
+ * `rounded-xl` in the same rollout).
+ *
+ * A collapsed card matches nothing here, which is exactly right: there is no
+ * report body in the DOM to extract.
+ */
+const DEEP_RESEARCH_PROSE: readonly string[] = [
+  '.prose.max-w-none',
+  '.prose.dark\\:prose-invert.max-w-none',
+];
+
 // ========== Citation transformation (issue #291) ==========
 //
 // Perplexity renders inline source citations as "pill" spans:
@@ -289,7 +329,7 @@ export class PerplexityExtractor extends BaseExtractor {
       tagged.push({ type: 'user', element: el });
     }
 
-    for (const el of this.queryAllWithFallback<HTMLElement>(SELECTORS.markdownContent)) {
+    for (const el of this.queryAllWithFallback<HTMLElement>(LEGACY_MARKDOWN_CONTENT)) {
       tagged.push({ type: 'response', element: el });
     }
 
@@ -302,20 +342,17 @@ export class PerplexityExtractor extends BaseExtractor {
     //
     // Collecting these unconditionally is safe rather than clever: under the
     // old layout every answer prose IS inside a placeholder, so this set is
-    // empty and nothing is added twice. Deep Research cards are skipped
-    // because the report path below already owns them, and a card nests an
+    // empty and nothing is added twice. Deep Research report prose is skipped
+    // because the report path below already owns it — a report nests an
     // `inline` prose of its own that would otherwise be counted as an answer.
     for (const prose of this.queryAllWithFallback<HTMLElement>(SELECTORS.answerProse)) {
-      if (this.isInside(prose, SELECTORS.markdownContent)) continue;
-      if (this.isInside(prose, SELECTORS.deepResearchCard)) continue;
+      if (this.isInside(prose, LEGACY_MARKDOWN_CONTENT)) continue;
+      if (this.isInside(prose, DEEP_RESEARCH_PROSE)) continue;
       tagged.push({ type: 'response', element: prose });
     }
 
-    for (const card of this.queryAllWithFallback<HTMLElement>(SELECTORS.deepResearchCard)) {
-      const proseEl = this.queryWithFallback<HTMLElement>(SELECTORS.deepResearchProse, card);
-      if (proseEl) {
-        tagged.push({ type: 'report', element: card });
-      }
+    for (const prose of this.queryAllWithFallback<HTMLElement>(DEEP_RESEARCH_PROSE)) {
+      tagged.push({ type: 'report', element: prose });
     }
 
     return tagged;
@@ -368,23 +405,19 @@ export class PerplexityExtractor extends BaseExtractor {
   }
 
   /**
-   * Extract Deep Research report content from a report card element
+   * Extract Deep Research report content from the report prose element.
    *
-   * The report card contains prose with max-w-none, and potentially
-   * an inner prose element with the actual content. Citations are
-   * converted to footnotes the same way as normal answers.
+   * The `max-w-none` prose is the report's outer wrapper; the rendered body is
+   * an inner prose inside it under both the inline-card layout and the
+   * `?preview=1` panel, so the inner element is preferred and the wrapper is
+   * the fallback. Citations are converted to footnotes the same way as normal
+   * answers.
    */
-  private extractReportContent(card: HTMLElement, messageIndex: number): string {
-    const proseEl = this.queryWithFallback<HTMLElement>(SELECTORS.deepResearchProse, card);
-    if (proseEl) {
-      const innerProse = this.queryWithFallback<HTMLElement>(SELECTORS.proseContent, proseEl);
-      const targetEl = innerProse ?? proseEl;
-      const content = this.toSanitizedHtmlWithFootnotes(targetEl.innerHTML, messageIndex);
-      if (content.trim()) {
-        return content;
-      }
-    }
-    return '';
+  private extractReportContent(reportProse: HTMLElement, messageIndex: number): string {
+    const innerProse = this.queryWithFallback<HTMLElement>(SELECTORS.proseContent, reportProse);
+    const targetEl = innerProse ?? reportProse;
+    const content = this.toSanitizedHtmlWithFootnotes(targetEl.innerHTML, messageIndex);
+    return content.trim() ? content : '';
   }
 
   /**

--- a/src/content/extractors/selectors/perplexity.ts
+++ b/src/content/extractors/selectors/perplexity.ts
@@ -10,16 +10,12 @@ import type { SelectorGroup } from './types';
 
 export const SELECTORS = {
   // User query text
-  // 2026-07: the bubble class bg-offset became bg-subtle; the group/query
-  // ancestor is the stabler anchor
+  // 2026-07: the bubble class bg-offset became bg-subtle.
+  // 2026-08: the `group/query` ancestor disappeared; the bubble itself
+  // (bg-subtle rounded-2xl) is what now scopes the query text.
   userQuery: [
     'span.select-text', // Semantic (HIGH)
-    'div[class~="group/query"] span.select-text', // Query container (MEDIUM)
-  ],
-
-  // Assistant response content container
-  markdownContent: [
-    'div[id^="markdown-content-"]', // ID pattern (HIGH)
+    'div.bg-subtle.rounded-2xl span.select-text', // Query bubble (MEDIUM)
   ],
 
   // Prose content within response
@@ -28,35 +24,26 @@ export const SELECTORS = {
     '.prose', // Fallback (LOW)
   ],
 
-  // The answer block itself, wherever it is mounted.
+  // The answer block itself, wherever it is mounted — the ONLY container the
+  // assistant message is read out of since 2026-08.
   //
-  // 2026-08 (issue #444): a rollout keeps `markdownContent` as an EMPTY
-  // placeholder and renders the answer beside it. The class list of the answer
-  // prose is identical under both layouts, so this selector finds it either
-  // way; what differs is only whether it sits inside the placeholder.
+  // Issue #444 saw the first half of the rollout: `#markdown-content-N` stayed
+  // as an EMPTY placeholder and the answer rendered beside it. The second half
+  // removed the placeholder id outright, so nothing anchors an answer any more
+  // except its own class list. The legacy placeholder still exists for users
+  // who have not received the rollout, but as a private selector in
+  // perplexity.ts — it can no longer be validated against a live page, and a
+  // selector the live contract cannot see does not belong in this group
+  // (ADR-016, issue #402).
   //
-  // `inline` is what separates it from a Deep Research card's own prose
-  // (`… max-w-none text-sm`). That is a narrowing, not the guard: a card also
-  // nests an `inline` prose, so perplexity.ts additionally excludes anything
-  // inside a deepResearchCard, which the report path already owns.
+  // `inline` is what separates it from a Deep Research report body
+  // (`… max-w-none …`). That is a narrowing, not the guard: a report nests an
+  // `inline` prose of its own, so perplexity.ts additionally excludes anything
+  // inside the report prose, which the report path already owns.
   answerProse: [
     '.prose.dark\\:prose-invert.inline', // Answer block (HIGH)
     '.prose.inline', // Without the theme class (MEDIUM)
-  ],
-
-  // Deep Research report card container. Matches generic raised panels too;
-  // the extractor only tags a card as a report when deepResearchProse is
-  // found inside it (perplexity.ts collectTaggedElements).
-  // 2026-07: the border-borderMain token disappeared site-wide (removed
-  // under the zero-match baseline contract).
-  deepResearchCard: [
-    'div.bg-raised.rounded-lg', // Style (HIGH)
-  ],
-
-  // Prose content within a Deep Research report card (max-w-none distinguishes it)
-  deepResearchProse: [
-    '.prose.max-w-none', // Specific to report (HIGH)
-    '.prose.dark\\:prose-invert.max-w-none', // Full match (MEDIUM)
+    '.prose[data-renderer="lm"]', // Renderer hook, added 2026-08 (LOW)
   ],
 
   // Inline citation pill carrying the source URL (issue #291).

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -1113,4 +1113,152 @@ describe('PerplexityExtractor', () => {
       expect(result.data?.metadata.assistantMessageCount).toBe(1);
     });
   });
+  // ========================================================================
+  // 2026-08 layout rollout (live-verified via CDP on www.perplexity.ai)
+  //
+  // Three changes landed together after the 2026-08-16 selector baseline:
+  //   1. `#markdown-content-N` is gone id and all — the answer renders as a
+  //      bare `.prose.inline` carrying the new `data-renderer="lm"` hook.
+  //   2. The user bubble lost its `group/query` wrapper; the bubble itself is
+  //      `.bg-subtle.rounded-2xl`.
+  //   3. A Deep Research report is no longer inline prose in a raised card.
+  //      It collapses to an attachment card (`rounded-xl`, title + "Deep
+  //      research report" label, NO body in the DOM) and the report only
+  //      mounts — into a `?preview=1` side panel — once the card is clicked.
+  //
+  // The old layout is still exercised by the blocks above: this rollout is a
+  // migration, not a replacement, so both must extract.
+  // ========================================================================
+  describe('2026-08 layout: placeholder removed, Deep Research collapsed', () => {
+    const ANSWER_PROSE_CLASS =
+      'prose dark:prose-invert inline leading-relaxed break-words min-w-0 [word-break:break-word]';
+
+    /** User bubble as rendered since 2026-08 (no `group/query` ancestor). */
+    const userBubble = (text: string): string => `
+      <div class="group flex items-start justify-end gap-2">
+        <div class="flex flex-col items-end gap-1 max-w-[600px]">
+          <div class="relative inline-flex flex-col items-end">
+            <div class="min-w-[48px] select-none p-3 bg-subtle rounded-2xl flex items-center justify-center">
+              <span class="min-w-0 font-sans text-base select-text break-words">${text}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    /** Assistant answer as rendered since 2026-08 (no placeholder anywhere). */
+    const answer = (html: string): string => `
+      <div class="flex flex-col flex-1 min-w-0 gap-4">
+        <div class="contents">
+          <div class="break-words min-w-0 flex-1">
+            <div>
+              <div class="${ANSWER_PROSE_CLASS}" data-renderer="lm">${html}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    /** Collapsed Deep Research attachment card — carries no report body. */
+    const collapsedReportCard = (title: string): string => `
+      <div class="flex w-full flex-col divide-y divide-subtlest overflow-hidden rounded-xl border border-subtlest bg-raised">
+        <div class="group relative w-full gap-2.5 overflow-hidden p-2 flex items-center">
+          <button class="absolute inset-0 z-0 cursor-pointer appearance-none"></button>
+          <div class="pointer-events-none relative z-[1] flex min-w-0 flex-1 flex-col">
+            <div class="font-sans text-primary font-bold text-sm truncate"><span>${title}</span></div>
+            <div class="flex min-w-0 items-center gap-1">
+              <div class="min-w-0 font-sans text-secondary text-sm truncate">Deep research report</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    /** The `?preview=1` side panel mounted after the card is clicked. */
+    const openedReportPanel = (html: string): string => `
+      <div class="relative flex h-full min-h-0">
+        <div class="relative min-w-0 flex-1">
+          <div class="scrollbar-subtle h-full min-h-0 overflow-auto">
+            <div class="relative prose dark:prose-invert max-w-none p-6">
+              <div class="@container/artifact-comment relative">
+                <div>
+                  <div class="${ANSWER_PROSE_CLASS}" data-renderer="lm">${html}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    beforeEach(() => {
+      setPerplexityLocation('conv-2026-08');
+    });
+
+    it('extracts a multi-turn thread that has no markdown-content placeholder', () => {
+      loadFixture(
+        userBubble('first question') +
+          answer('<p>first answer</p>') +
+          userBubble('second question') +
+          answer('<p>second answer</p>')
+      );
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+      expect(messages[0].content).toBe('first question');
+      expect(messages[1].content).toContain('first answer');
+      expect(messages[2].content).toBe('second question');
+      expect(messages[3].content).toContain('second answer');
+    });
+
+    it('titles the conversation from the query in the new bubble', () => {
+      loadFixture(userBubble('what changed in the layout') + answer('<p>a</p>'));
+
+      expect(extractor.getTitle()).toBe('what changed in the layout');
+    });
+
+    it('keeps the inline summary and adds nothing for a collapsed report card', () => {
+      loadFixture(
+        userBubble('research this') +
+          collapsedReportCard('A Deep Research Report') +
+          answer('<p>summary of the report</p>')
+      );
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.role)).toEqual(['user', 'assistant']);
+      expect(messages[1].content).toContain('summary of the report');
+    });
+
+    it('extracts the opened preview panel as a report message', () => {
+      loadFixture(
+        userBubble('research this') +
+          collapsedReportCard('A Deep Research Report') +
+          answer('<p>summary of the report</p>') +
+          openedReportPanel('<h1>Executive summary</h1><p>the full report body</p>')
+      );
+
+      const messages = extractor.extractMessages();
+      const report = messages.filter(m => m.content.includes('the full report body'));
+
+      expect(report).toHaveLength(1);
+      expect(report[0].id).toMatch(/^report-/);
+      expect(report[0].role).toBe('assistant');
+      expect(report[0].content).toContain('Executive summary');
+    });
+
+    it('does not also count the opened panel as a plain answer', () => {
+      loadFixture(
+        userBubble('research this') +
+          collapsedReportCard('A Deep Research Report') +
+          answer('<p>summary of the report</p>') +
+          openedReportPanel('<p>the full report body</p>')
+      );
+
+      const messages = extractor.extractMessages();
+
+      expect(messages.map(m => m.id)).toEqual(['user-0', 'assistant-0', 'report-0']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`nix run .#e2e-selectors` failed on Perplexity with three zero-match selectors, and the run took 54.6s against ~6s for every other platform. Every DOM claim below was measured live through the CDP daemon against an authenticated session, not inferred from the failure output.

Perplexity shipped the second half of the rollout #444 caught:

| selector | baseline 2026-08-16 | now |
| --- | --- | --- |
| `div[id^="markdown-content-"]` | 2 | **0** |
| `[id^="markdown-content"]` (prefix loosened) | — | **0** |
| `div[class~="group/query"] span.select-text` | 2 | **0** |
| `div.bg-raised.rounded-lg` | 4 | **0** |
| `.prose.max-w-none` | 1 | **0** |

- The answer placeholder was removed **id and all**. The answer is now a bare `.prose.dark:prose-invert.inline` carrying a new `data-renderer="lm"` hook.
- The user bubble lost its `group/query` wrapper; `div.bg-subtle.rounded-2xl` scopes the query text.
- Deep Research collapsed to an attachment card carrying **no body**. It mounts only on click, into a `?preview=1` side panel (948/756 chars collapsed → 948/756/**3785** opened).

### Changes

- **Selectors that cannot be proven against a freshly loaded conversation leave `SELECTORS`.** The baseline refuses to record a zero-match selector and the refusal is per selector *string*, so one unprovable entry blocks the whole platform (#402). The legacy placeholder and the report prose move to private constants in `perplexity.ts` — they still drive extraction, so the pre-rollout layout keeps working, but they are invisible to the live contract.
- **The report is keyed off `.prose.max-w-none`, not its card.** That prose wraps the report's own `inline` prose under both layouts, so one match both *finds* the report and *excludes* it from the answer set. The card's `rounded-lg` → `rounded-xl` rename therefore costs nothing.
- **An opened preview panel is extracted as a report.** Its prose already satisfied `answerProse`, so the shipped extension was capturing it by accident as a trailing plain answer; routing it through the report path keeps the content and makes the capture deliberate.
- **`answerProse` inherits the content guard.** `markdownContent` was Perplexity's only `CONTENT_REQUIRED` entry, so deleting it would have removed the platform's matched-but-empty guard — the exact hole #444 fell through.
- **The e2e ready selector was the same dead placeholder**, which is where the 54.6s came from; it becomes `.prose[data-renderer="lm"]`.
- ADR-035 records the rollout and the decisions it forced.

### Known limitation

A Deep Research report the user has **not** opened is not exported — there is no body in the DOM to extract. Tracked as #463, same class as #283.

## Test plan

- [x] `nix run .#test` — 86 files / 2199 tests pass (the legacy-layout Deep Research tests all stay green)
- [x] `nix run .#lint` — 0 errors; the 3 warnings are pre-existing, proved by re-running under `git stash`
- [x] `nix run .#build` — typecheck + build clean
- [x] `nix run .#test-coverage` — 96.54% stmts overall, `perplexity.ts` 97.11%; thresholds met
- [x] TDD: 2 tests written first and observed failing for the right reason (`expected 'assistant-1' to match /^report-/`)
- [x] Live — all 12 selector strings match with content (`answerProse` ne=2, satisfying the new `CONTENT_REQUIRED` entry), verified **before** the baseline update
- [x] `nix run .#e2e-baseline-update -- -g Perplexity` accepted: **54.6s → 6.1s**
- [x] `nix run .#e2e-selectors` — 7/7 pass, Perplexity 0 fail / 0 blocking / 0 advisory; suite 1.6m → 44.8s

Fixes the Perplexity selector regression. Refs #444, #402, #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
