### PR TITLE
refactor(test): consolidate per-platform HTML escape helpers

### DIFF
--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -428,7 +428,7 @@ export function createClaudeConversationDOM(messages: ClaudeConversationMessage[
         <div data-test-render-count="2" class="group" style="height: auto;">
           <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
             <div data-testid="user-message">
-              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(msg.content)}</p>
+              <p class="whitespace-pre-wrap break-words">${escapeHtml(msg.content)}</p>
             </div>
             <span class="text-text-500 text-xs" data-state="closed">Dec 6, 2025</span>
           </div>
@@ -480,7 +480,7 @@ export function createClaudeDeepResearchDOM(
   return `
     <div id="markdown-artifact" class="font-claude-response">
       <div class="standard-markdown">
-        <h1 class="text-text-100">${escapeHtmlForClaude(title)}</h1>
+        <h1 class="text-text-100">${escapeHtml(title)}</h1>
         ${contentWithCitations}
       </div>
     </div>
@@ -542,7 +542,7 @@ export function createClaudeInlineCitation(url: string, title: string): string {
   return `
     <span class="inline-flex">
       <a href="${url}" target="_blank" rel="noopener">
-        <span class="text-text-300">${escapeHtmlForClaude(title)}</span>
+        <span class="text-text-300">${escapeHtml(title)}</span>
       </a>
     </span>
   `;
@@ -591,15 +591,6 @@ export function createEmptyClaudeDeepResearchPanel(): string {
       </div>
     </div>
   `;
-}
-
-/**
- * Escape HTML entities for Claude DOM helpers
- */
-function escapeHtmlForClaude(text: string): string {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
 }
 
 /**
@@ -656,7 +647,7 @@ function createClaudeToolUseBlock(options: ToolUseGridOptions): string {
                     <div class="flex-1 min-w-0">
                       <button class="group/row flex flex-row items-center rounded-lg px-2.5 w-full justify-between text-text-300 !cursor-default">
                         <div class="flex flex-row items-center gap-2 min-w-0 flex-1">
-                          <div class="text-sm text-text-500 text-left truncate w-0 flex-grow">${escapeHtmlForClaude(options.searchQuery)}</div>
+                          <div class="text-sm text-text-500 text-left truncate w-0 flex-grow">${escapeHtml(options.searchQuery)}</div>
                         </div>
                         <div class="flex flex-row items-center gap-1.5 shrink-0">
                           <p class="pl-1 text-text-500 font-small shrink-0 whitespace-nowrap">${options.searchResultCount ?? 0} results</p>
@@ -674,8 +665,8 @@ function createClaudeToolUseBlock(options: ToolUseGridOptions): string {
                             r => `
                           <div class="flex flex-row gap-3 items-center px-2 py-1.5 w-full rounded-md cursor-pointer transition-colors hover:bg-bg-200">
                             <div class="flex-shrink-0"><img alt="favicon" loading="lazy" width="12" height="12" src="" /></div>
-                            <div class="w-0 flex-grow font-small text-text-300 truncate">${escapeHtmlForClaude(r.title)}</div>
-                            <div class="text-xs text-text-400 shrink-0">${escapeHtmlForClaude(r.domain)}</div>
+                            <div class="w-0 flex-grow font-small text-text-300 truncate">${escapeHtml(r.title)}</div>
+                            <div class="text-xs text-text-400 shrink-0">${escapeHtml(r.domain)}</div>
                           </div>`
                           )
                           .join('')}
@@ -695,7 +686,7 @@ function createClaudeToolUseBlock(options: ToolUseGridOptions): string {
         <div><div class="grid grid-rows-[auto_auto] min-w-0">
           <div class="row-start-1 col-start-1 min-w-0">
             <div class="min-w-0 pl-2 py-1.5">
-              <button class="group/status"><span class="truncate text-sm font-base">${escapeHtmlForClaude(options.summaryText)}</span></button>
+              <button class="group/status"><span class="truncate text-sm font-base">${escapeHtml(options.summaryText)}</span></button>
               ${searchQueryHtml}
               ${toolStepsHtml}
             </div>
@@ -733,7 +724,7 @@ export function createClaudePageWithToolUse(
         <div data-test-render-count="2" class="group" style="height: auto;">
           <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
             <div data-testid="user-message">
-              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(msg.content)}</p>
+              <p class="whitespace-pre-wrap break-words">${escapeHtml(msg.content)}</p>
             </div>
             <span class="text-text-500 text-xs" data-state="closed">Dec 6, 2025</span>
           </div>
@@ -809,7 +800,7 @@ function createClaudeThinkingStatusResponse(options: ThinkingStatusOptions): str
           <div class="flex items-center gap-2 rounded-lg">
             <button class="group/status flex items-center gap-2 py-1 text-sm" aria-expanded="false">
               <div class="inline-flex items-center gap-1 min-w-0">
-                <span class="truncate text-sm font-base">${escapeHtmlForClaude(options.statusText)}</span>
+                <span class="truncate text-sm font-base">${escapeHtml(options.statusText)}</span>
               </div>
             </button>
           </div>
@@ -850,7 +841,7 @@ export function createClaudePageWithThinkingStatus(
         <div data-test-render-count="2" class="group" style="height: auto;">
           <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
             <div data-testid="user-message">
-              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(msg.content)}</p>
+              <p class="whitespace-pre-wrap break-words">${escapeHtml(msg.content)}</p>
             </div>
           </div>
         </div>
@@ -913,7 +904,7 @@ export function createClaudePageWithMultiStatusResponse(
         <div class="row-start-1 col-start-1 min-w-0">
           <div class="min-w-0 pl-2 py-1.5">
             <button class="group/status" aria-expanded="false">
-              <span class="truncate font-base">${escapeHtmlForClaude(step.statusText)}</span>
+              <span class="truncate font-base">${escapeHtml(step.statusText)}</span>
             </button>
           </div>
         </div>
@@ -932,7 +923,7 @@ export function createClaudePageWithMultiStatusResponse(
         <div data-test-render-count="2" class="group" style="height: auto;">
           <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
             <div data-testid="user-message">
-              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(userContent)}</p>
+              <p class="whitespace-pre-wrap break-words">${escapeHtml(userContent)}</p>
             </div>
           </div>
         </div>
@@ -1003,7 +994,7 @@ export function createClaudePageWithMixedContentBlocks(
           <div class="min-w-0 pl-2 py-[var(--msg-pill-py,0.375rem)]">
             ${block.thinking ? '<div class="group/thinking border rounded">' : ''}
             <button class="group/status" aria-expanded="false">
-              <span class="truncate font-base">${escapeHtmlForClaude(block.statusText)}</span>
+              <span class="truncate font-base">${escapeHtml(block.statusText)}</span>
             </button>
             ${block.toolMarkdown ? `<div class="standard-markdown"><p>${block.toolMarkdown}</p></div>` : ''}
             ${block.thinking ? '</div>' : ''}
@@ -1039,7 +1030,7 @@ export function createClaudePageWithMixedContentBlocks(
         <div data-test-render-count="2" class="group" style="height: auto;">
           <div class="bg-bg-300 rounded-xl pl-2.5 py-2.5">
             <div data-testid="user-message">
-              <p class="whitespace-pre-wrap break-words">${escapeHtmlForClaude(userContent)}</p>
+              <p class="whitespace-pre-wrap break-words">${escapeHtml(userContent)}</p>
             </div>
           </div>
         </div>
@@ -1087,7 +1078,7 @@ export function createChatGPTConversationDOM(messages: ChatGPTConversationMessag
           <div data-message-author-role="user"
                data-message-id="${messageId}">
             <div class="whitespace-pre-wrap">
-              ${escapeHtmlForChatGPT(msg.content)}
+              ${escapeHtml(msg.content)}
             </div>
           </div>
         </section>
@@ -1185,7 +1176,7 @@ export function createChatGPTInlineCitation(url: string, displayText: string): s
            rel="noopener"
            class="flex h-4.5 overflow-hidden rounded-xl px-2 text-[9px] font-medium">
           <span class="max-w-[15ch] grow truncate overflow-hidden text-center">
-            ${escapeHtmlForChatGPT(displayText)}
+            ${escapeHtml(displayText)}
           </span>
         </a>
       </span>
@@ -1207,15 +1198,6 @@ export function createChatGPTPage(
       ${createChatGPTConversationDOM(messages)}
     </div>
   `);
-}
-
-/**
- * Escape HTML entities for ChatGPT DOM helpers
- */
-function escapeHtmlForChatGPT(text: string): string {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
 }
 
 // ========== Perplexity DOM Helpers ==========
@@ -1243,7 +1225,7 @@ export function createPerplexityConversationDOM(messages: PerplexityConversation
       blocks.push(`
         <div class="group/query">
           <div class="bg-offset rounded-2xl">
-            <span class="select-text">${escapeHtmlForPerplexity(msg.content)}</span>
+            <span class="select-text">${escapeHtml(msg.content)}</span>
           </div>
         </div>
       `);
@@ -1320,7 +1302,7 @@ function perplexityPillBody(domainText: string, extraCount?: number): string {
     extraCount === undefined
       ? ''
       : `<span class="inline-block ml-xs mr-px"><span class="opacity-50">+${extraCount}</span></span>`;
-  return `<span class="relative -mt-px max-w-full min-w-0 whitespace-nowrap"><span class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer align-middle"><span class="inline-block relative overflow-hidden">${escapeHtmlForPerplexity(domainText)}</span>${counter}</span></span>`;
+  return `<span class="relative -mt-px max-w-full min-w-0 whitespace-nowrap"><span class="text-3xs rounded-badge group min-w-4 max-w-full cursor-pointer align-middle"><span class="inline-block relative overflow-hidden">${escapeHtml(domainText)}</span>${counter}</span></span>`;
 }
 
 /** Wrap pill content in the modern data-pplx-citation-url carrier span. */
@@ -1344,7 +1326,7 @@ export function createPerplexityInlineCitation(
   displayText: string,
   title?: string
 ): string {
-  const ariaAttr = title ? ` aria-label="${escapeHtmlForPerplexity(title)}"` : '';
+  const ariaAttr = title ? ` aria-label="${escapeHtml(title)}"` : '';
   const anchor = `<span class="inline-flex"${ariaAttr} data-state="closed"><span class="citation inline"><a rel="noopener" class="inline-flex max-w-full min-w-0" target="_blank" href="${url}">${perplexityPillBody(displayText)}</a></span></span>`;
   return perplexityCitationWrapper(url, anchor);
 }
@@ -1442,7 +1424,7 @@ function createPerplexityDeepResearchDOM(config: PerplexityDeepResearchConfig): 
                 <div class="group/title relative inline-flex flex-col">
                   <div class="group/query relative whitespace-pre-line">
                     <div class="min-w-[48px] select-none p-3 bg-subtle rounded-2xl">
-                      <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtmlForPerplexity(config.query)}</span>
+                      <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtml(config.query)}</span>
                     </div>
                   </div>
                 </div>
@@ -1462,7 +1444,7 @@ function createPerplexityDeepResearchDOM(config: PerplexityDeepResearchConfig): 
             <div class="border-subtlest flex items-center justify-between border-b px-3 py-2">
               <div class="flex items-center gap-1.5 min-w-0">
                 <svg role="img" class="inline-flex fill-current shrink-0 text-super shrink-0" width="16" height="16"><use xlink:href="#pplx-icon-telescope"></use></svg>
-                <span class="text-textMain truncate text-sm font-medium">${escapeHtmlForPerplexity(config.reportTitle)}</span>
+                <span class="text-textMain truncate text-sm font-medium">${escapeHtml(config.reportTitle)}</span>
               </div>
               <div class="flex items-center gap-1 shrink-0 ml-2 -mr-1">
                 <button>Download</button>
@@ -1534,7 +1516,7 @@ export function createPerplexityMultiTurnWithDeepResearch(
                   <div class="group/title relative inline-flex flex-col">
                     <div class="group/query relative whitespace-pre-line">
                       <div class="min-w-[48px] select-none p-3 bg-subtle rounded-2xl">
-                        <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtmlForPerplexity(config.firstQuery)}</span>
+                        <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtml(config.firstQuery)}</span>
                       </div>
                     </div>
                   </div>
@@ -1558,7 +1540,7 @@ export function createPerplexityMultiTurnWithDeepResearch(
                   <div class="group/title relative inline-flex flex-col">
                     <div class="group/query relative whitespace-pre-line">
                       <div class="min-w-[48px] select-none p-3 bg-subtle rounded-2xl">
-                        <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtmlForPerplexity(config.secondQuery)}</span>
+                        <span class="min-w-0 font-sans text-base text-foreground font-normal select-text break-words">${escapeHtml(config.secondQuery)}</span>
                       </div>
                     </div>
                   </div>
@@ -1576,7 +1558,7 @@ export function createPerplexityMultiTurnWithDeepResearch(
               <div class="border-subtlest flex items-center justify-between border-b px-3 py-2">
                 <div class="flex items-center gap-1.5 min-w-0">
                   <svg role="img" class="inline-flex fill-current shrink-0 text-super shrink-0" width="16" height="16"><use xlink:href="#pplx-icon-telescope"></use></svg>
-                  <span class="text-textMain truncate text-sm font-medium">${escapeHtmlForPerplexity(config.reportTitle)}</span>
+                  <span class="text-textMain truncate text-sm font-medium">${escapeHtml(config.reportTitle)}</span>
                 </div>
               </div>
               <div class="relative">
@@ -1599,15 +1581,6 @@ export function createPerplexityMultiTurnWithDeepResearch(
   `);
 }
 
-/**
- * Escape HTML entities for Perplexity DOM helpers
- */
-function escapeHtmlForPerplexity(text: string): string {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
 // ============================================================
 // NotebookLM Helpers
 // ============================================================
@@ -1618,15 +1591,6 @@ function escapeHtmlForPerplexity(text: string): string {
 interface NotebookLMConversationMessage {
   role: 'user' | 'assistant';
   content: string;
-}
-
-/**
- * Escape HTML for NotebookLM fixture safety
- */
-function escapeHtmlForNotebookLM(text: string): string {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
 }
 
 /**
@@ -1656,7 +1620,7 @@ function createNotebookLMConversationDOM(
               <mat-card-content class="mat-mdc-card-content from-user-message-inner-content message-content">
                 <div class="message-text-content mat-body-medium">
                   <div class="is-rich-chat-ui" role="heading" aria-level="3">
-                    <p>${escapeHtmlForNotebookLM(user.content)}</p>
+                    <p>${escapeHtml(user.content)}</p>
                   </div>
                 </div>
               </mat-card-content>
@@ -1698,7 +1662,7 @@ function createNotebookLMConversationDOM(
           <chat-panel-header>
             <div class="cover-image can-customize is-rich-chat-ui">
               <div class="cover-content">
-                <div class="cover-title mat-headline-medium">${escapeHtmlForNotebookLM(notebookTitle)}</div>
+                <div class="cover-title mat-headline-medium">${escapeHtml(notebookTitle)}</div>
               </div>
             </div>
           </chat-panel-header>


### PR DESCRIPTION
## Summary

`test/fixtures/dom-helpers.ts` carried **five** copies of the same three-line function: `escapeHtml`, plus `escapeHtmlForClaude`, `escapeHtmlForChatGPT`, `escapeHtmlForPerplexity` and `escapeHtmlForNotebookLM`. All four platform-suffixed bodies were byte-identical to the shared one already at the top of the file.

- All call sites now use the single `escapeHtml()`; the four duplicates are deleted.
- Test-fixture only — no `src/` change, so no effect on the shipped extension.

Net −36 lines in one file.

## Test plan

- [x] `npm run test` — 2240 passed (87 files), identical to `main`
- [x] `npm run build` (`tsc --noEmit`) — clean
- [x] `npm run lint` — 0 errors, 3 warnings (identical to `main`)
- [x] `npm run format:check` — clean
- [x] Rebased onto `main` at v2.10.3, so the numbers above are the post-merge state

🤖 Generated with [Claude Code](https://claude.com/claude-code)