### PR TITLE
refactor(test): build every location fixture on one defineLocation helper

### DIFF
--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -13,7 +13,7 @@ import {
   createGeminiConversationDOM,
   setGeminiLocation,
   setClaudeLocation,
-  setNonGeminiLocation,
+  defineLocation,
   resetLocation,
 } from '../fixtures/dom-helpers';
 
@@ -152,19 +152,19 @@ describe('content/bootstrap', () => {
     });
 
     it('returns null on unsupported hostnames', () => {
-      setNonGeminiLocation('example.com');
+      defineLocation('example.com');
       expect(getExtractor()).toBeNull();
     });
 
     it('rejects malicious subdomains embedding a platform hostname', () => {
-      setNonGeminiLocation('gemini.google.com.attacker.com');
+      defineLocation('gemini.google.com.attacker.com');
       expect(getExtractor()).toBeNull();
     });
   });
 
   describe('initialize', () => {
     it('skips initialization on unsupported pages', async () => {
-      setNonGeminiLocation('example.com');
+      defineLocation('example.com');
       await initialize();
       expect(injectSyncButton).not.toHaveBeenCalled();
     });
@@ -323,7 +323,7 @@ describe('content/bootstrap', () => {
     });
 
     it('shows an error on unsupported pages', async () => {
-      setNonGeminiLocation('example.com');
+      defineLocation('example.com');
       mockMessaging({});
 
       await handleSync();

--- a/test/extractors/can-extract.test.ts
+++ b/test/extractors/can-extract.test.ts
@@ -18,7 +18,7 @@ import { PerplexityExtractor } from '../../src/content/extractors/perplexity';
 import { NotebookLMExtractor } from '../../src/content/extractors/notebooklm';
 import { PLATFORM_REGISTRY, ALL_PLATFORMS } from '../../src/lib/platform-registry';
 import type { AIPlatform, IConversationExtractor } from '../../src/lib/types';
-import { resetLocation } from '../fixtures/dom-helpers';
+import { defineLocation, resetLocation } from '../fixtures/dom-helpers';
 
 /**
  * Keyed by AIPlatform so the compiler demands an entry when the union grows —
@@ -31,14 +31,6 @@ const EXTRACTOR_FACTORIES: Record<AIPlatform, () => IConversationExtractor> = {
   perplexity: () => new PerplexityExtractor(),
   notebooklm: () => new NotebookLMExtractor(),
 };
-
-function setHostname(hostname: string): void {
-  Object.defineProperty(window, 'location', {
-    value: { hostname, pathname: '/', href: `https://${hostname}/`, search: '', hash: '' },
-    writable: true,
-    configurable: true,
-  });
-}
 
 /** Hostnames that embed a real host but must never be accepted. */
 function lookalikesFor(host: string): string[] {
@@ -55,7 +47,7 @@ describe('canExtract() is derived from the platform registry', () => {
     const { hosts } = PLATFORM_REGISTRY[platform];
 
     it.each(hosts)('accepts its registered host %s', host => {
-      setHostname(host);
+      defineLocation(host);
       expect(createExtractor().canExtract()).toBe(true);
     });
 
@@ -64,18 +56,18 @@ describe('canExtract() is derived from the platform registry', () => {
         p => PLATFORM_REGISTRY[p].hosts
       );
       for (const host of foreignHosts) {
-        setHostname(host);
+        defineLocation(host);
         expect(createExtractor().canExtract(), `${platform} accepted ${host}`).toBe(false);
       }
     });
 
     it.each(lookalikesFor(hosts[0]))('rejects lookalike hostname %s', hostname => {
-      setHostname(hostname);
+      defineLocation(hostname);
       expect(createExtractor().canExtract()).toBe(false);
     });
 
     it('rejects an unrelated host', () => {
-      setHostname('localhost');
+      defineLocation('localhost');
       expect(createExtractor().canExtract()).toBe(false);
     });
   });

--- a/test/extractors/chatgpt.test.ts
+++ b/test/extractors/chatgpt.test.ts
@@ -4,10 +4,9 @@ import {
   loadFixture,
   clearFixture,
   resetLocation,
-  setNonGeminiLocation,
   createChatGPTConversationDOM,
   setChatGPTLocation,
-  setNonChatGPTLocation,
+  defineLocation,
   createChatGPTInlineCitation,
   createChatGPTPage,
 } from '../fixtures/dom-helpers';
@@ -40,12 +39,12 @@ describe('ChatGPTExtractor', () => {
       });
 
       it('returns false for other hosts', () => {
-        setNonGeminiLocation('chat.openai.com');
+        defineLocation('chat.openai.com');
         expect(extractor.canExtract()).toBe(false);
       });
 
       it('returns false for chat.openai.com (legacy domain)', () => {
-        setNonChatGPTLocation('chat.openai.com', '/c/test-123');
+        defineLocation('chat.openai.com', '/c/test-123');
         expect(extractor.canExtract()).toBe(false);
       });
     });
@@ -54,12 +53,12 @@ describe('ChatGPTExtractor', () => {
   // ========== 6.3.2 Security Tests (4 tests) ==========
   describe('Security', () => {
     it('rejects malicious subdomains containing chatgpt.com', () => {
-      setNonChatGPTLocation('evil-chatgpt.com.attacker.com');
+      defineLocation('evil-chatgpt.com.attacker.com');
       expect(extractor.canExtract()).toBe(false);
     });
 
     it('rejects chatgpt.com as subdomain', () => {
-      setNonChatGPTLocation('chatgpt.com.evil.com');
+      defineLocation('chatgpt.com.evil.com');
       expect(extractor.canExtract()).toBe(false);
     });
 
@@ -102,20 +101,12 @@ describe('ChatGPTExtractor', () => {
     });
 
     it('returns null for non-chat URLs', () => {
-      setNonChatGPTLocation('chatgpt.com', '/');
+      defineLocation('chatgpt.com', '/');
       expect(extractor.getConversationId()).toBeNull();
     });
 
     it('generates fallback ID when URL parsing fails', async () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: 'chatgpt.com',
-          pathname: '/settings',
-          href: 'https://chatgpt.com/settings',
-        },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation('chatgpt.com', '/settings');
       loadFixture(
         createChatGPTConversationDOM([
           { role: 'user', content: 'Hello' },

--- a/test/extractors/claude.test.ts
+++ b/test/extractors/claude.test.ts
@@ -4,11 +4,10 @@ import {
   loadFixture,
   clearFixture,
   resetLocation,
-  setNonGeminiLocation,
   createClaudeConversationDOM,
   createClaudeDeepResearchDOM,
   setClaudeLocation,
-  setNonClaudeLocation,
+  defineLocation,
   createClaudeInlineCitation,
   createClaudePage,
   createClaudeDeepResearchPage,
@@ -47,7 +46,7 @@ describe('ClaudeExtractor', () => {
       });
 
       it('returns false for other hosts', () => {
-        setNonGeminiLocation('chat.openai.com');
+        defineLocation('chat.openai.com');
         expect(extractor.canExtract()).toBe(false);
       });
 
@@ -145,12 +144,12 @@ describe('ClaudeExtractor', () => {
   // ========== 6.3.2 Security Tests (5 tests) ==========
   describe('Security', () => {
     it('rejects malicious subdomains containing claude.ai', () => {
-      setNonClaudeLocation('evil-claude.ai.attacker.com');
+      defineLocation('evil-claude.ai.attacker.com');
       expect(extractor.canExtract()).toBe(false);
     });
 
     it('rejects claude.ai as subdomain', () => {
-      setNonClaudeLocation('claude.ai.evil.com');
+      defineLocation('claude.ai.evil.com');
       expect(extractor.canExtract()).toBe(false);
     });
 
@@ -209,22 +208,12 @@ describe('ClaudeExtractor', () => {
     });
 
     it('returns null for non-chat URLs', () => {
-      setNonClaudeLocation('claude.ai', '/');
+      defineLocation('claude.ai', '/');
       expect(extractor.getConversationId()).toBeNull();
     });
 
     it('generates fallback ID when URL parsing fails', async () => {
-      setNonClaudeLocation('claude.ai', '/settings');
-      // Set hostname correctly for canExtract
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: 'claude.ai',
-          pathname: '/settings',
-          href: 'https://claude.ai/settings',
-        },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation('claude.ai', '/settings');
       loadFixture(
         createClaudeConversationDOM([
           { role: 'user', content: 'Hello' },

--- a/test/extractors/gemini.test.ts
+++ b/test/extractors/gemini.test.ts
@@ -12,7 +12,7 @@ import {
   clearFixture,
   setGeminiLocation,
   setGeminiGemLocation,
-  setNonGeminiLocation,
+  defineLocation,
   createGeminiConversationDOM,
   createGeminiScrollableDOM,
   mockScrollContainer,
@@ -50,7 +50,7 @@ describe('GeminiExtractor', () => {
     });
 
     it('returns false for other hosts', () => {
-      setNonGeminiLocation('chat.openai.com');
+      defineLocation('chat.openai.com');
       expect(extractor.canExtract()).toBe(false);
     });
 
@@ -67,12 +67,12 @@ describe('GeminiExtractor', () => {
     });
 
     it('returns null for invalid URL', () => {
-      setNonGeminiLocation('gemini.google.com', '/');
+      defineLocation('gemini.google.com', '/');
       expect(extractor.getConversationId()).toBeNull();
     });
 
     it('returns null when no ID in path', () => {
-      setNonGeminiLocation('gemini.google.com', '/settings');
+      defineLocation('gemini.google.com', '/settings');
       expect(extractor.getConversationId()).toBeNull();
     });
 
@@ -407,7 +407,7 @@ describe('GeminiExtractor', () => {
     });
 
     it('generates fallback ID when no conversation ID in URL', async () => {
-      setNonGeminiLocation('gemini.google.com', '/');
+      defineLocation('gemini.google.com', '/');
       const html = createGeminiConversationDOM([
         { role: 'user', content: 'Hello' },
         { role: 'assistant', content: 'Hi' },

--- a/test/extractors/notebooklm.test.ts
+++ b/test/extractors/notebooklm.test.ts
@@ -4,6 +4,7 @@ import { htmlToMarkdown } from '../../src/content/markdown';
 import {
   loadFixture,
   clearFixture,
+  defineLocation,
   resetLocation,
   setNotebookLMLocation,
   createNotebookLMPage,
@@ -40,11 +41,7 @@ describe('NotebookLMExtractor', () => {
 
     it('returns false for other hosts', () => {
       // Use gemini location as a non-notebooklm host
-      Object.defineProperty(window, 'location', {
-        value: { hostname: 'gemini.google.com', pathname: '/app/123' },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation('gemini.google.com', '/app/123');
       expect(extractor.canExtract()).toBe(false);
     });
 
@@ -53,11 +50,7 @@ describe('NotebookLMExtractor', () => {
       'notebook.google.com.attacker.com',
       'sub.notebook.google.com',
     ])('returns false for lookalike host %s', hostname => {
-      Object.defineProperty(window, 'location', {
-        value: { hostname, pathname: '/notebook/abc' },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation(hostname, '/notebook/abc');
       expect(extractor.canExtract()).toBe(false);
     });
   });
@@ -75,14 +68,7 @@ describe('NotebookLMExtractor', () => {
     });
 
     it('returns null for non-notebook URLs', () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: 'notebooklm.google.com',
-          pathname: '/',
-        },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation('notebooklm.google.com', '/');
       expect(extractor.getConversationId()).toBeNull();
     });
   });

--- a/test/extractors/perplexity.test.ts
+++ b/test/extractors/perplexity.test.ts
@@ -8,7 +8,7 @@ import {
   resetLocation,
   createPerplexityConversationDOM,
   setPerplexityLocation,
-  setNonPerplexityLocation,
+  defineLocation,
   createPerplexityInlineCitation,
   createPerplexityPillCitation,
   createPerplexityLegacyPillCitation,
@@ -45,17 +45,17 @@ describe('PerplexityExtractor', () => {
       });
 
       it('returns false for perplexity.ai (no www)', () => {
-        setNonPerplexityLocation('perplexity.ai');
+        defineLocation('perplexity.ai');
         expect(extractor.canExtract()).toBe(false);
       });
 
       it('returns false for evil.www.perplexity.ai.attacker.com', () => {
-        setNonPerplexityLocation('evil.www.perplexity.ai.attacker.com');
+        defineLocation('evil.www.perplexity.ai.attacker.com');
         expect(extractor.canExtract()).toBe(false);
       });
 
       it('returns false for other domains', () => {
-        setNonPerplexityLocation('chatgpt.com');
+        defineLocation('chatgpt.com');
         expect(extractor.canExtract()).toBe(false);
       });
     });
@@ -76,12 +76,12 @@ describe('PerplexityExtractor', () => {
     });
 
     it('returns null for non-search paths', () => {
-      setNonPerplexityLocation('www.perplexity.ai', '/hub');
+      defineLocation('www.perplexity.ai', '/hub');
       expect(extractor.getConversationId()).toBeNull();
     });
 
     it('returns null for root path', () => {
-      setNonPerplexityLocation('www.perplexity.ai', '/');
+      defineLocation('www.perplexity.ai', '/');
       expect(extractor.getConversationId()).toBeNull();
     });
   });
@@ -511,15 +511,7 @@ describe('PerplexityExtractor', () => {
     });
 
     it('generates fallback ID when URL parsing fails', async () => {
-      Object.defineProperty(window, 'location', {
-        value: {
-          hostname: 'www.perplexity.ai',
-          pathname: '/pro',
-          href: 'https://www.perplexity.ai/pro',
-        },
-        writable: true,
-        configurable: true,
-      });
+      defineLocation('www.perplexity.ai', '/pro');
       loadFixture(
         createPerplexityConversationDOM([
           { role: 'user', content: 'Hello' },

--- a/test/fixtures/dom-helpers.test.ts
+++ b/test/fixtures/dom-helpers.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The one place every `set*Location` fixture helper builds its `window.location`
+ * from. Before this helper existed each of the eleven helpers hand-wrote href,
+ * origin and host separately — a slip in one of them surfaced as a confusing
+ * extractor failure rather than as a fixture bug. These pin the derivation.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { defineLocation, resetLocation, setClaudeLocation } from './dom-helpers';
+
+describe('defineLocation', () => {
+  afterEach(() => resetLocation());
+
+  it('derives href, origin and host from hostname and pathname', () => {
+    defineLocation('claude.ai', '/chat/abc');
+
+    expect(window.location).toMatchObject({
+      hostname: 'claude.ai',
+      host: 'claude.ai',
+      pathname: '/chat/abc',
+      href: 'https://claude.ai/chat/abc',
+      origin: 'https://claude.ai',
+      protocol: 'https:',
+      search: '',
+      hash: '',
+    });
+  });
+
+  it('defaults the path to the root', () => {
+    defineLocation('evil-claude.ai.attacker.com');
+
+    expect(window.location.pathname).toBe('/');
+    expect(window.location.href).toBe('https://evil-claude.ai.attacker.com/');
+  });
+
+  it('is what the platform helpers are built on', () => {
+    setClaudeLocation('abc');
+
+    expect(window.location.href).toBe('https://claude.ai/chat/abc');
+    expect(window.location.origin).toBe('https://claude.ai');
+  });
+
+  it('resets to the jsdom default over http', () => {
+    defineLocation('claude.ai', '/chat/abc');
+    resetLocation();
+
+    expect(window.location.href).toBe('http://localhost/');
+    expect(window.location.protocol).toBe('http:');
+  });
+});

--- a/test/fixtures/dom-helpers.ts
+++ b/test/fixtures/dom-helpers.ts
@@ -74,59 +74,23 @@ export function createGeminiConversationDOM(messages: ConversationMessage[]): st
 }
 
 /**
- * Set window.location for Gemini URL testing
+ * Point `window.location` at `{protocol}//{hostname}{pathname}`.
+ *
+ * jsdom's location is not assignable, so it is replaced wholesale. Every
+ * `set*Location` helper below and `resetLocation()` build on this one so that
+ * href, origin and host are always derived the same way — each helper used to
+ * hand-write all three, and a slip in one surfaced as an extractor failure.
+ * The fields are the ones the extractors read.
  */
-export function setGeminiLocation(conversationId: string): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'gemini.google.com',
-      pathname: `/app/${conversationId}`,
-      href: `https://gemini.google.com/app/${conversationId}`,
-      origin: 'https://gemini.google.com',
-      protocol: 'https:',
-      host: 'gemini.google.com',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Set window.location for a Gemini Gem conversation.
- * Gem URLs have TWO path segments: /gem/{gemId}/{conversationId};
- * a freshly opened Gem chat sits at /gem/{gemId} (pass conversationId='').
- */
-export function setGeminiGemLocation(gemId: string, conversationId = ''): void {
-  const pathname = conversationId ? `/gem/${gemId}/${conversationId}` : `/gem/${gemId}`;
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'gemini.google.com',
-      pathname,
-      href: `https://gemini.google.com${pathname}`,
-      origin: 'https://gemini.google.com',
-      protocol: 'https:',
-      host: 'gemini.google.com',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Set window.location for non-Gemini URL
- */
-export function setNonGeminiLocation(hostname: string, pathname = '/'): void {
+export function defineLocation(hostname: string, pathname = '/', protocol = 'https:'): void {
+  const origin = `${protocol}//${hostname}`;
   Object.defineProperty(window, 'location', {
     value: {
       hostname,
       pathname,
-      href: `https://${hostname}${pathname}`,
-      origin: `https://${hostname}`,
-      protocol: 'https:',
+      href: `${origin}${pathname}`,
+      origin,
+      protocol,
       host: hostname,
       search: '',
       hash: '',
@@ -137,23 +101,27 @@ export function setNonGeminiLocation(hostname: string, pathname = '/'): void {
 }
 
 /**
- * Reset window.location to default
+ * Set window.location for Gemini URL testing
+ */
+export function setGeminiLocation(conversationId: string): void {
+  defineLocation('gemini.google.com', `/app/${conversationId}`);
+}
+
+/**
+ * Set window.location for a Gemini Gem conversation.
+ * Gem URLs have TWO path segments: /gem/{gemId}/{conversationId};
+ * a freshly opened Gem chat sits at /gem/{gemId} (pass conversationId='').
+ */
+export function setGeminiGemLocation(gemId: string, conversationId = ''): void {
+  const pathname = conversationId ? `/gem/${gemId}/${conversationId}` : `/gem/${gemId}`;
+  defineLocation('gemini.google.com', pathname);
+}
+
+/**
+ * Reset window.location to jsdom's default
  */
 export function resetLocation(): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'localhost',
-      pathname: '/',
-      href: 'http://localhost/',
-      origin: 'http://localhost',
-      protocol: 'http:',
-      host: 'localhost',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
+  defineLocation('localhost', '/', 'http:');
 }
 
 /**
@@ -489,46 +457,9 @@ export function createClaudeDeepResearchDOM(
 
 /**
  * Set window.location for Claude URL testing
- *
- * @param conversationId UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  */
 export function setClaudeLocation(conversationId: string): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'claude.ai',
-      pathname: `/chat/${conversationId}`,
-      href: `https://claude.ai/chat/${conversationId}`,
-      origin: 'https://claude.ai',
-      protocol: 'https:',
-      host: 'claude.ai',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Set window.location for non-Claude URL (security testing)
- *
- * Used to test hostname validation against subdomain attacks
- */
-export function setNonClaudeLocation(hostname: string, pathname = '/'): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname,
-      pathname,
-      href: `https://${hostname}${pathname}`,
-      origin: `https://${hostname}`,
-      protocol: 'https:',
-      host: hostname,
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
+  defineLocation('claude.ai', `/chat/${conversationId}`);
 }
 
 /**
@@ -1112,52 +1043,13 @@ export function createChatGPTConversationDOM(messages: ChatGPTConversationMessag
 /**
  * Set window.location for ChatGPT URL testing
  *
- * @param conversationId UUID format or custom ID
- * @param prefix URL prefix: 'c' for regular chat, 'g' for custom GPT mode
- *
  * URL formats:
  *   prefix='c': https://chatgpt.com/c/{conversationId}
  *   prefix='g': https://chatgpt.com/g/{gptSlug}/c/{conversationId}
  */
 export function setChatGPTLocation(conversationId: string, prefix: 'c' | 'g' = 'c'): void {
   const gptSlug = 'g-abc123-test-gpt';
-  const pathname = prefix === 'g' ? `/g/${gptSlug}/c/${conversationId}` : `/c/${conversationId}`;
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'chatgpt.com',
-      pathname,
-      href: `https://chatgpt.com${pathname}`,
-      origin: 'https://chatgpt.com',
-      protocol: 'https:',
-      host: 'chatgpt.com',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Set window.location for non-ChatGPT URL (security testing)
- *
- * Used to test hostname validation against subdomain attacks
- */
-export function setNonChatGPTLocation(hostname: string, pathname = '/'): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname,
-      pathname,
-      href: `https://${hostname}${pathname}`,
-      origin: `https://${hostname}`,
-      protocol: 'https:',
-      host: hostname,
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
+  defineLocation('chatgpt.com', prefix === 'g' ? `/g/${gptSlug}/c/${conversationId}` : `/c/${conversationId}`);
 }
 
 /**
@@ -1254,42 +1146,7 @@ export function createPerplexityConversationDOM(messages: PerplexityConversation
  * @param slug Full URL slug from /search/{slug}
  */
 export function setPerplexityLocation(slug: string): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname: 'www.perplexity.ai',
-      pathname: `/search/${slug}`,
-      href: `https://www.perplexity.ai/search/${slug}`,
-      origin: 'https://www.perplexity.ai',
-      protocol: 'https:',
-      host: 'www.perplexity.ai',
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
-}
-
-/**
- * Set window.location for non-Perplexity URL (security testing)
- *
- * Used to test hostname validation against subdomain attacks
- */
-export function setNonPerplexityLocation(hostname: string, pathname = '/'): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname,
-      pathname,
-      href: `https://${hostname}${pathname}`,
-      origin: `https://${hostname}`,
-      protocol: 'https:',
-      host: hostname,
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
+  defineLocation('www.perplexity.ai', `/search/${slug}`);
 }
 
 /**
@@ -1684,20 +1541,7 @@ export function setNotebookLMLocation(
   options: { legacyHost?: boolean } = {}
 ): void {
   const hostname = options.legacyHost ? 'notebooklm.google.com' : 'notebook.google.com';
-  Object.defineProperty(window, 'location', {
-    value: {
-      hostname,
-      pathname: `/notebook/${notebookId}`,
-      href: `https://${hostname}/notebook/${notebookId}`,
-      origin: `https://${hostname}`,
-      protocol: 'https:',
-      host: hostname,
-      search: '',
-      hash: '',
-    },
-    writable: true,
-    configurable: true,
-  });
+  defineLocation(hostname, `/notebook/${notebookId}`);
 }
 
 /**


### PR DESCRIPTION
Phase 2 of the 2026-09-03 optimisation plan. Test fixtures only — no `src/` change.

## Summary

- `test/fixtures/dom-helpers.ts` replaced `window.location` with the same hand-written object literal **11 times**, and five test files carried **7 more inline copies**. The four `setNon{Gemini,Claude,ChatGPT,Perplexity}Location` helpers were byte-identical apart from their names (verified by diff).
- One `defineLocation(hostname, pathname = '/', protocol = 'https:')` now derives `href`, `origin` and `host` in a single place. Every `set*Location` helper and `resetLocation()` delegate to it; the four `setNon*` aliases are removed and their 27 call sites use `defineLocation` directly; the inline copies collapse onto it (including a redundant double-assignment in `claude.test.ts`).
- `test/fixtures/dom-helpers.test.ts` (4 tests) pins the derivation — a slip there used to surface as an extractor failure rather than a fixture bug.
- Same consolidation pattern as #471. Net **−206 lines**.

## Test plan

- [x] `npm run test` — **2244 passed** (2240 unchanged + 4 new), 88 files
- [x] Standalone `tsc --strict` over the fixture file — clean
- [x] No `Object.defineProperty(window, 'location'` left outside the helper; no `setNon*` / `setHostname` references remain
- [x] `npm run lint` / `format:check` unaffected (test files are outside both scopes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Van9LpnGKc682CAB9P5J