### PR TITLE
fix: report a rejected save instead of crashing on the missing results

### DIFF
--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -26,7 +26,7 @@ import { showSyncBadge, clearSyncBadge } from './ui-badge';
 import { buildSyncStatus, buildFailedSyncStatus, type SyncStatus } from './sync-status';
 import { startConversationWatcher, type StopWatching } from './conversation-watcher';
 import { startNewMessageWatcher } from './message-watcher';
-import { sendMessage } from '../lib/messaging';
+import { sendMessage, isMultiOutputResponse, describeUnexpectedResponse } from '../lib/messaging';
 import {
   AUTO_SAVE_CHECK_INTERVAL,
   EVENT_THROTTLE_DELAY,
@@ -501,10 +501,16 @@ function testConnection(): Promise<{ success: boolean; error?: string }> {
 /**
  * Save note to multiple outputs via background script
  * Uses type-safe messaging utility
+ *
+ * A rejection envelope from the worker becomes an ordinary failure, reported
+ * through the same toast and badge as any other (issue #467): it must never
+ * reach displaySaveResults(), which reads `results`.
  */
-function saveToOutputs(
+async function saveToOutputs(
   note: ObsidianNote,
   outputs: OutputDestination[]
 ): Promise<MultiOutputResponse> {
-  return sendMessage({ action: 'saveToOutputs', data: note, outputs });
+  const response = await sendMessage({ action: 'saveToOutputs', data: note, outputs });
+  if (isMultiOutputResponse(response)) return response;
+  throw new Error(describeUnexpectedResponse(response));
 }

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -3,7 +3,12 @@
  * Promise-based wrapper for chrome.runtime.sendMessage
  */
 
-import type { ExtensionMessage, ContentScriptSettings, MultiOutputResponse } from './types';
+import type {
+  ExtensionMessage,
+  ContentScriptSettings,
+  ErrorResponse,
+  MultiOutputResponse,
+} from './types';
 
 /** User-friendly message for extension context invalidation */
 const CONTEXT_INVALIDATED_MESSAGE = 'Extension context invalidated. Please reload the page.';
@@ -14,19 +19,52 @@ const CONTEXT_INVALIDATED_MESSAGE = 'Extension context invalidated. Please reloa
 interface MessageResponseMap {
   getSettings: ContentScriptSettings;
   testConnection: { success: boolean; error?: string };
-  saveToOutputs: MultiOutputResponse;
+  /**
+   * Either the save result or the worker's rejection envelope. The union is
+   * deliberate: a caller has to narrow with {@link isMultiOutputResponse}
+   * before touching `results`, which is what stops a rejected message from
+   * crashing the toast code (issue #467).
+   */
+  saveToOutputs: MultiOutputResponse | ErrorResponse;
+}
+
+/**
+ * Whether a `saveToOutputs` answer is the real save result.
+ *
+ * The background replies `{ success: false, error }` — no `results` — when the
+ * sender is unauthorized, the message fails validation, the action is unknown,
+ * or the handler throws. The content script used to cast that envelope to a
+ * save result and die on `results.map` (issue #467).
+ */
+export function isMultiOutputResponse(value: unknown): value is MultiOutputResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<MultiOutputResponse>;
+  return (
+    Array.isArray(candidate.results) &&
+    typeof candidate.allSuccessful === 'boolean' &&
+    typeof candidate.anySuccessful === 'boolean'
+  );
+}
+
+/**
+ * The user-facing text for a `saveToOutputs` answer that is not a save result:
+ * the worker's own error when it sent one, a generic line otherwise.
+ */
+export function describeUnexpectedResponse(value: unknown): string {
+  const error = (value as Partial<ErrorResponse> | null | undefined)?.error;
+  return typeof error === 'string' && error.length > 0
+    ? error
+    : 'Unexpected response from the extension background';
 }
 
 /**
  * Type-safe message sending
  *
- * Design Decision: Runtime validation is intentionally omitted here because:
- * 1. Messages originate from and are handled within the same extension
- * 2. The background service worker (src/background/service-worker.ts) performs
- *    comprehensive validation via validateMessageContent() before processing
- * 3. Adding redundant validation would impact performance without security benefit
- *
- * The type assertion below is safe under these controlled conditions.
+ * The response type is the map entry for the action. Messages and replies stay
+ * inside one extension, and the worker validates every incoming message
+ * (validateMessageContent()), so the cast covers the success path. It does NOT
+ * cover the worker's *rejection* envelope — that is why `saveToOutputs` is
+ * typed as a union the caller must narrow (issue #467).
  */
 /**
  * Check if the extension context is still valid.
@@ -67,8 +105,6 @@ export function sendMessage<K extends keyof MessageResponseMap>(
           reject(new Error(isContextError ? CONTEXT_INVALIDATED_MESSAGE : errorMsg));
           return;
         }
-        // Type assertion is safe: background validates all messages before responding
-        // See: src/background/service-worker.ts validateMessageContent()
         resolve(response as MessageResponseMap[K]);
       });
     } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -338,6 +338,18 @@ export type ExtensionMessage =
   | { action: 'fetchImage'; url: string };
 
 /**
+ * What the background worker answers instead of a real result: an
+ * unauthorized sender, a message that failed validation, an unknown action,
+ * or a handler that threw (see the listener in service-worker.ts). It carries
+ * no `results`, so it must never be read as a {@link MultiOutputResponse}
+ * (issue #467).
+ */
+export interface ErrorResponse {
+  success: false;
+  error: string;
+}
+
+/**
  * Response to a `fetchImage` message. The background worker fetches remote
  * images the content script cannot reach (CORS) and returns them as base64.
  */

--- a/test/content/index.test.ts
+++ b/test/content/index.test.ts
@@ -26,7 +26,10 @@ vi.mock('../../src/content/ui', () => ({
   showToast: vi.fn(),
 }));
 
-vi.mock('../../src/lib/messaging', () => ({
+// Mock only the transport: the response guards are the code under test in
+// "save response validation" and must stay real.
+vi.mock('../../src/lib/messaging', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../src/lib/messaging')>()),
   sendMessage: vi.fn(),
 }));
 
@@ -696,5 +699,58 @@ describe('badge invalidation on new messages (issue #465)', () => {
 
     const [params] = vi.mocked(startNewMessageWatcher).mock.calls[0];
     expect(params.syncedWatermark).toBeNull();
+  });
+});
+
+describe('save response validation (issue #467)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    watcherState.stops.length = 0;
+    watcherState.messageStops.length = 0;
+  });
+
+  afterEach(() => {
+    clearFixture();
+    resetLocation();
+  });
+
+  /** What the background actually sends when it rejects a message (service-worker.ts). */
+  const rejection = { success: false, error: 'Invalid message content' };
+
+  it('reports the rejection instead of crashing on the missing results array', async () => {
+    // A 1,077-message note tripped the body-size check in the background, which
+    // answered {success:false,error}. That envelope used to be handed to the
+    // toast code as a save result: "Cannot read properties of undefined
+    // (reading 'map')" — the exact text in the report.
+    mockMessaging({ save: rejection as unknown as MultiOutputResponse });
+    loadGeminiConversation();
+
+    await handleSync();
+
+    expect(showErrorToast).toHaveBeenCalledWith('Invalid message content');
+    expect(vi.mocked(showErrorToast).mock.calls[0][0]).not.toContain('reading');
+    const [status] = vi.mocked(showSyncBadge).mock.calls[0];
+    expect(status.kind).toBe('error');
+    expect(status.error).toBe('Invalid message content');
+  });
+
+  it('names the problem when the response is not a save result at all', async () => {
+    mockMessaging({ save: {} as MultiOutputResponse });
+    loadGeminiConversation();
+
+    await handleSync();
+
+    const [message] = vi.mocked(showErrorToast).mock.calls[0];
+    expect(message).toMatch(/unexpected response/i);
+    expect(message).not.toContain('reading');
+  });
+
+  it('still leaves the button usable after a rejected save', async () => {
+    mockMessaging({ save: rejection as unknown as MultiOutputResponse });
+    loadGeminiConversation();
+
+    await handleSync();
+
+    expect(setButtonLoading).toHaveBeenLastCalledWith(false);
   });
 });

--- a/test/lib/messaging.test.ts
+++ b/test/lib/messaging.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { sendMessage } from '../../src/lib/messaging';
+import {
+  sendMessage,
+  isMultiOutputResponse,
+  describeUnexpectedResponse,
+} from '../../src/lib/messaging';
 
 describe('sendMessage', () => {
   beforeEach(() => {
@@ -167,4 +171,55 @@ describe('sendMessage - extension context invalidation', () => {
       'Extension context invalidated. Please reload the page.'
     );
   });
+});
+
+describe('isMultiOutputResponse (issue #467)', () => {
+  it('accepts a save result', () => {
+    expect(
+      isMultiOutputResponse({
+        results: [{ destination: 'obsidian', success: true }],
+        allSuccessful: true,
+        anySuccessful: true,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts an all-failed save result', () => {
+    expect(
+      isMultiOutputResponse({
+        results: [{ destination: 'obsidian', success: false, error: 'offline' }],
+        allSuccessful: false,
+        anySuccessful: false,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects the rejection envelope the background sends', () => {
+    // {success:false,error} is what validateMessageContent / an unauthorized
+    // sender / a thrown handler all produce. None of them carries `results`.
+    expect(isMultiOutputResponse({ success: false, error: 'Invalid message content' })).toBe(false);
+  });
+
+  it.each([undefined, null, 'ok', 42, [], {}])('rejects %p', value => {
+    expect(isMultiOutputResponse(value)).toBe(false);
+  });
+
+  it('rejects a result whose flags are missing', () => {
+    expect(isMultiOutputResponse({ results: [] })).toBe(false);
+  });
+});
+
+describe('describeUnexpectedResponse (issue #467)', () => {
+  it('surfaces the error text of a rejection envelope', () => {
+    expect(describeUnexpectedResponse({ success: false, error: 'Unauthorized' })).toBe(
+      'Unauthorized'
+    );
+  });
+
+  it.each([undefined, null, {}, { success: false }, { error: 7 }])(
+    'falls back to a generic message for %p',
+    value => {
+      expect(describeUnexpectedResponse(value)).toMatch(/unexpected response/i);
+    }
+  );
 });


### PR DESCRIPTION
Closes #467. PR A of the approved plan; the size setting (PR B) follows.

## Root cause

The background listener answers `{ success: false, error }` when it rejects a message (`service-worker.ts:43,53,58,73,126`). `messaging.ts` cast that envelope to `MultiOutputResponse`, and `displaySaveResults()` (`bootstrap.ts`) then hit `saveResult.results.map` → **"Cannot read properties of undefined (reading 'map')"**, the exact text in the report. The trigger in #467 was a 1,077-message Claude note exceeding the 1 MiB body check in `validateNoteData()` — the user saw the TypeError instead of that reason.

## Summary

- `types.ts`: `ErrorResponse { success: false; error: string }` names the worker's rejection envelope.
- `messaging.ts`: `saveToOutputs` is now typed `MultiOutputResponse | ErrorResponse` so callers **must** narrow; `isMultiOutputResponse()` and `describeUnexpectedResponse()` do it. The comment claiming the cast was "safe because the background validates" is corrected — the background's *rejection* is precisely what was unvalidated.
- `bootstrap.ts` `saveToOutputs()`: narrows; a rejection throws with the worker's text and lands in the existing `handleSync` catch → error toast + `×` badge. No new UI path.
- Covers every envelope, not just size: Unauthorized, Unknown action, thrown handler.
- `index.test.ts` now mocks only the messaging *transport* (`importOriginal`), so the guards stay real under test.

## Test plan

- [x] RED reproduced the report verbatim: `[G2O] Sync error: TypeError: Cannot read properties of undefined (reading 'map')`
- [x] GREEN: toast and badge show `Invalid message content`; a non-result answer shows "Unexpected response from the extension background"; the button is re-enabled
- [x] `npm run test:coverage` — **2264 passed** (+20), 96.61 / 87.71 / 99.12 / 97.73
- [x] `npm run lint` (ESLint at `error` level, platform lint, knip) — clean
- [x] `tsc --noEmit`, `npm run build`, `format:check` — clean
- [x] Manual: sync a conversation whose note exceeds 1 MiB and confirm the badge reads "Invalid message content" instead of the TypeError (PR B replaces this text with a size-specific one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Van9LpnGKc682CAB9P5J