### PR TITLE
docs: sync READMEs and store descriptions with the shipped badge and Perplexity behaviour

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@ Google Gemini、Claude AI、ChatGPT、Perplexity、Gemini Notebook（旧 Noteboo
 
 - **マルチプラットフォーム対応**: Google Gemini、Claude AI、ChatGPT、Perplexity、Gemini Notebook（旧 NotebookLM）からエクスポート
 - **ワンクリック保存**: 対応 AI ページに表示される「Sync」ボタンで即座に保存
-- **同期ステータスの常設表示**: 同期完了後も同期ボタンに ✓ / ! / × のバッジが残ります。クリックすると保存先ごとの結果・ファイル名・警告・同期時刻が確認できます。会話を切り替えるか、閉じるまで表示されます
+- **同期ステータスの常設表示**: 同期完了後も同期ボタンに ✓ / ! / × のバッジが残ります。クリックすると保存先ごとの結果・ファイル名・警告・同期時刻が確認できます。会話を切り替えるか閉じるまで表示され、Claude と ChatGPT では同期後に新しいメッセージが届いた時点でも消えます
 - **複数の出力オプション**: Obsidian への保存、ファイルダウンロード、クリップボードへコピー
 - **Deep Research 対応**: Gemini Deep Research、Claude Extended Thinking、Perplexity Deep Research レポートを保存
 - **Artifact 対応**: Claude Artifacts をインライン引用とソース付きで抽出
@@ -144,7 +144,7 @@ Gemini が生成した画像は自動的に捕捉・エクスポートされま�
 
 **Perplexity Deep Research:**
 
-1. Deep Research レポートを含む Perplexity の会話を開く
+1. Deep Research レポートを含む Perplexity の会話を開き、レポート自体も開く（カードをクリック）— Perplexity はレポート本文を開いた時に初めて読み込むため、折りたたまれたままのレポートはエクスポートできません
 2. 「Sync」ボタンをクリック
 3. レポート内容が通常の会話メッセージとともに抽出されます
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Chrome Extension that exports AI conversations from Google Gemini, Claude AI, Ch
 
 - **Multi-platform support**: Export from Google Gemini, Claude AI, ChatGPT, Perplexity, and Gemini Notebook (formerly NotebookLM)
 - **One-click export**: Floating "Sync" button on supported AI pages
-- **Persistent sync status**: A ✓ / ! / × badge stays on the sync button after a sync finishes — click it for the file name, per-destination results, warnings, and when the sync ran. It clears when you switch conversations or dismiss it
+- **Persistent sync status**: A ✓ / ! / × badge stays on the sync button after a sync finishes — click it for the file name, per-destination results, warnings, and when the sync ran. It clears when you switch conversations, dismiss it, or — on Claude and ChatGPT — when a message newer than the sync appears
 - **Multiple output options**: Save to Obsidian, download as file, or copy to clipboard
 - **Deep Research support**: Export Gemini Deep Research, Claude Extended Thinking, and Perplexity Deep Research reports
 - **Artifact support**: Extract Claude Artifacts with inline citations and sources
@@ -144,7 +144,7 @@ Gemini-generated images are captured and exported automatically (see [Image Expo
 
 **Perplexity Deep Research:**
 
-1. Open a Perplexity conversation containing a Deep Research report
+1. Open a Perplexity conversation containing a Deep Research report, then open the report itself (click its card) — Perplexity loads the report body only when it is opened, so a collapsed report cannot be exported
 2. Click the "Sync" button
 3. The report content will be extracted alongside normal conversation messages
 

--- a/docs/store/description_en.md
+++ b/docs/store/description_en.md
@@ -10,6 +10,7 @@ This extension extracts conversations from Google Gemini (gemini.google.com), Cl
 
 ✨ KEY FEATURES
 • One-click export from Gemini, Claude, ChatGPT, Perplexity, and Gemini Notebook conversations
+• Sync-status badge - a ✓ / ! / × mark stays on the button after each sync; click it for the file name, per-destination results, and when it ran
 • Clean Markdown formatting with YAML frontmatter
 • Obsidian callout syntax for Q&A blocks (shows correct AI name)
 • Deep Research support (Gemini, Perplexity) and Extended Thinking/Artifacts (Claude)

--- a/docs/store/description_ja.md
+++ b/docs/store/description_ja.md
@@ -10,6 +10,7 @@ Google Gemini（gemini.google.com）、Claude AI（claude.ai）、ChatGPT（chat
 
 ✨ 主な機能
 • Gemini、Claude、ChatGPT、Perplexity、Gemini Notebook の会話をワンクリックでエクスポート
+• 同期ステータスのバッジ - 同期後もボタンに ✓ / ! / × が残り、クリックでファイル名・保存先ごとの結果・同期時刻を確認
 • YAML フロントマター付きの整形された Markdown
 • Q&A ブロックに Obsidian コールアウト構文（正しい AI 名を表示）
 • Deep Research（Gemini、Perplexity）と Extended Thinking / Artifacts（Claude）に対応


### PR DESCRIPTION
Docs only (`/sync-docs`). No `src/`, test, or config change.

## Summary

- **Badge invalidation** (#468, ADR-036): the "Persistent sync status" feature bullet now says the badge also clears on Claude and ChatGPT when a message newer than the sync appears — it previously listed only "switch conversations or dismiss".
- **Perplexity Deep Research** (#464, ADR-035, #463): step 1 now tells the user to open the report card first, because Perplexity loads the report body only on open and a collapsed report cannot be exported.
- **Store descriptions**: the sync-status badge (v2.10.0) had no KEY FEATURES bullet; one added to `description_en.md` and `description_ja.md` in the same position.

Everything else was checked and found current: every `SyncSettings` / `TemplateOptions` field and popup label is documented, the five registry platforms match, and the note-size setting landed with #488.

## Test plan

- [x] `npm run format:check` — clean (READMEs and store files are in scope)
- [x] EN/JA heading structure identical (33 each); internal anchors resolve
- [x] Store bullet counts EN 32 / JA 32, same order
- [x] `test/arch/store-listing-*` (character limits, fields, format safety) — 53 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Van9LpnGKc682CAB9P5J