### PR TITLE
fix(claude): anchor auto-scroll on the thread scroller, not the sidebar

### DIFF
--- a/src/content/extractors/selectors/claude.ts
+++ b/src/content/extractors/selectors/claude.ts
@@ -73,12 +73,25 @@ export const SELECTORS = {
 
   // Scroll container for virtualized-conversation auto-scroll (ADR-017).
   // Claude windows/evicts turns; this is the overflow-y-auto element that
-  // scrolls the message list (observed live 2026-07: the div also carries
-  // overflow-x-hidden, flex-1, and [scrollbar-gutter:stable]).
+  // scrolls the message list.
+  //
+  // 2026-09 (issue #499): the container was found by its overflow classes
+  // alone (`.overflow-y-auto.overflow-x-hidden.flex-1`). Claude's redesigned
+  // left sidebar (`dframe-nav-scroll`) now carries the same three classes,
+  // precedes the thread in document order, and is itself scrollable — so the
+  // first match was the sidebar, auto-scroll scrolled the wrong element, and
+  // only the initially mounted tail of the conversation was exported (a
+  // 22-message thread came out as 7). ChatGPT's nav caused the identical
+  // failure in 2026-07, which is why that platform anchors on
+  // `[data-scroll-root]`. The thread scroller is the only element carrying
+  // `data-autoscroll-container` (measured live 2026-09-12: 1 match, holding
+  // every `[data-index]` row), so anchor on that. The class-based fallback
+  // keeps a `:has([data-index])` guard: a fallback that resolves to the
+  // sidebar is worse than none, and the two looser class selectors that used
+  // to sit below it resolved there first, so they are gone.
   scrollContainer: [
-    '.overflow-y-auto.overflow-x-hidden.flex-1', // Composite (HIGH)
-    '.overflow-y-auto.overflow-x-hidden', // Style pair (MEDIUM)
-    'div[class*="overflow-y-auto"]', // Partial match (LOW)
+    '[data-autoscroll-container]', // Semantic scroll root (HIGH)
+    '.overflow-y-auto.overflow-x-hidden.flex-1:has([data-index])', // Classes, thread-only (MEDIUM)
   ],
 } as const satisfies SelectorGroup;
 

--- a/test/extractors/claude-autoscroll.test.ts
+++ b/test/extractors/claude-autoscroll.test.ts
@@ -29,12 +29,57 @@ function renderTurn(turn: Turn, index: number): string {
 }
 
 /**
+ * The thread scroller as Claude renders it (measured live 2026-09-12): the
+ * overflow classes plus the `data-autoscroll-container` marker.
+ */
+const SCROLLER_HTML =
+  '<div class="overflow-y-auto overflow-x-hidden flex-1" data-autoscroll-container="true" id="scroller"></div>';
+
+/**
+ * Claude's left sidebar (`dframe-nav-scroll`, live 2026-09-12): it precedes the
+ * thread in document order, carries the SAME overflow classes as the thread
+ * scroller, is itself scrollable, and holds no conversation rows. It is the
+ * decoy that issue #499 tripped over.
+ */
+const SIDEBAR_HTML =
+  '<div class="dframe-nav-scroll flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-hidden" id="sidebar"></div>';
+
+const SIDEBAR_SCROLL_HEIGHT = 985;
+const SIDEBAR_CLIENT_HEIGHT = 723;
+
+/** Make the sidebar decoy scrollable and record how far it was scrolled. */
+function installSidebarScrolling(sidebar: HTMLElement): { readonly maxScrolled: () => number } {
+  let scrollTop = 0;
+  let maxScrolled = 0;
+  Object.defineProperty(sidebar, 'scrollTop', {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = Math.max(0, Math.min(SIDEBAR_SCROLL_HEIGHT - SIDEBAR_CLIENT_HEIGHT, v));
+      maxScrolled = Math.max(maxScrolled, scrollTop);
+    },
+    configurable: true,
+  });
+  Object.defineProperty(sidebar, 'clientHeight', {
+    get: () => SIDEBAR_CLIENT_HEIGHT,
+    configurable: true,
+  });
+  Object.defineProperty(sidebar, 'scrollHeight', {
+    get: () => SIDEBAR_SCROLL_HEIGHT,
+    configurable: true,
+  });
+  return { maxScrolled: () => maxScrolled };
+}
+
+/**
  * Install a virtualized Claude conversation into the DOM. Only `windowSize`
  * consecutive turns are mounted at once, chosen by the current scrollTop
  * (bottom on open). Returns nothing; sets up document.body.
+ *
+ * With `withSidebar`, the sidebar decoy is mounted BEFORE the scroller, as on
+ * the live page.
  */
-function mountVirtualizedClaude(turns: Turn[], windowSize: number): void {
-  document.body.innerHTML = `<div class="overflow-y-auto overflow-x-hidden flex-1" id="scroller"></div>`;
+function mountVirtualizedClaude(turns: Turn[], windowSize: number, withSidebar = false): void {
+  document.body.innerHTML = withSidebar ? SIDEBAR_HTML + SCROLLER_HTML : SCROLLER_HTML;
   const scroller = document.getElementById('scroller') as HTMLElement;
 
   let scrollTop = MAX_SCROLL; // opens at the bottom
@@ -117,6 +162,31 @@ describe('ClaudeExtractor auto-scroll (virtualization)', () => {
     ]);
     // Indices are contiguous after accumulation.
     expect(result.data?.messages.map(m => m.index)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('scrolls the thread, not a sidebar that shares its overflow classes (issue #499)', async () => {
+    // Claude's 2026-09 sidebar matches the class-based container selector and
+    // sorts first, so a first-match lookup scrolled the sidebar while the
+    // thread stayed put — only the initially mounted tail was exported.
+    mountVirtualizedClaude(conversation, 3, true);
+    const sidebar = installSidebarScrolling(document.getElementById('sidebar') as HTMLElement);
+    extractor.applySettings(settings());
+
+    const promise = extractor.extract();
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    expect(result.data?.messages.map(m => plainText(m.content))).toEqual([
+      'Q1',
+      'A1',
+      'Q2',
+      'A2',
+      'Q3',
+      'A3',
+    ]);
+    expect(sidebar.maxScrolled()).toBe(0);
     expect(result.warnings).toBeUndefined();
   });
 
@@ -218,6 +288,21 @@ describe('ClaudeExtractor message watermark (issue #465)', () => {
     document.body.innerHTML = `
       <nav id="sidebar"><div data-index="99"></div></nav>
       <div class="overflow-y-auto overflow-x-hidden flex-1">
+        <div data-index="2"></div><div data-index="3"></div>
+      </div>`;
+
+    expect(extractor.getMessageWatermark()).toBe(3);
+  });
+
+  it('ignores a sidebar that shares the scroller classes (issue #499)', () => {
+    // Same decoy as the auto-scroll case: a first-match container lookup would
+    // root the watermark in the sidebar, reading its virtual rows (or none) and
+    // never the thread's.
+    document.body.innerHTML = `
+      <div class="dframe-nav-scroll flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-hidden" id="sidebar">
+        <div data-index="99"></div>
+      </div>
+      <div class="overflow-y-auto overflow-x-hidden flex-1" data-autoscroll-container="true">
         <div data-index="2"></div><div data-index="3"></div>
       </div>`;
 


### PR DESCRIPTION
## Summary

Fixes #499 — Claude conversations came out partially exported (a 22-message thread saved as 7, missing the first question and the middle), on every extension version since about 2026-09-10.

**Root cause: a Claude DOM change, not the extension version.** Claude's redesigned left sidebar (`dframe-nav-scroll`) now carries the same `overflow-y-auto overflow-x-hidden flex-1` classes as the conversation scroller and precedes it in document order. The class-only `scrollContainer` selector therefore resolved to the sidebar, auto-scroll scrolled the sidebar, the thread never moved, and only the initially mounted tail window of the virtualized conversation was harvested. The `getMessageWatermark()` root is the same lookup, so the new-message badge (#465) silently went null as well.

This is the same failure ChatGPT's `<nav>` caused in 2026-07 (fixed there with `[data-scroll-root]`).

## Changes

- `src/content/extractors/selectors/claude.ts`: `scrollContainer` now anchors on `[data-autoscroll-container]` (the thread scroller's own attribute) with a `.overflow-y-auto.overflow-x-hidden.flex-1:has([data-index])` fallback. The two looser class fallbacks resolved to the sidebar first and are removed — a fallback that returns the wrong element is worse than none.
- `test/extractors/claude-autoscroll.test.ts`: fixture scroller now mirrors the live attribute; two regression tests mount the sidebar decoy before the scroller (same classes, scrollable, no rows) and assert full accumulation, an untouched decoy, and a decoy-proof watermark. Both were RED on `main`.

## Evidence (CDP daemon, live claude.ai, 2026-09-12)

| Check | Result |
| --- | --- |
| `.overflow-y-auto.overflow-x-hidden.flex-1` matches | 2 (baseline of 2026-08-16: 1) |
| First match | sidebar — scrollable (985 / 723), 0 `[data-index]` rows inside |
| Recent conversations whose first match is the sidebar | 10 / 10 |
| `[data-autoscroll-container]` matches | 1, holding all 12 rows |
| `…flex-1:has([data-index])` | same element |

The live selector suite stayed green because the e2e conversation has 12 rows, all mounted at once, so no scrolling is needed there; the 1 → 2 match-count change was advisory only.

## Test plan

- [x] `npm run test` — 2319 passed
- [x] `npm run lint`, `npm run format:check` — clean
- [x] Live e2e (`Claude › conversation selectors`): both new selectors match 1 element; the only failure is the expected `new_selector` baseline contract
- [ ] After merge: `nix run .#e2e-baseline-update` to record the new selectors
- [ ] Reporter confirmation on a long Claude conversation with auto-scroll on
