### PR TITLE
fix: clear the sync-status badge when a newer message appears

### DIFF
--- a/docs/adr/034-persistent-sync-status-indicator.md
+++ b/docs/adr/034-persistent-sync-status-indicator.md
@@ -29,6 +29,11 @@ Add a small **status badge** anchored to the sync button, and **no setting**.
 
 ### The badge reports the last sync, not "up to date"
 
+> **Superseded in part by [ADR-036](036-badge-invalidation-on-new-messages.md)
+> (2026-08-29, issue #465):** Claude and ChatGPT now clear the badge when a turn
+> newer than the sync appears. The rest of this section still holds for Gemini,
+> Perplexity and Gemini Notebook, which expose no conversation-wide ordinal.
+
 Invalidating the badge when new messages arrive was **deliberately not
 implemented** (tracked in #424, which needs the same "what counts as a new
 message" machinery for auto-sync). So the badge can outlive the state it
@@ -110,7 +115,8 @@ the failures an absent user needs to still see.
 - The three-way success/partial/error split lives once, in
   `buildSyncStatus()`, and both the toast and the badge read it, so the two
   cannot disagree.
-- A stale `✓` after new messages is a known, documented limitation until #424.
+- A stale `✓` after new messages is a known, documented limitation until #424
+  — narrowed to the three platforms without a turn ordinal by ADR-036.
 
 ## Files
 

--- a/docs/adr/036-badge-invalidation-on-new-messages.md
+++ b/docs/adr/036-badge-invalidation-on-new-messages.md
@@ -1,0 +1,114 @@
+# ADR-036: The sync-status badge clears when a newer message appears
+
+- Status: Accepted
+- Date: 2026-08-29
+- Extends: [ADR-034](034-persistent-sync-status-indicator.md)
+- Follows: [#465](https://github.com/sho7650/obsidian-AI-exporter/issues/465)
+- Related: [ADR-017](017-autoscroll-virtualized-platforms.md), [#424](https://github.com/sho7650/obsidian-AI-exporter/issues/424)
+
+## Context
+
+ADR-034 shipped the badge as *the result of the last sync*, explicitly **not**
+*this conversation is up to date*: adding messages after a sync left the `✓` in
+place. #465 reports exactly that as a defect —
+
+> successful syncs to part of the conversations cannot be distinguished from a
+> need to resync additional conversation content
+
+— and it is a fair reading. A `✓` that survives ten new turns is indistinguishable
+from a `✓` that describes everything on screen.
+
+## Decision
+
+Invalidate the badge when the conversation grows past what the sync covered, on
+the platforms where that can be detected without false positives. The badge's
+definition is otherwise unchanged, and so is every other invalidation path
+(conversation change, dismiss, a newer sync).
+
+### The signal is a turn ordinal, never a turn count
+
+The obvious signal — "more turns are in the DOM than there were" — is wrong on
+every platform we support, in both directions:
+
+| Platform | Why a count lies |
+| --- | --- |
+| Gemini | Scrolling **up** lazy-loads older turns (`infinite-scroller` fires `onScrolledTopPastThreshold`, see `selectors/gemini.ts`). The count grows with no new message. |
+| Claude, ChatGPT | Virtualized (ADR-017): turns mount and unmount as the user scrolls, so the count moves in both directions for no reason at all. |
+
+Claude and ChatGPT do expose something a count cannot give: a **conversation-wide
+ordinal that is never renumbered** — Claude's virtual-row `data-index` and
+ChatGPT's `data-testid="conversation-turn-N"`. Both were measured live and are
+already relied on for extraction ordering (#352, #353: a mid-scroll window
+reported turns 17-21 while the top window reported 1-21, with no renumbering).
+
+The rule is therefore:
+
+> An ordinal **strictly greater** than the one the sync covered means a new turn
+> exists. Anything else — equal, lower, unreadable — does not.
+
+The read is scoped to the thread scroller, not the document. `[data-index]` is a
+bare attribute selector and both platforms virtualize their **sidebar** lists as
+well; unscoped, scrolling the conversation list would raise the watermark and
+clear the badge (caught by a test that returned 99 from a sidebar row).
+
+Scrolling the thread can only ever surface ordinals at or below the synced one,
+so it can never trip the rule. The cost is a false *negative* while the user is scrolled
+far up when a message arrives; it resolves the moment they return to the bottom.
+
+### The baseline comes from the extraction, not from the DOM
+
+The number to compare against cannot be read from the page after the sync.
+`accumulateWhileScrolling()` walks **upward** and returns with the container at
+`scrollTop = 0` (`scroll-manager.ts`), so when the sync ends the mounted window
+is the *oldest* turns: a post-sync read of a 120-turn conversation reports
+something like 5. The badge would then clear itself the instant the user scrolled
+back down.
+
+So the accumulator, which sees every window including the newest one pinned by
+`seedAtBottom()`, reports the highest ordinal it saw as `AccumulateResult.maxOrder`.
+That travels out as `ConversationData.messageWatermark` and becomes
+`SyncStatus.messageWatermark`. When auto-scroll is off, the baseline is a plain
+DOM read — which is correct there, because the mounted window *is* what was
+extracted.
+
+### Platforms without an ordinal are left exactly as they were
+
+Gemini, Perplexity and Gemini Notebook report `null`, and the watcher then arms
+nothing — not even a timer. A badge that lingers is a known limitation; a badge
+that clears itself because the user scrolled would be a new defect. The same
+applies to a sync that failed before extracting anything: no extraction, no
+trustworthy ordinal, no watcher.
+
+Finding a safe signal for those three needs live CDP measurement of what their
+DOM does on upward scroll, and is left to a follow-up.
+
+### Why polling again
+
+Same reasoning as ADR-034: a content script cannot observe the page's own
+framework, and the alternative here is a `MutationObserver` on the thread, which
+fires on **every streamed token** and would still have to re-read the ordinal
+afterwards. The tick is one `querySelectorAll` over the *mounted* window (a few
+dozen nodes on both virtualized platforms), it runs only while a badge is on
+screen, and it stops permanently the first time it fires.
+
+## Consequences
+
+- On Claude and ChatGPT the badge now answers #465: it disappears as soon as the
+  conversation moves past the sync it describes.
+- The wording stays "Last sync …" and the detail panel still always states the
+  age, because three platforms still cannot detect a new message.
+- `#424` (auto-sync) can reuse `getMessageWatermark()` as its "what counts as a
+  new message" signal instead of inventing a second one.
+- No new setting, no new permission, no change to extraction output.
+
+## Files
+
+| Path | Role |
+| --- | --- |
+| `src/content/message-watcher.ts` | ordinal poll → new-message callback |
+| `src/content/extractors/base.ts` | `getMessageWatermark()` hook (null default) + watermark plumbing |
+| `src/content/extractors/claude.ts` | highest mounted `data-index` |
+| `src/content/extractors/chatgpt.ts` | highest mounted `conversation-turn-N` |
+| `src/lib/scroll-manager.ts` | `AccumulateResult.maxOrder` |
+| `src/content/sync-status.ts` | `SyncStatus.messageWatermark` |
+| `src/content/bootstrap.ts` | both watchers share one composed lifetime |

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -25,6 +25,7 @@ import {
 import { showSyncBadge, clearSyncBadge } from './ui-badge';
 import { buildSyncStatus, buildFailedSyncStatus, type SyncStatus } from './sync-status';
 import { startConversationWatcher, type StopWatching } from './conversation-watcher';
+import { startNewMessageWatcher } from './message-watcher';
 import { sendMessage } from '../lib/messaging';
 import {
   AUTO_SAVE_CHECK_INTERVAL,
@@ -35,6 +36,7 @@ import {
 import type {
   AIPlatform,
   ContentScriptSettings,
+  ExtractionResult,
   ObsidianNote,
   OutputDestination,
   OutputResult,
@@ -214,15 +216,16 @@ export async function initialize(): Promise<void> {
 }
 
 /**
- * Stops the watcher that clears the badge on a conversation change, or null
- * when no badge is on screen. Module-level because the badge outlives the
- * `handleSync()` call that created it.
+ * Stops every watcher that keeps the badge honest, or null when no badge is on
+ * screen. Module-level because the badge outlives the `handleSync()` call that
+ * created it, and composed because the two watchers share one lifetime: both
+ * start with the badge and both must stop with it.
  */
-let stopConversationWatch: StopWatching | null = null;
+let stopBadgeWatchers: StopWatching | null = null;
 
-function stopWatchingConversation(): void {
-  stopConversationWatch?.();
-  stopConversationWatch = null;
+function stopWatchingBadge(): void {
+  stopBadgeWatchers?.();
+  stopBadgeWatchers = null;
 }
 
 /** The conversation the page is currently showing, or null. */
@@ -230,28 +233,45 @@ function currentConversationKey(): string | null {
   return getExtractor()?.getConversationId() ?? null;
 }
 
+/** The highest turn ordinal currently mounted, or null on platforms without one. */
+function currentMessageWatermark(): number | null {
+  return getExtractor()?.getMessageWatermark() ?? null;
+}
+
 /**
- * Show the persistent status badge and keep it honest (issue #458).
+ * Show the persistent status badge and keep it honest (issues #458, #465).
  *
- * The badge reports the last sync, not that the conversation is current — new
- * messages do not clear it. What it must never do is describe a DIFFERENT
- * conversation, so it is dropped the moment the user navigates away. Every
- * platform navigates without reloading the document (measured 2026-08-23),
- * which is why this needs a watcher at all.
+ * The badge describes one sync of one conversation, and is dropped as soon as
+ * that stops being what the page shows — either because the user navigated to a
+ * different conversation (every platform does that without reloading the
+ * document, measured 2026-08-23) or because the conversation has grown past
+ * what the sync covered. Neither is observable as an event, so both are polled,
+ * and only while a badge is on screen.
  */
 function presentSyncStatus(status: SyncStatus): void {
-  stopWatchingConversation();
+  stopWatchingBadge();
 
-  showSyncBadge(status, { onDismiss: stopWatchingConversation });
+  showSyncBadge(status, { onDismiss: stopWatchingBadge });
 
-  stopConversationWatch = startConversationWatcher({
-    initialKey: status.conversationKey,
-    getKey: currentConversationKey,
-    onChanged: () => {
-      clearSyncBadge();
-      stopWatchingConversation();
-    },
-  });
+  const invalidate = (): void => {
+    clearSyncBadge();
+    stopWatchingBadge();
+  };
+
+  const stops = [
+    startConversationWatcher({
+      initialKey: status.conversationKey,
+      getKey: currentConversationKey,
+      onChanged: invalidate,
+    }),
+    startNewMessageWatcher({
+      syncedWatermark: status.messageWatermark,
+      getWatermark: currentMessageWatermark,
+      onNewMessage: invalidate,
+    }),
+  ];
+
+  stopBadgeWatchers = () => stops.forEach(stop => stop());
 }
 
 /** Report a sync that failed before any destination ran. */
@@ -368,15 +388,19 @@ function reportSyncResult(
   saveResult: MultiOutputResponse,
   fileName: string,
   conversationKey: string | null,
-  extractionWarnings?: string[]
+  extraction: ExtractionResult
 ): void {
-  displaySaveResults(saveResult, fileName, extractionWarnings);
+  displaySaveResults(saveResult, fileName, extraction.warnings);
   presentSyncStatus(
     buildSyncStatus({
       saveResult,
       fileName,
-      warnings: extractionWarnings,
+      warnings: extraction.warnings,
       conversationKey,
+      // Taken from the extraction, never re-read from the DOM: the auto-scroll
+      // pass ends pinned at the top of the conversation, where the newest turn
+      // is unmounted and its ordinal is gone (issue #465).
+      messageWatermark: extraction.data?.messageWatermark,
       at: new Date(),
     })
   );
@@ -449,7 +473,7 @@ export async function handleSync(): Promise<void> {
     showToast('Saving...', 'info', INFO_TOAST_DURATION);
     const saveResult = await saveToOutputs(note, enabledOutputs);
 
-    reportSyncResult(saveResult, note.fileName, extractor.getConversationId(), result.warnings);
+    reportSyncResult(saveResult, note.fileName, extractor.getConversationId(), result);
   } catch (error) {
     console.error('[G2O] Sync error:', error);
     reportSyncFailure(extractErrorMessage(error));

--- a/src/content/extractors/base.ts
+++ b/src/content/extractors/base.ts
@@ -116,12 +116,18 @@ export abstract class BaseExtractor implements IConversationExtractor {
       }
 
       console.info(`[G2O] Extracting ${this.platformLabel} conversation`);
-      const { messages, warning, truncated } = await this.collectMessages();
+      const { messages, warning, truncated, watermark } = await this.collectMessages();
       const conversationId = this.getConversationId() || `${this.platform}-${Date.now()}`;
       const title = this.getTitle();
       const result = this.buildConversationResult(messages, conversationId, title, this.platform);
       if (!result.success) return result;
-      const data = truncated && result.data ? { ...result.data, truncated } : result.data;
+      const data = result.data
+        ? {
+            ...result.data,
+            ...(truncated ? { truncated } : {}),
+            ...(watermark === undefined ? {} : { messageWatermark: watermark }),
+          }
+        : result.data;
       return warning
         ? { ...result, data, warnings: [...(result.warnings ?? []), warning] }
         : { ...result, data };
@@ -175,16 +181,18 @@ export abstract class BaseExtractor implements IConversationExtractor {
     warning?: string;
     /** The pass ended on a deadline, so earlier messages may be missing (#449). */
     truncated?: boolean;
+    /** Ordinal of the newest turn covered, when the platform has one (#465). */
+    watermark?: number;
   }> {
     const config = this.getScrollConfig();
     if (!this.enableAutoScroll || !config) {
-      return { messages: this.extractMessages() };
+      return { messages: this.extractMessages(), watermark: this.currentWatermark() };
     }
 
     const container = this.queryWithFallback<HTMLElement>(config.container);
     if (!container) {
       console.info('[G2O] No scroll container found, skipping auto-scroll');
-      return { messages: this.extractMessages() };
+      return { messages: this.extractMessages(), watermark: this.currentWatermark() };
     }
 
     const result = await accumulateWhileScrolling(
@@ -195,8 +203,32 @@ export abstract class BaseExtractor implements IConversationExtractor {
     // Re-index into contiguous conversation order after de-duplication.
     const messages = result.items.map((message, index) => ({ ...message, index }));
 
+    // Deliberately the accumulated maximum, never a DOM re-read: the pass ends
+    // pinned at the TOP of the conversation, where the newest turn is unmounted
+    // and its ordinal is no longer readable (issue #465).
+    const watermark = result.maxOrder;
+
     const warning = describeScrollStop(result.stopReason, result.itemCount, this.scrollDeadlines);
-    return warning ? { messages, warning, truncated: true } : { messages };
+    return warning ? { messages, warning, truncated: true, watermark } : { messages, watermark };
+  }
+
+  /**
+   * Hook: highest conversation-wide turn ordinal currently in the DOM.
+   *
+   * Null by default. A platform may only override this with an ordinal that is
+   * **monotonic in conversation order and never renumbered** — Claude's
+   * `data-index` and ChatGPT's `conversation-turn-N` qualify (measured live,
+   * issues #352/#353). A turn *count* does not: Gemini lazy-loads older turns
+   * when the user scrolls up, so its count grows with no new message and the
+   * badge would clear itself for nothing (ADR-036).
+   */
+  getMessageWatermark(): number | null {
+    return null;
+  }
+
+  /** {@link getMessageWatermark} as the optional field callers store. */
+  private currentWatermark(): number | undefined {
+    return this.getMessageWatermark() ?? undefined;
   }
 
   // ========== Settings ==========

--- a/src/content/extractors/chatgpt.ts
+++ b/src/content/extractors/chatgpt.ts
@@ -247,6 +247,26 @@ export class ChatGPTExtractor extends BaseExtractor {
   }
 
   /**
+   * Highest `conversation-turn-N` ordinal currently mounted (issue #465).
+   *
+   * N is numbered across the whole conversation and never renumbered per window
+   * (see {@link turnOrdinal}), so a value above the one a sync covered can only
+   * mean a turn was added — scrolling up mounts *smaller* ordinals.
+   */
+  getMessageWatermark(): number | null {
+    // Scoped to the thread scroller, for the same reason accumulation is: the
+    // sidebar <nav> matches loose selectors and carries its own list.
+    const root = this.queryWithFallback<HTMLElement>(SELECTORS.scrollContainer) ?? document;
+    let highest: number | null = null;
+    this.queryAllWithFallback<HTMLElement>(SELECTORS.conversationTurn, root).forEach(turn => {
+      const ordinal = this.turnOrdinal(turn);
+      if (ordinal === undefined || !Number.isFinite(ordinal)) return;
+      if (highest === null || ordinal > highest) highest = ordinal;
+    });
+    return highest;
+  }
+
+  /**
    * Harvest the currently-mounted window as keyed messages.
    *
    * Keyed by the turn's stable uuid (data-turn-id, then data-message-id),

--- a/src/content/extractors/claude.ts
+++ b/src/content/extractors/claude.ts
@@ -196,6 +196,27 @@ export class ClaudeExtractor extends BaseExtractor {
   }
 
   /**
+   * Highest `data-index` currently mounted (issue #465).
+   *
+   * `data-index` is the virtual-row ordinal Claude assigns in conversation
+   * order and never renumbers, so a value above the one a sync covered can only
+   * mean a turn was added — scrolling up mounts *smaller* indices, never larger.
+   */
+  getMessageWatermark(): number | null {
+    // Scoped to the thread scroller: `[data-index]` is a bare attribute
+    // selector and Claude's own chrome virtualizes lists too, so a sidebar row
+    // would otherwise raise the watermark and clear the badge for a scroll.
+    const root = this.queryWithFallback<HTMLElement>(SELECTORS.scrollContainer) ?? document;
+    let highest: number | null = null;
+    this.queryAllWithFallback<HTMLElement>(SELECTORS.conversationRow, root).forEach(row => {
+      const index = Number(row.getAttribute('data-index'));
+      if (!Number.isFinite(index)) return;
+      if (highest === null || index > highest) highest = index;
+    });
+    return highest;
+  }
+
+  /**
    * Harvest the currently-mounted window as keyed messages.
    *
    * The key is the virtual-row `data-index` (stable per turn across windows),

--- a/src/content/message-watcher.ts
+++ b/src/content/message-watcher.ts
@@ -1,0 +1,69 @@
+/**
+ * New-message watcher for the sync-status badge (issue #465, ADR-036).
+ *
+ * Answers one question: has the conversation grown past what the last sync
+ * covered? On Claude and ChatGPT every turn carries a conversation-wide ordinal
+ * that is monotonic and never renumbered, so an ordinal ABOVE the synced one is
+ * proof of a new turn — while scrolling, which mounts and unmounts turns
+ * constantly, can only ever surface ordinals at or below it.
+ *
+ * Platforms without such an ordinal supply no baseline, and this watcher then
+ * does nothing at all: a badge that clears itself for a scroll would be worse
+ * than one that lingers.
+ */
+
+import { NEW_MESSAGE_POLL_INTERVAL } from '../lib/constants';
+import type { StopWatching } from './conversation-watcher';
+
+/**
+ * Start watching for a turn newer than the one a sync covered.
+ *
+ * `syncedWatermark` comes from the extraction itself
+ * ({@link import('../lib/types').ConversationData.messageWatermark}), never
+ * from a DOM read after the sync: the auto-scroll pass ends pinned at the top
+ * of the conversation, where the newest turn is unmounted.
+ *
+ * Fires at most once, then stops polling — the badge it invalidates is gone.
+ */
+export function startNewMessageWatcher(params: {
+  /** Ordinal the sync covered. Null/undefined disarms the watcher entirely. */
+  syncedWatermark: number | null | undefined;
+  /** Highest ordinal currently mounted, e.g. `extractor.getMessageWatermark()`. */
+  getWatermark: () => number | null;
+  /** Called once, with the ordinal that proved a new turn arrived. */
+  onNewMessage: (watermark: number) => void;
+  intervalMs?: number;
+}): StopWatching {
+  const {
+    syncedWatermark,
+    getWatermark,
+    onNewMessage,
+    intervalMs = NEW_MESSAGE_POLL_INTERVAL,
+  } = params;
+
+  if (syncedWatermark === null || syncedWatermark === undefined) {
+    return () => {};
+  }
+
+  const timer = setInterval(() => {
+    const watermark = readWatermark(getWatermark);
+    // null marks "nothing mounted / read failed", which says nothing about
+    // whether a message arrived. Equal or lower is the user scrolling.
+    if (watermark === null || watermark <= syncedWatermark) return;
+
+    clearInterval(timer);
+    onNewMessage(watermark);
+  }, intervalMs);
+
+  return () => clearInterval(timer);
+}
+
+/** The current ordinal, or null when the DOM could not be read. */
+function readWatermark(getWatermark: () => number | null): number | null {
+  try {
+    return getWatermark();
+  } catch (error) {
+    console.debug('[G2O] Message watermark read failed:', error);
+    return null;
+  }
+}

--- a/src/content/sync-status.ts
+++ b/src/content/sync-status.ts
@@ -14,9 +14,11 @@ export type SyncStatusKind = 'success' | 'partial' | 'error';
 /**
  * The result of the **last** sync attempt.
  *
- * Deliberately NOT "is this conversation up to date": new messages added after
- * a sync do not clear the badge (Phase 3 of the #458 plan was not implemented),
- * so the UI must present this as a point-in-time record and always show `at`.
+ * Still a point-in-time record, not a claim that the conversation is current:
+ * the badge is invalidated when a newer turn appears on a platform that exposes
+ * a conversation-wide ordinal (#465, ADR-036), but the three platforms without
+ * one keep a badge that can outlive the state it describes. Every rendering
+ * path therefore states `at`.
  */
 export interface SyncStatus {
   readonly kind: SyncStatusKind;
@@ -27,6 +29,11 @@ export interface SyncStatus {
    * derive one (e.g. a brand-new chat that has no id yet).
    */
   readonly conversationKey: string | null;
+  /**
+   * Ordinal of the newest turn the sync covered, or null when the platform
+   * exposes none. The baseline for "a newer message has appeared" (issue #465).
+   */
+  readonly messageWatermark: number | null;
   /** Name the note was actually saved under, when a destination reported one. */
   readonly fileName?: string;
   readonly results: readonly OutputResult[];
@@ -53,9 +60,11 @@ export function buildSyncStatus(params: {
   fileName: string;
   warnings?: readonly string[];
   conversationKey: string | null;
+  /** `ConversationData.messageWatermark` from the extraction that was saved. */
+  messageWatermark?: number;
   at: Date;
 }): SyncStatus {
-  const { saveResult, fileName, warnings = [], conversationKey, at } = params;
+  const { saveResult, fileName, warnings = [], conversationKey, messageWatermark, at } = params;
 
   // `allSuccessful` is vacuously true for an empty result set, so anySuccessful
   // is checked first: nothing ran means nothing succeeded.
@@ -74,6 +83,7 @@ export function buildSyncStatus(params: {
     kind,
     at,
     conversationKey,
+    messageWatermark: messageWatermark ?? null,
     fileName: savedAs ?? fileName,
     results: saveResult.results,
     warnings: [...destinationWarnings, ...warnings],
@@ -98,6 +108,8 @@ export function buildFailedSyncStatus(params: {
     kind: 'error',
     at: params.at,
     conversationKey: params.conversationKey,
+    // Nothing was extracted, so there is no ordinal to trust (issue #465).
+    messageWatermark: null,
     results: [],
     warnings: [],
     error: params.error,
@@ -122,9 +134,10 @@ export interface StatusAge {
 /**
  * Describe how long ago a sync happened.
  *
- * The badge deliberately does not claim the conversation is up to date — new
- * messages do not clear it — so the detail panel always states the age and the
- * user can judge for themselves.
+ * The badge reports a sync, not that the conversation is up to date — on
+ * Gemini, Perplexity and Notebook nothing invalidates it but a navigation
+ * (ADR-036) — so the detail panel always states the age and the user can judge
+ * for themselves.
  */
 export function describeAge(at: Date, now: Date): StatusAge {
   const minutes = Math.floor((now.getTime() - at.getTime()) / 60_000);

--- a/src/content/ui-badge.ts
+++ b/src/content/ui-badge.ts
@@ -3,11 +3,12 @@
  *
  * A toast that disappears after five seconds is invisible to anyone who
  * started a long sync and looked away — which is the whole complaint in #458.
- * The badge stays until the conversation changes or the user dismisses it.
+ * The badge stays until the conversation changes, a message newer than the sync
+ * appears (#465, ADR-036), or the user dismisses it.
  *
- * It reports the result of the LAST sync, not that the conversation is up to
- * date: adding messages afterwards does not clear it, so every rendering path
- * here states the age.
+ * It reports the result of the LAST sync, never that the conversation is up to
+ * date — the three platforms with no conversation-wide ordinal cannot detect a
+ * new message at all — so every rendering path here states the age.
  */
 
 import { getMessage } from '../lib/i18n';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -166,6 +166,17 @@ export const MUTATION_DEBOUNCE_DELAY = 100;
  */
 export const CONVERSATION_POLL_INTERVAL = 1000;
 
+/**
+ * How often the sync-status badge checks whether the conversation grew past the
+ * sync it reports (milliseconds).
+ *
+ * One `querySelectorAll` over the *mounted* window per tick — a few dozen nodes
+ * on Claude and ChatGPT, which virtualize — and only while a badge is on screen
+ * (ADR-036). A MutationObserver would fire on every streamed token instead, and
+ * would still have to re-read the ordinal afterwards.
+ */
+export const NEW_MESSAGE_POLL_INTERVAL = 1000;
+
 // ============================================================
 // Security Constants
 // ============================================================

--- a/src/lib/scroll-manager.ts
+++ b/src/lib/scroll-manager.ts
@@ -332,6 +332,16 @@ export interface AccumulateResult<T> {
   skipped: boolean;
   /** Which deadline ended the pass, or 'complete' (ADR-032). */
   stopReason: ScrollStopReason;
+  /**
+   * Highest {@link HarvestEntry.order} seen in any window, i.e. the ordinal of
+   * the newest turn this pass covered. Undefined when no turn carried one.
+   *
+   * Reported because the pass ends pinned at the *top* of the conversation, so
+   * the newest turn is unmounted by then and its ordinal cannot be re-read from
+   * the DOM afterwards. The sync-status badge needs it as the baseline for
+   * "a message newer than the one I synced has appeared" (issue #465).
+   */
+  maxOrder?: number;
 }
 
 /**
@@ -454,6 +464,7 @@ export async function accumulateWhileScrolling<T>(
       iterations: 0,
       skipped: true,
       stopReason: 'complete',
+      maxOrder: acc.maxOrder,
     };
   }
 
@@ -481,6 +492,7 @@ export async function accumulateWhileScrolling<T>(
     iterations,
     skipped: false,
     stopReason,
+    maxOrder: acc.maxOrder,
   };
 }
 
@@ -489,6 +501,7 @@ function createAccumulator<T>(harvest: () => HarvestEntry<T>[]): {
   ingest: () => void;
   toItems: () => T[];
   readonly size: number;
+  readonly maxOrder: number | undefined;
 } {
   const content = new Map<string, T>();
   const orderIndex = new Map<string, number>();
@@ -509,6 +522,13 @@ function createAccumulator<T>(harvest: () => HarvestEntry<T>[]): {
     toItems: () => resolveOrder(order, orderIndex).map(key => content.get(key) as T),
     get size() {
       return content.size;
+    },
+    get maxOrder() {
+      let max: number | undefined;
+      for (const value of orderIndex.values()) {
+        if (max === undefined || value > max) max = value;
+      }
+      return max;
     },
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,15 @@ export interface ConversationData {
   metadata: ConversationMetadata;
   /** Auto-scroll stopped early, so earlier messages may be missing (#449). */
   truncated?: boolean;
+  /**
+   * Ordinal of the newest turn this extraction covered, on platforms that
+   * expose a conversation-wide monotonic ordinal (Claude's `data-index`,
+   * ChatGPT's `conversation-turn-N`). Undefined elsewhere.
+   *
+   * The sync-status badge compares it against the live DOM to tell "a message
+   * newer than the sync has appeared" from "the user scrolled" (issue #465).
+   */
+  messageWatermark?: number;
 }
 
 /**
@@ -395,4 +404,13 @@ export interface IConversationExtractor {
   extractMessages(): ConversationMessage[];
   validate(result: ExtractionResult): ValidationResult;
   applySettings(settings: SyncSettings): void;
+  /**
+   * Highest conversation-wide turn ordinal currently in the DOM, or null when
+   * the platform exposes no such ordinal.
+   *
+   * A *mounted*-window read: on virtualized platforms it drops as turns evict
+   * and rises again as they re-mount, so it is only ever meaningful compared
+   * against {@link ConversationData.messageWatermark} (issue #465).
+   */
+  getMessageWatermark(): number | null;
 }

--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -12,6 +12,7 @@ import {
   clearFixture,
   createGeminiConversationDOM,
   setGeminiLocation,
+  setClaudeLocation,
   setNonGeminiLocation,
   resetLocation,
 } from '../fixtures/dom-helpers';
@@ -29,7 +30,10 @@ vi.mock('../../src/lib/messaging', () => ({
   sendMessage: vi.fn(),
 }));
 
-const watcherState = vi.hoisted(() => ({ stops: [] as Array<() => void> }));
+const watcherState = vi.hoisted(() => ({
+  stops: [] as Array<() => void>,
+  messageStops: [] as Array<() => void>,
+}));
 
 vi.mock('../../src/content/ui-badge', () => ({
   showSyncBadge: vi.fn(),
@@ -40,6 +44,14 @@ vi.mock('../../src/content/conversation-watcher', () => ({
   startConversationWatcher: vi.fn(() => {
     const stop = vi.fn();
     watcherState.stops.push(stop);
+    return stop;
+  }),
+}));
+
+vi.mock('../../src/content/message-watcher', () => ({
+  startNewMessageWatcher: vi.fn(() => {
+    const stop = vi.fn();
+    watcherState.messageStops.push(stop);
     return stop;
   }),
 }));
@@ -55,6 +67,7 @@ import {
 import { sendMessage } from '../../src/lib/messaging';
 import { showSyncBadge, clearSyncBadge } from '../../src/content/ui-badge';
 import { startConversationWatcher } from '../../src/content/conversation-watcher';
+import { startNewMessageWatcher } from '../../src/content/message-watcher';
 import {
   initialize,
   handleSync,
@@ -124,6 +137,7 @@ describe('content/bootstrap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     watcherState.stops.length = 0;
+    watcherState.messageStops.length = 0;
   });
 
   afterEach(() => {
@@ -484,6 +498,7 @@ describe('sync status badge wiring (issue #458)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     watcherState.stops.length = 0;
+    watcherState.messageStops.length = 0;
   });
 
   afterEach(() => {
@@ -561,5 +576,125 @@ describe('sync status badge wiring (issue #458)', () => {
 
     expect(watcherState.stops[0]).toHaveBeenCalled();
     expect(startConversationWatcher).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Claude is the platform with a conversation-wide ordinal (`data-index`), so
+ * the new-message half of the badge lifetime is exercised there.
+ */
+function loadClaudeConversation(turns = 4): void {
+  setClaudeLocation('1fbb8252-2bec-4ef2-bf1f-88393dd9bb5f');
+  const rows = Array.from({ length: turns }, (_, i) => {
+    const body =
+      i % 2 === 0
+        ? '<div class="bg-bg-300 rounded-xl"><div data-testid="user-message">Q</div></div>'
+        : '<div class="font-claude-response"><div class="standard-markdown"><p>A</p></div></div>';
+    return `<div data-index="${i}"><div data-test-render-count="2">${body}</div></div>`;
+  }).join('');
+  loadFixture(rows);
+}
+
+describe('badge invalidation on new messages (issue #465)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    watcherState.stops.length = 0;
+    watcherState.messageStops.length = 0;
+  });
+
+  afterEach(() => {
+    clearFixture();
+    resetLocation();
+  });
+
+  it('watches from the ordinal the sync covered, not from a post-sync DOM read', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+
+    await handleSync();
+
+    expect(startNewMessageWatcher).toHaveBeenCalledTimes(1);
+    const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
+    expect(params.syncedWatermark).toBe(3);
+    expect(params.getWatermark()).toBe(3);
+  });
+
+  it('reads the live DOM on every tick', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+    await handleSync();
+
+    const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
+    loadClaudeConversation(6); // the user asked a follow-up
+
+    expect(params.getWatermark()).toBe(5);
+  });
+
+  it('clears the badge and stops both watchers once a newer message appears', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+    await handleSync();
+
+    const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
+    params.onNewMessage(4);
+
+    expect(clearSyncBadge).toHaveBeenCalledTimes(1);
+    expect(watcherState.stops[0]).toHaveBeenCalled();
+    expect(watcherState.messageStops[0]).toHaveBeenCalled();
+  });
+
+  it('stops the new-message watcher when the conversation changes', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+    await handleSync();
+
+    const [params] = vi.mocked(startConversationWatcher).mock.calls[0];
+    params.onChanged(null);
+
+    expect(watcherState.messageStops[0]).toHaveBeenCalled();
+  });
+
+  it('stops the new-message watcher when the user dismisses the badge', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+    await handleSync();
+
+    const [, handlers] = vi.mocked(showSyncBadge).mock.calls[0];
+    handlers?.onDismiss?.();
+
+    expect(watcherState.messageStops[0]).toHaveBeenCalled();
+  });
+
+  it('does not leave the previous new-message watcher running after a second sync', async () => {
+    mockMessaging({});
+    loadClaudeConversation(4);
+
+    await handleSync();
+    await handleSync();
+
+    expect(watcherState.messageStops[0]).toHaveBeenCalled();
+    expect(startNewMessageWatcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('arms nothing on a platform without a conversation-wide ordinal', async () => {
+    // Gemini: a turn count grows when the user scrolls UP, so there is no
+    // trustworthy baseline and the badge keeps its pre-#465 behaviour.
+    mockMessaging({});
+    loadGeminiConversation();
+
+    await handleSync();
+
+    const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
+    expect(params.syncedWatermark).toBeNull();
+  });
+
+  it('arms nothing when the sync failed before anything was extracted', async () => {
+    mockMessaging({ connection: { success: false, error: 'Cannot connect to Obsidian' } });
+    loadClaudeConversation(4);
+
+    await handleSync();
+
+    const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
+    expect(params.syncedWatermark).toBeNull();
   });
 });

--- a/test/content/message-watcher.test.ts
+++ b/test/content/message-watcher.test.ts
@@ -1,0 +1,201 @@
+/**
+ * New-message watcher tests (issue #465).
+ *
+ * The badge reports the last sync, so it must disappear as soon as the
+ * conversation has grown past what that sync covered. The hard part is telling
+ * "a turn was added" from "the user scrolled" on a virtualized page, where
+ * turns mount and unmount constantly: only an ordinal ABOVE the synced one is
+ * proof of a new message.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { startNewMessageWatcher } from '../../src/content/message-watcher';
+
+describe('startNewMessageWatcher', () => {
+  let stop: (() => void) | undefined;
+
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    stop?.();
+    stop = undefined;
+    vi.useRealTimers();
+  });
+
+  it('does not fire while the conversation stays at the synced ordinal', () => {
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => 12,
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(onNewMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not fire while the user scrolls up through older turns', () => {
+    // Virtualization: scrolling up evicts the newest turns, so the mounted
+    // maximum FALLS. A drop is never a new message.
+    const mounted = [12, 9, 6, 3, 0];
+    let tick = 0;
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => mounted[Math.min(tick++, mounted.length - 1)],
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(onNewMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when the user scrolls back down to the synced turn', () => {
+    // Coming back to the bottom re-mounts the tail, so the reading returns to
+    // exactly the synced ordinal. Equal is not greater.
+    const mounted = [3, 6, 9, 12, 12];
+    let tick = 0;
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => mounted[Math.min(tick++, mounted.length - 1)],
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(onNewMessage).not.toHaveBeenCalled();
+  });
+
+  it('fires once a turn newer than the sync appears', () => {
+    let watermark = 12;
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => watermark,
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(3000);
+    expect(onNewMessage).not.toHaveBeenCalled();
+
+    watermark = 13; // the user asked a follow-up question
+    vi.advanceTimersByTime(1000);
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+    expect(onNewMessage).toHaveBeenCalledWith(13);
+  });
+
+  it('stops polling once it has fired', () => {
+    const getWatermark = vi.fn(() => 20);
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark,
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(1000);
+    const callsAtFire = getWatermark.mock.calls.length;
+    vi.advanceTimersByTime(10_000);
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+    expect(getWatermark).toHaveBeenCalledTimes(callsAtFire);
+  });
+
+  it('never polls when the sync produced no watermark', () => {
+    // Gemini, Perplexity, Notebook, and any failed sync: with no trustworthy
+    // baseline the badge must behave exactly as it did before #465 rather than
+    // guess. Not even a timer is armed.
+    const getWatermark = vi.fn(() => 99);
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: null,
+      getWatermark,
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(getWatermark).not.toHaveBeenCalled();
+    expect(onNewMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps watching when the ordinal cannot be read', () => {
+    // Mid-navigation, or a window with no mounted rows: an unreadable DOM says
+    // nothing about whether a message arrived.
+    const readings: Array<number | null> = [null, null, 13];
+    let tick = 0;
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => readings[Math.min(tick++, readings.length - 1)],
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(3000);
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a read that throws', () => {
+    let shouldThrow = true;
+    const onNewMessage = vi.fn();
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => {
+        if (shouldThrow) throw new Error('extractor blew up mid-navigation');
+        return 13;
+      },
+      onNewMessage,
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(onNewMessage).not.toHaveBeenCalled();
+
+    shouldThrow = false;
+    vi.advanceTimersByTime(1000);
+
+    expect(onNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling when stopped', () => {
+    const getWatermark = vi.fn(() => 12);
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark,
+      onNewMessage: vi.fn(),
+      intervalMs: 1000,
+    });
+
+    vi.advanceTimersByTime(2000);
+    const before = getWatermark.mock.calls.length;
+    stop();
+    vi.advanceTimersByTime(10_000);
+
+    expect(getWatermark).toHaveBeenCalledTimes(before);
+  });
+
+  it('is safe to stop more than once', () => {
+    stop = startNewMessageWatcher({
+      syncedWatermark: 12,
+      getWatermark: () => 12,
+      onNewMessage: vi.fn(),
+      intervalMs: 1000,
+    });
+
+    expect(() => {
+      stop?.();
+      stop?.();
+    }).not.toThrow();
+  });
+});

--- a/test/content/sync-status.test.ts
+++ b/test/content/sync-status.test.ts
@@ -223,3 +223,41 @@ describe('buildFailedSyncStatus', () => {
     expect(status.at).toBe(AT);
   });
 });
+
+describe('sync watermark (issue #465)', () => {
+  it('records the ordinal the sync covered', () => {
+    const status = buildSyncStatus({
+      saveResult: response([{ destination: 'obsidian', success: true }]),
+      fileName: 'note.md',
+      conversationKey: 'conv-1',
+      messageWatermark: 42,
+      at: AT,
+    });
+
+    expect(status.messageWatermark).toBe(42);
+  });
+
+  it('records null when the platform exposes no ordinal', () => {
+    const status = buildSyncStatus({
+      saveResult: response([{ destination: 'obsidian', success: true }]),
+      fileName: 'note.md',
+      conversationKey: 'conv-1',
+      messageWatermark: undefined,
+      at: AT,
+    });
+
+    expect(status.messageWatermark).toBeNull();
+  });
+
+  it('records null for a sync that never reached a destination', () => {
+    // Nothing was extracted, so there is no ordinal to trust: the badge keeps
+    // its pre-#465 behaviour and waits for a conversation change.
+    const status = buildFailedSyncStatus({
+      error: 'Cannot connect to Obsidian',
+      conversationKey: 'conv-1',
+      at: AT,
+    });
+
+    expect(status.messageWatermark).toBeNull();
+  });
+});

--- a/test/content/ui-badge.test.ts
+++ b/test/content/ui-badge.test.ts
@@ -17,6 +17,7 @@ function status(overrides: Partial<SyncStatus> = {}): SyncStatus {
     kind: 'success',
     at: AT,
     conversationKey: 'conv-1',
+    messageWatermark: null,
     fileName: 'my-note.md',
     results: [{ destination: 'obsidian', success: true }] as OutputResult[],
     warnings: [],

--- a/test/extractors/base.test.ts
+++ b/test/extractors/base.test.ts
@@ -623,3 +623,15 @@ describe('BaseExtractor.applySettings — shared settings reach every platform',
     expect(extractor.deadlines()).toEqual({ idleMs: 15_000, maxMs: 300_000 });
   });
 });
+
+describe('BaseExtractor.getMessageWatermark (issue #465)', () => {
+  it('is null by default, because most platforms expose no monotonic ordinal', () => {
+    // Gemini lazy-loads OLDER turns when the user scrolls up (its
+    // infinite-scroller fires onScrolledTopPastThreshold), so a turn count grows
+    // with no new message. Until a platform has a signal that only ever grows
+    // with the conversation, its badge must behave exactly as it does today.
+    const extractor = new TestExtractor();
+
+    expect(extractor.getMessageWatermark()).toBeNull();
+  });
+});

--- a/test/extractors/chatgpt-autoscroll.test.ts
+++ b/test/extractors/chatgpt-autoscroll.test.ts
@@ -215,3 +215,83 @@ describe('ChatGPTExtractor auto-scroll (virtualization)', () => {
     expect(container).not.toBeNull();
   });
 });
+
+describe('ChatGPTExtractor message watermark (issue #465)', () => {
+  let extractor: ChatGPTExtractor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    extractor = new ChatGPTExtractor();
+    setChatGPTLocation('6789abcd-ef01-2345-6789-abcdef012345');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearFixture();
+    resetLocation();
+  });
+
+  it('reads the highest mounted conversation-turn ordinal', () => {
+    document.body.innerHTML = [
+      { role: 'user' as const, content: 'Q9', id: 'a', ordinal: 17 },
+      { role: 'assistant' as const, content: 'A9', id: 'b', ordinal: 18 },
+    ]
+      .map(renderTurn)
+      .join('');
+
+    expect(extractor.getMessageWatermark()).toBe(18);
+  });
+
+  it('ignores turns outside the thread scroller', () => {
+    // The sidebar <nav> matches loose overflow selectors and has its own list;
+    // only the thread scroller may raise the watermark.
+    document.body.innerHTML = `
+      <nav id="sidebar">${renderTurn({ role: 'user', content: 'old', id: 'z', ordinal: 99 })}</nav>
+      <div data-scroll-root="" id="scroller">
+        ${renderTurn({ role: 'user', content: 'Q', id: 'a', ordinal: 5 })}
+      </div>`;
+
+    expect(extractor.getMessageWatermark()).toBe(5);
+  });
+
+  it('is null when no turn carries a conversation-turn testid', () => {
+    document.body.innerHTML = renderTurn({ role: 'user', content: 'Q1', id: 'a' });
+
+    expect(extractor.getMessageWatermark()).toBeNull();
+  });
+
+  it('reports the ordinal of the newest turn the extraction covered', async () => {
+    const long: Turn[] = Array.from({ length: 12 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      content: `M${i + 1}`,
+      id: `turn-${i}`,
+      ordinal: i + 1,
+    }));
+    mountVirtualizedChatGPT(long, 4);
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data?.messageWatermark).toBe(12);
+  });
+
+  it('leaves the watermark unset when the platform exposes no ordinal', async () => {
+    // Turns without `conversation-turn-N`: the badge must stay as it is today
+    // rather than invalidate on a number it cannot trust.
+    const long: Turn[] = Array.from({ length: 8 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      content: `M${i + 1}`,
+      id: `turn-${i}`,
+    }));
+    mountVirtualizedChatGPT(long, 4);
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data?.messageWatermark).toBeUndefined();
+  });
+});

--- a/test/extractors/claude-autoscroll.test.ts
+++ b/test/extractors/claude-autoscroll.test.ts
@@ -171,3 +171,92 @@ describe('ClaudeExtractor auto-scroll (virtualization)', () => {
     expect(warning).toContain('turns captured');
   });
 });
+
+describe('ClaudeExtractor message watermark (issue #465)', () => {
+  let extractor: ClaudeExtractor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    extractor = new ClaudeExtractor();
+    setClaudeLocation('1fbb8252-2bec-4ef2-bf1f-88393dd9bb5f');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearFixture();
+    resetLocation();
+  });
+
+  const conversation: Turn[] = [
+    { role: 'user', content: 'Q1' },
+    { role: 'assistant', content: 'A1' },
+    { role: 'user', content: 'Q2' },
+    { role: 'assistant', content: 'A2' },
+    { role: 'user', content: 'Q3' },
+    { role: 'assistant', content: 'A3' },
+  ];
+
+  it('reads the highest mounted data-index', () => {
+    mountVirtualizedClaude(conversation, 6);
+
+    expect(extractor.getMessageWatermark()).toBe(5);
+  });
+
+  it('reads only what is mounted, so a window near the top reports a low ordinal', () => {
+    // This is why the badge baseline cannot be a post-sync DOM read: the pass
+    // leaves the scroller at the top, where the newest turn is unmounted.
+    document.body.innerHTML =
+      '<div data-index="0"></div><div data-index="1"></div><div data-index="2"></div>';
+
+    expect(extractor.getMessageWatermark()).toBe(2);
+  });
+
+  it('ignores data-index rows outside the conversation scroller', () => {
+    // `[data-index]` is a bare attribute selector, and Claude's own chrome uses
+    // virtualized lists too. A sidebar row must never raise the watermark, or
+    // scrolling the sidebar would clear the badge.
+    document.body.innerHTML = `
+      <nav id="sidebar"><div data-index="99"></div></nav>
+      <div class="overflow-y-auto overflow-x-hidden flex-1">
+        <div data-index="2"></div><div data-index="3"></div>
+      </div>`;
+
+    expect(extractor.getMessageWatermark()).toBe(3);
+  });
+
+  it('is null when no virtual row is mounted', () => {
+    document.body.innerHTML = '<div class="font-claude-response">no wrapper</div>';
+
+    expect(extractor.getMessageWatermark()).toBeNull();
+  });
+
+  it('ignores rows whose data-index is not a number', () => {
+    document.body.innerHTML = '<div data-index="4"></div><div data-index="header"></div>';
+
+    expect(extractor.getMessageWatermark()).toBe(4);
+  });
+
+  it('reports the ordinal of the newest turn the extraction covered', async () => {
+    mountVirtualizedClaude(conversation, 3); // ends pinned at the top
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data?.messageWatermark).toBe(5);
+    // ...and the DOM alone could not have told us: the pass ended at the top.
+    expect(extractor.getMessageWatermark()).toBeLessThan(5);
+  });
+
+  it('falls back to the mounted window when auto-scroll is off', async () => {
+    mountVirtualizedClaude(conversation, 3);
+    extractor.applySettings(settings({ enableAutoScroll: false }));
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.data?.messageWatermark).toBe(5);
+  });
+});

--- a/test/lib/scroll-manager.test.ts
+++ b/test/lib/scroll-manager.test.ts
@@ -710,3 +710,51 @@ describe('scroll stop reason', () => {
     expect(result.iterations).toBeLessThan(45);
   });
 });
+
+describe('accumulateWhileScrolling — highest ordinal covered by the pass (issue #465)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('reports the highest order seen across every window', async () => {
+    // The badge needs the ordinal of the LAST turn of the conversation, and the
+    // pass ends pinned at the TOP — so the number cannot be re-read from the DOM
+    // afterwards. It has to be carried out of the accumulation that saw it.
+    const { container, harvest } = createPersistentTailList({
+      total: 20,
+      movingWindow: 6,
+      tail: 3,
+    });
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.itemCount).toBe(20);
+    expect(result.maxOrder).toBe(19);
+  });
+
+  it('reports the highest order for a conversation that fits without scrolling', async () => {
+    // seedAtBottom() ends the pass immediately, so the single seeded window is
+    // the only place the ordinal can come from.
+    const { container, harvest } = createRecordedWindowList([[1, 2, 3]], true);
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.maxOrder).toBe(3);
+  });
+
+  it('is undefined when no harvested turn carries an order', async () => {
+    // ChatGPT before `conversation-turn-N`, or any DOM where the ordinal is
+    // unreadable: an absent watermark must stay absent rather than default to 0,
+    // which would make every later window look like a new message.
+    const { container, harvest } = createRecordedWindowList(TURN_WINDOWS);
+
+    const promise = accumulateWhileScrolling(container, harvest);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.maxOrder).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #465.

## Summary

The sync-status badge (ADR-034) reported the last sync and nothing invalidated it when the conversation grew, so a `✓` covering half a conversation looked identical to one covering all of it.

- **New `src/content/message-watcher.ts`** — polls the highest mounted turn ordinal while a badge is on screen and fires **once**, only on a value *strictly greater* than the one the sync covered. Stops permanently after firing.
- **Ordinal, not count.** Claude's `data-index` and ChatGPT's `conversation-turn-N` are conversation-wide and never renumbered (#352/#353), so scrolling can only ever surface ordinals at or below the synced one. A count lies on every platform: Gemini lazy-loads *older* turns on upward scroll (`infinite-scroller` / `onScrolledTopPastThreshold`), and Claude/ChatGPT mount and unmount turns constantly (ADR-017).
- **The baseline comes from the extraction, not the DOM.** `accumulateWhileScrolling()` ends pinned at `scrollTop = 0`, so a post-sync read of a 120-turn chat reports ~5 and the badge would clear the moment the user scrolled back down. The accumulator now reports `maxOrder` → `ConversationData.messageWatermark` → `SyncStatus.messageWatermark`.
- **Scoped to the thread scroller.** `[data-index]` is a bare attribute selector and both platforms virtualize their sidebars; a RED test proved an unscoped read returned **99** from a sidebar row instead of 3.
- **`bootstrap.ts`**: `presentSyncStatus()` composes the conversation watcher and the new-message watcher into one `stopBadgeWatchers`, so dismiss / navigation / new message / a second sync each stop both.
- Gemini, Perplexity and Gemini Notebook report `null` and arm no timer at all — unchanged behaviour, as does a sync that failed before extracting anything. Same for **ADR-036** (new) and the pointer added to ADR-034.

## Test plan

- [x] `npm run test` — 2238 passed (87 files), +39 new tests
- [x] `npm run build` (`tsc --noEmit`) — clean
- [x] `npm run lint` — 0 errors, 3 warnings (identical to `main`, verified by stashing)
- [x] `npm run format:check` — clean
- [x] `npm run lint:platforms` — 8/8 consistent
- [x] Coverage 96.6 / 87.52 / 99.1 / 97.72 vs. thresholds 95/85/95/95; `message-watcher.ts` at 13/13 lines, 9/9 branches
- [x] Manual smoke on live Claude and ChatGPT: sync, scroll up and back down (badge must stay), then send a new message (badge must clear)
- [x] Manual smoke on Gemini: badge must survive new messages exactly as it does today

🤖 Generated with [Claude Code](https://claude.com/claude-code)