### PR TITLE
chore: bump nixpkgs in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788334797,
-        "narHash": "sha256-nskSa8kDimM7F0VFSP8IdoSNo4G0vKzOtxwvOFpoGDI=",
+        "lastModified": 1789009968,
+        "narHash": "sha256-GB16oaxpsrnGNnGIE+0uYBqMRzB9X6FYDUvjvnJAYew=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c19db427a1fdfc7591c0b0baeb4665dcef2c61da",
+        "rev": "d58a46e3bc02d91ebe04667f8397752a749c0024",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Update the pinned `nixpkgs` input (`nixpkgs-26.05-darwin`) in `flake.lock` from `c19db427` to `d58a46e3`
- No source, test, or config changes; only the Nix task surface (ADR-011) picks up the newer package set

## Test plan

- [x] `nix run .#build` succeeds on the new pin
- [x] `nix run .#test` passes
- [ ] `nix run .#lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)