### PR TITLE
refactor: drop export from symbols only used inside their own module

### DIFF
--- a/e2e/selectors/load-readiness.ts
+++ b/e2e/selectors/load-readiness.ts
@@ -48,7 +48,7 @@ export async function waitForReadyWithRetry(
   return false;
 }
 
-export type LoadAction = 'validate' | 'skip';
+type LoadAction = 'validate' | 'skip';
 
 export interface LoadDecision {
   readonly action: LoadAction;

--- a/e2e/selectors/notifier.ts
+++ b/e2e/selectors/notifier.ts
@@ -108,7 +108,7 @@ const AUTH_GUIDANCE: Readonly<Record<Exclude<AuthStatus, 'authenticated'>, strin
 };
 
 /** Short note for a transition back to a clean pass. */
-export function generateRecoveryMarkdown(report: ValidationReport): string {
+function generateRecoveryMarkdown(report: ValidationReport): string {
   const dateStr = report.timestamp.slice(0, 10);
   return [
     '---',
@@ -126,7 +126,7 @@ export function generateRecoveryMarkdown(report: ValidationReport): string {
   ].join('\n');
 }
 
-export function generateMarkdown(report: ValidationReport): string {
+function generateMarkdown(report: ValidationReport): string {
   const dateStr = report.timestamp.slice(0, 10);
   const lines: string[] = [
     '---',

--- a/src/content/extractors/footnotes.ts
+++ b/src/content/extractors/footnotes.ts
@@ -9,7 +9,7 @@
  * footnote syntax by the Turndown rules in markdown-rules.ts.
  */
 
-export const FOOTNOTE_REF_ATTR = 'data-footnote-ref';
+const FOOTNOTE_REF_ATTR = 'data-footnote-ref';
 
 export interface CitationTransformResult {
   /** HTML with citation elements replaced by footnote-ref placeholder spans. */
@@ -66,7 +66,7 @@ const HTML_ESCAPE_MAP: Record<string, string> = {
   "'": '&#39;',
 };
 
-export function escapeHtml(value: string): string {
+function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, ch => HTML_ESCAPE_MAP[ch] ?? ch);
 }
 

--- a/src/content/ui.ts
+++ b/src/content/ui.ts
@@ -243,7 +243,7 @@ let currentToast: HTMLDivElement | null = null;
 /**
  * Inject CSS styles into the page
  */
-export function injectStyles(): void {
+function injectStyles(): void {
   if (styleInjected) return;
 
   const style = document.createElement('style');

--- a/src/lib/append-utils.ts
+++ b/src/lib/append-utils.ts
@@ -31,7 +31,7 @@ import { formatDateWithTimezone } from './date-utils';
  * - `budget-exhausted` — the scan hit {@link SCAN_MAX_REQUESTS} first, so the
  *   note may well exist beyond the point the scan stopped.
  */
-export type LookupMissReason =
+type LookupMissReason =
   | 'no-candidate-suffix'
   | 'empty-directory'
   | 'no-candidate-file'

--- a/src/lib/code-fence.ts
+++ b/src/lib/code-fence.ts
@@ -25,7 +25,7 @@
 export const MIN_FENCE_LENGTH = 3;
 
 /** The two fence characters CommonMark permits. They cannot be mixed. */
-export type FenceChar = '`' | '~';
+type FenceChar = '`' | '~';
 
 /** Both fence characters, in the order they are probed. */
 const ALL_FENCE_CHARS: readonly FenceChar[] = ['`', '~'];

--- a/src/lib/frontmatter-parser.ts
+++ b/src/lib/frontmatter-parser.ts
@@ -17,7 +17,7 @@ export type LineEnding = '\r\n' | '\n' | '\r';
  * mixed-ending file ends up consistently on whichever style it opened with
  * rather than staying mixed.
  */
-export function detectLineEnding(content: string): LineEnding {
+function detectLineEnding(content: string): LineEnding {
   const match = /\r\n|\r|\n/.exec(content);
   return (match?.[0] as LineEnding | undefined) ?? '\n';
 }

--- a/src/lib/image-output.ts
+++ b/src/lib/image-output.ts
@@ -12,7 +12,7 @@ import { mimeToExtension } from './image-utils';
 import type { ExtractedImage } from './types';
 
 /** A resolved image ready to be written (vault) or downloaded (file). */
-export interface ResolvedImageFile {
+interface ResolvedImageFile {
   readonly fileName: string;
   readonly mimeType: string;
   /** Base64-encoded image bytes (no `data:` prefix). */


### PR DESCRIPTION
Phase 1 of the 2026-09-03 optimisation plan (export-surface trim). Follow-ups: knip adoption + `playwright` devDependency, fixture location helper, ADR-012 ratchet.

## Summary

- knip and an independent grep scan agreed on **10 symbols** that carry `export` but are never imported anywhere. None is dead code — each is used inside its own file — so only the keyword is removed. No declaration moves, no behaviour change.
- src/ (7): `FOOTNOTE_REF_ATTR`, `escapeHtml` (footnotes.ts), `injectStyles` (ui.ts), `detectLineEnding` (frontmatter-parser.ts), `LookupMissReason` (append-utils.ts), `FenceChar` (code-fence.ts), `ResolvedImageFile` (image-output.ts).
- e2e/ (3): `generateMarkdown`, `generateRecoveryMarkdown` (notifier.ts), `LoadAction` (load-readiness.ts).
- Kept exported: the 13 same-file types that appear in an exported signature (`AccumulateResult`, `StatusAge`, `SyncBadgeHandlers`, `PlatformInfo`, …) — consumers must be able to name them. `tsconfig` emits no declarations, so a non-exported `FenceChar` inside the exported `OpenFence` alias is legal.
- Test-only exports (ADR-015 entry-shim functions, constant tables) are deliberate and untouched.

## Test plan

- [x] `tsc --noEmit` (src) and `tsc -p e2e/tsconfig.json` — clean
- [x] `npm run test` — 2240 passed (87 files), unchanged
- [x] `npm run lint` — 0 errors, 3 warnings (identical to `main`; they are Phase 3's target)
- [x] `npm run format:check` — clean
- [x] knip after the change: **0 unused exports, 0 unused exported types** (was 4 + 4). The remaining knip lines — two CRXJS entry shims reported as unused files, and `playwright` unlisted — are addressed by the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Van9LpnGKc682CAB9P5J